### PR TITLE
fix: minor usability fix and documentation updates

### DIFF
--- a/src/helix/endpoints/chat/update_chat_settings.rs
+++ b/src/helix/endpoints/chat/update_chat_settings.rs
@@ -63,22 +63,24 @@ use crate::helix::{parse_json, HelixRequestPatchError};
 
 use super::*;
 use helix::RequestPatch;
-/// Query Parameters for [Update Chat Settingss](super::update_chat_settings)
+/// Query Parameters for [Update Chat Settings](super::update_chat_settings)
 ///
 /// [`update-chat-settings`](https://dev.twitch.tv/docs/api/reference#update-chat-settings)
 #[derive(PartialEq, Eq, typed_builder::TypedBuilder, Deserialize, Serialize, Clone, Debug)]
 #[non_exhaustive]
 pub struct UpdateChatSettingsRequest {
-    // FIXME: Wrong documentation by twitch?
-    /// The ID of the broadcaster whose chat settings you want to update. This ID must match the user ID associated with the user OAuth token.
+    /// The ID of the broadcaster whose chat settings you want to update.
     #[builder(setter(into))]
     pub broadcaster_id: types::UserId,
-    /// The ID of a user that has permission to moderate the broadcaster’s chat room. This ID must match the user ID associated with the user OAuth token.
+    /// The ID of a user that has permission to moderate the broadcaster’s chat room.
+    /// This ID must match the user ID associated with the user OAuth token.
+    ///
+    /// If the broadcaster is making the update, also set this parameter to the broadcaster’s ID.
     #[builder(setter(into))]
     pub moderator_id: types::UserId,
 }
 
-/// Body Parameters for [Update Chat Settingss](super::update_chat_settings)
+/// Body Parameters for [Update Chat Settings](super::update_chat_settings)
 ///
 /// [`update-chat-settings`](https://dev.twitch.tv/docs/api/reference#update-chat-settings)
 #[derive(PartialEq, Eq, typed_builder::TypedBuilder, Deserialize, Serialize, Clone, Debug)]

--- a/src/helix/endpoints/moderation/ban_user.rs
+++ b/src/helix/endpoints/moderation/ban_user.rs
@@ -80,10 +80,12 @@ pub struct BanUserBody {
     /// To put a user in a timeout, include this field and specify the timeout period, in seconds.
     /// The minimum timeout is 1 second and the maximum is 1,209,600 seconds (2 weeks).
     /// To end a user’s timeout early, set this field to 1, or send an Unban user request.
+    #[builder(default, setter(into))]
     pub duration: Option<u32>,
     /// The reason the user is being banned or put in a timeout. The text is user defined and limited to a maximum of 500 characters.
     pub reason: String,
     /// The ID of the user to ban or put in a timeout.
+    #[builder(setter(into))]
     pub user_id: types::UserId,
 }
 

--- a/src/helix/endpoints/moderation/ban_user.rs
+++ b/src/helix/endpoints/moderation/ban_user.rs
@@ -62,7 +62,11 @@ pub struct BanUserRequest {
     /// The ID of the broadcaster whose chat room the user is being banned from.
     #[builder(setter(into))]
     pub broadcaster_id: types::UserId,
-    /// The ID of a user that has permission to moderate the broadcaster’s chat room. This ID must match the user ID associated with the user OAuth token.
+    /// The ID of a user that has permission to moderate the broadcaster’s chat room.
+    /// This ID must match the user ID associated with the user OAuth token.
+    ///
+    /// If the broadcaster wants to ban the user (instead of having the moderator do it),
+    /// set this parameter to the broadcaster’s ID, too.
     #[builder(setter(into))]
     pub moderator_id: types::UserId,
 }


### PR DESCRIPTION
* `BanUserRequest` didn't specify `setter(into)`.
* The  `moderator_id` and `broadcaster_id` docs for [`Ban User`](https://dev.twitch.tv/docs/api/reference#ban-user) and [`Update Chat Settings`](https://dev.twitch.tv/docs/api/reference#update-chat-settings) got updated.