### PR TITLE
refactor: Use (mostly) References in Requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 
 ### Breaking changes
 
+- Requests for helix endpoints have been converted to take `Cow`s.
+  This change means the `builder()` methods are harder to use, consider using the new methods on
+  each request which provide the same functionality but with better ergonomics.
+  See the top-level documentation for a endpoint for more examples.
 - Crate name changed: `twitch_api2` -> `twitch_api`, also changed to new org `twitch-rs`
 - All (most) types are now living in their own crate `twitch_types`
 - Features for clients are now named after the client, e.g feature `reqwest_client` is now simply `reqwest`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2671,7 +2671,7 @@ dependencies = [
 
 [[package]]
 name = "twitch_types"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "aliri_braid",
  "displaydoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ crypto_hmac = { package = "hmac", version = "0.12.1", optional = true }
 aliri_braid = "0.2.4"
 futures = { version = "0.3.25", optional = true }
 hyper = { version = "0.14.20", optional = true }
-twitch_types = { version = "0.3.5", path = "./twitch_types" }
+twitch_types = { version = "0.3.6", path = "./twitch_types" }
 
 [features]
 default = []

--- a/examples/automod_check.rs
+++ b/examples/automod_check.rs
@@ -35,11 +35,11 @@ async fn run() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>>
 
     let req =
         twitch_api::helix::moderation::CheckAutoModStatusRequest::broadcaster_id(broadcaster_id);
-    let data =
-        twitch_api::helix::moderation::CheckAutoModStatusBody::new("123", args.collect::<String>());
+    let text = args.collect::<String>();
+    let data = twitch_api::helix::moderation::CheckAutoModStatusBody::new("123", &text);
     println!("data: {:?}", data);
-    let response = client.req_post(req, vec![data], &token).await?;
-    println!("{:?}", response.data);
+    let response = client.req_post(req, &[&data], &token).await?.data;
+    println!("{response:?}");
 
     Ok(())
 }

--- a/examples/channel_information.rs
+++ b/examples/channel_information.rs
@@ -31,7 +31,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>>
         .expect("no user found");
 
     let channel = client
-        .get_channel_from_id(&*user.id, &token)
+        .get_channel_from_id(&user.id, &token)
         .await?
         .expect("no channel found");
 

--- a/examples/channel_information.rs
+++ b/examples/channel_information.rs
@@ -26,12 +26,12 @@ async fn run() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>>
     let token = UserToken::from_existing(&client, token, None, None).await?;
 
     let user = client
-        .get_user_from_login(args.next().unwrap(), &token)
+        .get_user_from_login(&*args.next().unwrap(), &token)
         .await?
         .expect("no user found");
 
     let channel = client
-        .get_channel_from_id(user.id.clone(), &token)
+        .get_channel_from_id(&*user.id, &token)
         .await?
         .expect("no channel found");
 

--- a/examples/channel_information_custom.rs
+++ b/examples/channel_information_custom.rs
@@ -24,11 +24,10 @@ async fn run() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>>
         .map(AccessToken::new)
         .expect("Please set env: TWITCH_TOKEN or pass token as first argument");
     let token = UserToken::from_existing(&client, token, None, None).await?;
-    let id = token.user_id.clone();
 
     let resp = client
         .req_get_custom(
-            helix::channels::GetChannelInformationRequest::broadcaster_id(id),
+            helix::channels::GetChannelInformationRequest::broadcaster_id(&*token.user_id),
             &token,
         )
         .await

--- a/examples/channel_information_custom.rs
+++ b/examples/channel_information_custom.rs
@@ -27,7 +27,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>>
 
     let resp = client
         .req_get_custom(
-            helix::channels::GetChannelInformationRequest::broadcaster_id(&*token.user_id),
+            helix::channels::GetChannelInformationRequest::broadcaster_id(&token.user_id),
             &token,
         )
         .await

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -1,4 +1,4 @@
-use twitch_api::{helix::streams::GetStreamsRequest, TwitchClient};
+use twitch_api::{helix::streams::GetStreamsRequest, types, TwitchClient};
 use twitch_oauth2::{AccessToken, UserToken};
 fn main() {
     use std::error::Error;
@@ -36,9 +36,20 @@ async fn run() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>>
     )
     .await?;
 
-    let req = GetStreamsRequest::user_login(args.next().expect("please provide an username"));
     foo_client.client.helix.clone_client();
-    let response = foo_client.client.helix.req_get(req, &token).await?;
-    println!("{:?}", response);
+    let response = foo_client
+        .client
+        .helix
+        .req_get(
+            GetStreamsRequest::user_logins(
+                &[types::UserNameRef::from_str(
+                    &args.next().expect("please provide an username"),
+                )][..],
+            ),
+            &token,
+        )
+        .await?
+        .data;
+    println!("{response:?}");
     Ok(())
 }

--- a/examples/eventsub/src/main.rs
+++ b/examples/eventsub/src/main.rs
@@ -74,7 +74,7 @@ pub async fn run(opts: &Opts) -> eyre::Result<()> {
     .await?;
 
     let broadcaster = client
-        .get_user_from_login(&*opts.broadcaster_login, &token)
+        .get_user_from_login(&opts.broadcaster_login, &token)
         .await?
         .ok_or_else(|| eyre::eyre!("broadcaster not found"))?;
 

--- a/examples/eventsub/src/twitch.rs
+++ b/examples/eventsub/src/twitch.rs
@@ -264,7 +264,9 @@ pub async fn is_live<'a>(
     tracing::info!("checking if live");
     if let Some(stream) = client
         .req_get(
-            helix::streams::get_streams::GetStreamsRequest::user_id(config.broadcaster.id.clone()),
+            helix::streams::get_streams::GetStreamsRequest::user_ids(
+                &[config.broadcaster.id.as_ref()][..],
+            ),
             token,
         )
         .await

--- a/examples/followed_streams.rs
+++ b/examples/followed_streams.rs
@@ -37,7 +37,13 @@ async fn run() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>>
         .try_collect::<Vec<_>>()
         .await?;
     let games = client
-        .get_games_by_id(streams.iter().map(|s| s.game_id.clone()), &token)
+        .get_games_by_id(
+            &streams
+                .iter()
+                .map(|s| s.game_id.as_ref())
+                .collect::<Vec<_>>(),
+            &token,
+        )
         .await?;
 
     println!(

--- a/examples/get_channel_status.rs
+++ b/examples/get_channel_status.rs
@@ -1,4 +1,4 @@
-use twitch_api::{helix::streams::GetStreamsRequest, HelixClient};
+use twitch_api::{helix::streams::GetStreamsRequest, types, HelixClient};
 use twitch_oauth2::{AccessToken, UserToken};
 
 fn main() {
@@ -31,10 +31,17 @@ async fn run() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>>
     .await
     .unwrap();
 
-    let req = GetStreamsRequest::user_login(args.next().unwrap());
+    let response = client
+        .req_get(
+            GetStreamsRequest::user_logins(
+                &[types::UserNameRef::from_str(&args.next().unwrap())][..],
+            ),
+            &token,
+        )
+        .await
+        .unwrap()
+        .data;
 
-    let response = client.req_get(req, &token).await.unwrap();
-
-    println!("Stream information:\n\t{:?}", response.data);
+    println!("Stream information:\n\t{response:?}");
     Ok(())
 }

--- a/examples/mock_api.rs
+++ b/examples/mock_api.rs
@@ -59,16 +59,16 @@ async fn run() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>>
     .await?;
 
     let user = client
-        .get_user_from_id(&*user_id, &token)
+        .get_user_from_id(&user_id, &token)
         .await?
         .expect("no user found");
 
     let _channel = client
-        .get_channel_from_id(&*user_id, &token)
+        .get_channel_from_id(&user_id, &token)
         .await?
         .expect("no channel found");
     let _channel = client
-        .get_channel_from_id(&*user.id, &token)
+        .get_channel_from_id(&user.id, &token)
         .await?
         .expect("no channel found");
 
@@ -86,7 +86,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>>
         .await?;
     dbg!(search.get(0));
     let _total = client
-        .get_total_followers_from_id(&*search.get(0).unwrap().id, &token)
+        .get_total_followers_from_id(&search.get(0).unwrap().id, &token)
         .await?;
     dbg!(_total);
     let streams: Vec<_> = client.get_followed_streams(&token).try_collect().await?;

--- a/examples/mock_api.rs
+++ b/examples/mock_api.rs
@@ -68,7 +68,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>>
         .await?
         .expect("no channel found");
     let _channel = client
-        .get_channel_from_id(user.id.clone(), &token)
+        .get_channel_from_id(&*user.id, &token)
         .await?
         .expect("no channel found");
 
@@ -86,7 +86,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>>
         .await?;
     dbg!(search.get(0));
     let _total = client
-        .get_total_followers_from_id(search.get(0).unwrap().id.clone(), &token)
+        .get_total_followers_from_id(&*search.get(0).unwrap().id, &token)
         .await?;
     dbg!(_total);
     let streams: Vec<_> = client.get_followed_streams(&token).try_collect().await?;

--- a/examples/modify_channel.rs
+++ b/examples/modify_channel.rs
@@ -33,14 +33,19 @@ async fn run() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>>
     let broadcaster_id = token.validate_token(&client).await?.user_id.unwrap();
 
     let req = twitch_api::helix::channels::ModifyChannelInformationRequest::broadcaster_id(
-        broadcaster_id,
+        &*broadcaster_id,
     );
 
-    let mut data = twitch_api::helix::channels::ModifyChannelInformationBody::new();
-    data.title("Hello World!");
-
     println!("scopes: {:?}", token.scopes());
-    let response = client.req_patch(req, data, &token).await?;
+    let response = client
+        .req_patch(
+            req,
+            twitch_api::helix::channels::ModifyChannelInformationBody::builder()
+                .title("Hello World!")
+                .build(),
+            &token,
+        )
+        .await?;
     println!("{:?}", response);
 
     Ok(())

--- a/examples/modify_channel.rs
+++ b/examples/modify_channel.rs
@@ -33,7 +33,7 @@ async fn run() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>>
     let broadcaster_id = token.validate_token(&client).await?.user_id.unwrap();
 
     let req = twitch_api::helix::channels::ModifyChannelInformationRequest::broadcaster_id(
-        &*broadcaster_id,
+        &broadcaster_id,
     );
 
     let mut body = twitch_api::helix::channels::ModifyChannelInformationBody::new();

--- a/examples/modify_channel.rs
+++ b/examples/modify_channel.rs
@@ -36,16 +36,11 @@ async fn run() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>>
         &*broadcaster_id,
     );
 
+    let mut body = twitch_api::helix::channels::ModifyChannelInformationBody::new();
+    body.title("Hello World!");
+
     println!("scopes: {:?}", token.scopes());
-    let response = client
-        .req_patch(
-            req,
-            twitch_api::helix::channels::ModifyChannelInformationBody::builder()
-                .title("Hello World!")
-                .build(),
-            &token,
-        )
-        .await?;
+    let response = client.req_patch(req, body, &token).await?;
     println!("{:?}", response);
 
     Ok(())

--- a/src/helix/client/client_ext.rs
+++ b/src/helix/client/client_ext.rs
@@ -141,7 +141,7 @@ impl<'a, C: crate::HttpClient<'a> + Sync> HelixClient<'a, C> {
     where
         T: TwitchToken + Send + Sync + ?Sized,
     {
-        let req = helix::search::SearchCategoriesRequest::query(query).first(100);
+        let req = helix::search::SearchCategoriesRequest::query(query.into()).first(100);
         make_stream(req, token, self, std::collections::VecDeque::from)
     }
 

--- a/src/helix/endpoints/bits/get_bits_leaderboard.rs
+++ b/src/helix/endpoints/bits/get_bits_leaderboard.rs
@@ -44,7 +44,7 @@ use helix::RequestGet;
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug, Default)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct GetBitsLeaderboardRequest {
+pub struct GetBitsLeaderboardRequest<'a> {
     /// Number of results to be returned. Maximum: 100. Default: 10.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     pub count: Option<i32>,
@@ -57,16 +57,19 @@ pub struct GetBitsLeaderboardRequest {
     /// * "year" – 00:00:00 on the first day of the year specified in started_at, through 00:00:00 on the first day of the following year.
     /// * "all" – The lifetime of the broadcaster's channel. If this is specified (or used by default), started_at is ignored.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
-    pub period: Option<String>,
+    #[serde(borrow)]
+    pub period: Option<&'a str>,
     /// Timestamp for the period over which the returned data is aggregated. Must be in RFC 3339 format. If this is not provided, data is aggregated over the current period; e.g., the current day/week/month/year. This value is ignored if period is "all".
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
-    pub started_at: Option<types::Timestamp>,
+    #[serde(borrow)]
+    pub started_at: Option<&'a types::TimestampRef>,
     /// ID of the user whose results are returned; i.e., the person who paid for the Bits.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
-    pub user_id: Option<types::UserId>,
+    #[serde(borrow)]
+    pub user_id: Option<&'a types::UserIdRef>,
 }
 
-impl GetBitsLeaderboardRequest {
+impl<'a> GetBitsLeaderboardRequest<'a> {
     /// Number of results to be returned. Maximum: 100. Default: 10.
     pub fn count(self, count: i32) -> Self {
         Self {
@@ -76,7 +79,7 @@ impl GetBitsLeaderboardRequest {
     }
 
     /// Get loaderboard for this period. Valid values: `"day"`, `"week"`, `"month"`, `"year"`, `"all"`
-    pub fn period(self, period: String) -> Self {
+    pub fn period(self, period: &'a str) -> Self {
         Self {
             period: Some(period),
             ..self
@@ -84,7 +87,7 @@ impl GetBitsLeaderboardRequest {
     }
 
     /// Get leaderboard starting at this timestamp
-    pub fn started_at(self, started_at: impl Into<types::Timestamp>) -> Self {
+    pub fn started_at(self, started_at: impl Into<&'a types::TimestampRef>) -> Self {
         Self {
             started_at: Some(started_at.into()),
             ..self
@@ -92,7 +95,7 @@ impl GetBitsLeaderboardRequest {
     }
 
     /// Get leaderboard where this user is included (if they are on the leaderboard)
-    pub fn user_id(self, user_id: impl Into<types::UserId>) -> Self {
+    pub fn user_id(self, user_id: impl Into<&'a types::UserIdRef>) -> Self {
         Self {
             user_id: Some(user_id.into()),
             ..self
@@ -146,7 +149,7 @@ pub struct LeaderboardUser {
     pub user_login: types::UserName,
 }
 
-impl Request for GetBitsLeaderboardRequest {
+impl Request for GetBitsLeaderboardRequest<'_> {
     type Response = BitsLeaderboard;
 
     const PATH: &'static str = "bits/leaderboard";
@@ -154,7 +157,7 @@ impl Request for GetBitsLeaderboardRequest {
     const SCOPE: &'static [twitch_oauth2::Scope] = &[];
 }
 
-impl RequestGet for GetBitsLeaderboardRequest {
+impl RequestGet for GetBitsLeaderboardRequest<'_> {
     fn parse_inner_response(
         request: Option<Self>,
         uri: &http::Uri,

--- a/src/helix/endpoints/bits/get_bits_leaderboard.rs
+++ b/src/helix/endpoints/bits/get_bits_leaderboard.rs
@@ -58,7 +58,7 @@ pub struct GetBitsLeaderboardRequest<'a> {
     /// * "all" – The lifetime of the broadcaster's channel. If this is specified (or used by default), started_at is ignored.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(borrow)]
-    pub period: Option<&'a str>,
+    pub period: Option<Cow<'a, str>>,
     /// Timestamp for the period over which the returned data is aggregated. Must be in RFC 3339 format. If this is not provided, data is aggregated over the current period; e.g., the current day/week/month/year. This value is ignored if period is "all".
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(borrow)]
@@ -79,9 +79,9 @@ impl<'a> GetBitsLeaderboardRequest<'a> {
     }
 
     /// Get loaderboard for this period. Valid values: `"day"`, `"week"`, `"month"`, `"year"`, `"all"`
-    pub fn period(self, period: &'a str) -> Self {
+    pub fn period(self, period: impl Into<Cow<'a, str>>) -> Self {
         Self {
-            period: Some(period),
+            period: Some(period.into()),
             ..self
         }
     }

--- a/src/helix/endpoints/bits/get_bits_leaderboard.rs
+++ b/src/helix/endpoints/bits/get_bits_leaderboard.rs
@@ -10,7 +10,7 @@
 //!
 //! ```rust, no_run
 //! use twitch_api::helix::bits::get_bits_leaderboard;
-//! let request = get_bits_leaderboard::GetBitsLeaderboardRequest::new().period("day".to_string());
+//! let request = get_bits_leaderboard::GetBitsLeaderboardRequest::new().period("day");
 //! // Get leaderbord for the lifetime of the channel
 //! let request = get_bits_leaderboard::GetBitsLeaderboardRequest::new();
 //! ```

--- a/src/helix/endpoints/bits/get_bits_leaderboard.rs
+++ b/src/helix/endpoints/bits/get_bits_leaderboard.rs
@@ -62,11 +62,11 @@ pub struct GetBitsLeaderboardRequest<'a> {
     /// Timestamp for the period over which the returned data is aggregated. Must be in RFC 3339 format. If this is not provided, data is aggregated over the current period; e.g., the current day/week/month/year. This value is ignored if period is "all".
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(borrow)]
-    pub started_at: Option<&'a types::TimestampRef>,
+    pub started_at: Option<Cow<'a, types::TimestampRef>>,
     /// ID of the user whose results are returned; i.e., the person who paid for the Bits.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(borrow)]
-    pub user_id: Option<&'a types::UserIdRef>,
+    pub user_id: Option<Cow<'a, types::UserIdRef>>,
 }
 
 impl<'a> GetBitsLeaderboardRequest<'a> {
@@ -87,17 +87,17 @@ impl<'a> GetBitsLeaderboardRequest<'a> {
     }
 
     /// Get leaderboard starting at this timestamp
-    pub fn started_at(self, started_at: impl Into<&'a types::TimestampRef>) -> Self {
+    pub fn started_at(self, started_at: impl types::IntoCow<'a, types::TimestampRef> + 'a) -> Self {
         Self {
-            started_at: Some(started_at.into()),
+            started_at: Some(started_at.to_cow()),
             ..self
         }
     }
 
     /// Get leaderboard where this user is included (if they are on the leaderboard)
-    pub fn user_id(self, user_id: impl Into<&'a types::UserIdRef>) -> Self {
+    pub fn user_id(self, user_id: impl types::IntoCow<'a, types::UserIdRef> + 'a) -> Self {
         Self {
-            user_id: Some(user_id.into()),
+            user_id: Some(user_id.to_cow()),
             ..self
         }
     }

--- a/src/helix/endpoints/bits/get_cheermotes.rs
+++ b/src/helix/endpoints/bits/get_cheermotes.rs
@@ -44,18 +44,19 @@ use helix::RequestGet;
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug, Default)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct GetCheermotesRequest {
+pub struct GetCheermotesRequest<'a> {
     /// ID for the broadcaster who might own specialized Cheermotes.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
-    pub broadcaster_id: Option<types::UserId>,
+    #[serde(borrow)]
+    pub broadcaster_id: Option<&'a types::UserIdRef>,
 }
 
-impl GetCheermotesRequest {
+impl<'a> GetCheermotesRequest<'a> {
     /// Get available Cheermotes.
     pub fn new() -> Self { Self::default() }
 
     /// Get Cheermotes in a specific broadcasters channel.
-    pub fn broadcaster_id(broadcaster_id: impl Into<types::UserId>) -> Self {
+    pub fn broadcaster_id(broadcaster_id: impl Into<&'a types::UserIdRef>) -> Self {
         Self {
             broadcaster_id: Some(broadcaster_id.into()),
         }
@@ -176,7 +177,7 @@ pub struct CheermoteImageArray {
 #[serde(transparent)]
 pub struct Level(pub String);
 
-impl Request for GetCheermotesRequest {
+impl Request for GetCheermotesRequest<'_> {
     type Response = Vec<Cheermote>;
 
     const PATH: &'static str = "bits/cheermotes";
@@ -184,7 +185,7 @@ impl Request for GetCheermotesRequest {
     const SCOPE: &'static [twitch_oauth2::Scope] = &[];
 }
 
-impl RequestGet for GetCheermotesRequest {}
+impl RequestGet for GetCheermotesRequest<'_> {}
 
 #[cfg(test)]
 #[test]

--- a/src/helix/endpoints/bits/get_cheermotes.rs
+++ b/src/helix/endpoints/bits/get_cheermotes.rs
@@ -48,7 +48,7 @@ pub struct GetCheermotesRequest<'a> {
     /// ID for the broadcaster who might own specialized Cheermotes.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: Option<&'a types::UserIdRef>,
+    pub broadcaster_id: Option<Cow<'a, types::UserIdRef>>,
 }
 
 impl<'a> GetCheermotesRequest<'a> {
@@ -56,9 +56,9 @@ impl<'a> GetCheermotesRequest<'a> {
     pub fn new() -> Self { Self::default() }
 
     /// Get Cheermotes in a specific broadcasters channel.
-    pub fn broadcaster_id(broadcaster_id: impl Into<&'a types::UserIdRef>) -> Self {
+    pub fn broadcaster_id(broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a) -> Self {
         Self {
-            broadcaster_id: Some(broadcaster_id.into()),
+            broadcaster_id: Some(broadcaster_id.to_cow()),
         }
     }
 }

--- a/src/helix/endpoints/bits/mod.rs
+++ b/src/helix/endpoints/bits/mod.rs
@@ -22,6 +22,7 @@ use crate::{
     types,
 };
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 
 pub mod get_bits_leaderboard;
 pub mod get_cheermotes;

--- a/src/helix/endpoints/channels/add_channel_vip.rs
+++ b/src/helix/endpoints/channels/add_channel_vip.rs
@@ -45,22 +45,22 @@ pub struct AddChannelVipRequest<'a> {
     /// The ID of the broadcaster that’s granting VIP status to the user.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: &'a types::UserIdRef,
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
     /// The ID of the user to add as a VIP in the broadcaster’s chat room.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub user_id: &'a types::UserIdRef,
+    pub user_id: Cow<'a, types::UserIdRef>,
 }
 
 impl<'a> AddChannelVipRequest<'a> {
     /// Add a channel VIP
     pub fn new(
-        broadcaster_id: impl Into<&'a types::UserIdRef>,
-        user_id: impl Into<&'a types::UserIdRef>,
+        broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
+        user_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
     ) -> Self {
         Self {
-            broadcaster_id: broadcaster_id.into(),
-            user_id: user_id.into(),
+            broadcaster_id: broadcaster_id.to_cow(),
+            user_id: user_id.to_cow(),
         }
     }
 }

--- a/src/helix/endpoints/channels/add_channel_vip.rs
+++ b/src/helix/endpoints/channels/add_channel_vip.rs
@@ -41,20 +41,22 @@ use helix::RequestPost;
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct AddChannelVipRequest {
+pub struct AddChannelVipRequest<'a> {
     /// The ID of the broadcaster that’s granting VIP status to the user.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub broadcaster_id: types::UserId,
+    #[serde(borrow)]
+    pub broadcaster_id: &'a types::UserIdRef,
     /// The ID of the user to add as a VIP in the broadcaster’s chat room.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub user_id: types::UserId,
+    #[serde(borrow)]
+    pub user_id: &'a types::UserIdRef,
 }
 
-impl AddChannelVipRequest {
+impl<'a> AddChannelVipRequest<'a> {
     /// Add a channel VIP
     pub fn new(
-        broadcaster_id: impl Into<types::UserId>,
-        user_id: impl Into<types::UserId>,
+        broadcaster_id: impl Into<&'a types::UserIdRef>,
+        user_id: impl Into<&'a types::UserIdRef>,
     ) -> Self {
         Self {
             broadcaster_id: broadcaster_id.into(),
@@ -74,7 +76,7 @@ pub enum AddChannelVipResponse {
     Success,
 }
 
-impl Request for AddChannelVipRequest {
+impl Request for AddChannelVipRequest<'_> {
     type Response = AddChannelVipResponse;
 
     const PATH: &'static str = "channels/vips";
@@ -82,7 +84,7 @@ impl Request for AddChannelVipRequest {
     const SCOPE: &'static [twitch_oauth2::Scope] = &[twitch_oauth2::Scope::ChannelManageVips];
 }
 
-impl RequestPost for AddChannelVipRequest {
+impl RequestPost for AddChannelVipRequest<'_> {
     type Body = helix::EmptyBody;
 
     fn parse_inner_response(

--- a/src/helix/endpoints/channels/get_channel_editors.rs
+++ b/src/helix/endpoints/channels/get_channel_editors.rs
@@ -47,14 +47,14 @@ pub struct GetChannelEditorsRequest<'a> {
     /// Broadcaster’s user ID associated with the channel.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: &'a types::UserIdRef,
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
 }
 
 impl<'a> GetChannelEditorsRequest<'a> {
     /// Get specified broadcasters channel editors
-    pub fn broadcaster_id(broadcaster_id: impl Into<&'a types::UserIdRef>) -> Self {
+    pub fn broadcaster_id(broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a) -> Self {
         Self {
-            broadcaster_id: broadcaster_id.into(),
+            broadcaster_id: broadcaster_id.to_cow(),
         }
     }
 }

--- a/src/helix/endpoints/channels/get_channel_editors.rs
+++ b/src/helix/endpoints/channels/get_channel_editors.rs
@@ -43,15 +43,16 @@ use helix::RequestGet;
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct GetChannelEditorsRequest {
+pub struct GetChannelEditorsRequest<'a> {
     /// Broadcaster’s user ID associated with the channel.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub broadcaster_id: types::UserId,
+    #[serde(borrow)]
+    pub broadcaster_id: &'a types::UserIdRef,
 }
 
-impl GetChannelEditorsRequest {
+impl<'a> GetChannelEditorsRequest<'a> {
     /// Get specified broadcasters channel editors
-    pub fn broadcaster_id(broadcaster_id: impl Into<types::UserId>) -> Self {
+    pub fn broadcaster_id(broadcaster_id: impl Into<&'a types::UserIdRef>) -> Self {
         Self {
             broadcaster_id: broadcaster_id.into(),
         }
@@ -73,7 +74,7 @@ pub struct Editor {
     pub created_at: types::Timestamp,
 }
 
-impl Request for GetChannelEditorsRequest {
+impl Request for GetChannelEditorsRequest<'_> {
     type Response = Vec<Editor>;
 
     const PATH: &'static str = "channels/editors";
@@ -81,13 +82,13 @@ impl Request for GetChannelEditorsRequest {
     const SCOPE: &'static [twitch_oauth2::Scope] = &[twitch_oauth2::Scope::ChannelReadEditors];
 }
 
-impl RequestGet for GetChannelEditorsRequest {}
+impl RequestGet for GetChannelEditorsRequest<'_> {}
 
 #[cfg(test)]
 #[test]
 fn test_request() {
     use helix::*;
-    let req = GetChannelEditorsRequest::broadcaster_id("44445592".to_string());
+    let req = GetChannelEditorsRequest::broadcaster_id("44445592");
 
     // From twitch docs
     let data = br#"

--- a/src/helix/endpoints/channels/get_channel_information.rs
+++ b/src/helix/endpoints/channels/get_channel_information.rs
@@ -43,15 +43,16 @@ use helix::RequestGet;
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct GetChannelInformationRequest {
+pub struct GetChannelInformationRequest<'a> {
     /// ID of the channel
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub broadcaster_id: types::UserId,
+    #[serde(borrow)]
+    pub broadcaster_id: &'a types::UserIdRef,
 }
 
-impl GetChannelInformationRequest {
+impl<'a> GetChannelInformationRequest<'a> {
     /// Get channel information for a specific broadcaster.
-    pub fn broadcaster_id(broadcaster_id: impl Into<types::UserId>) -> Self {
+    pub fn broadcaster_id(broadcaster_id: impl Into<&'a types::UserIdRef>) -> Self {
         Self {
             broadcaster_id: broadcaster_id.into(),
         }
@@ -87,7 +88,7 @@ pub struct ChannelInformation {
     pub delay: i64,
 }
 
-impl Request for GetChannelInformationRequest {
+impl Request for GetChannelInformationRequest<'_> {
     type Response = Option<ChannelInformation>;
 
     const PATH: &'static str = "channels";
@@ -95,7 +96,7 @@ impl Request for GetChannelInformationRequest {
     const SCOPE: &'static [twitch_oauth2::Scope] = &[];
 }
 
-impl RequestGet for GetChannelInformationRequest {
+impl RequestGet for GetChannelInformationRequest<'_> {
     fn parse_inner_response(
         request: Option<Self>,
         uri: &http::Uri,
@@ -128,7 +129,7 @@ impl RequestGet for GetChannelInformationRequest {
 #[test]
 fn test_request() {
     use helix::*;
-    let req = GetChannelInformationRequest::broadcaster_id("44445592".to_string());
+    let req = GetChannelInformationRequest::broadcaster_id("44445592");
 
     // From twitch docs
     let data = br#"

--- a/src/helix/endpoints/channels/get_channel_information.rs
+++ b/src/helix/endpoints/channels/get_channel_information.rs
@@ -47,14 +47,14 @@ pub struct GetChannelInformationRequest<'a> {
     /// ID of the channel
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: &'a types::UserIdRef,
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
 }
 
 impl<'a> GetChannelInformationRequest<'a> {
     /// Get channel information for a specific broadcaster.
-    pub fn broadcaster_id(broadcaster_id: impl Into<&'a types::UserIdRef>) -> Self {
+    pub fn broadcaster_id(broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a) -> Self {
         Self {
-            broadcaster_id: broadcaster_id.into(),
+            broadcaster_id: broadcaster_id.to_cow(),
         }
     }
 }

--- a/src/helix/endpoints/channels/get_vips.rs
+++ b/src/helix/endpoints/channels/get_vips.rs
@@ -36,7 +36,6 @@
 //! and parse the [`http::Response`] with [`GetVipsRequest::parse_response(None, &request.get_uri(), response)`](GetVipsRequest::parse_response)
 use super::*;
 use helix::RequestGet;
-use std::borrow::Cow;
 
 /// Query Parameters for [Get VIPs](super::get_vips)
 ///
@@ -48,7 +47,7 @@ pub struct GetVipsRequest<'a> {
     /// The ID of the broadcaster whose list of VIPs you want to get.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: &'a types::UserIdRef,
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
     /// Filters the list for specific VIPs. To specify more than one user, include the user_id parameter for each user to get. For example, &user_id=1234&user_id=5678. The maximum number of IDs that you may specify is 100. Ignores those users in the list that aren’t VIPs.
     #[cfg_attr(feature = "typed-builder", builder(default))]
     #[serde(borrow)]
@@ -63,9 +62,9 @@ pub struct GetVipsRequest<'a> {
 
 impl<'a> GetVipsRequest<'a> {
     /// Get channel VIPs in channel
-    pub fn broadcaster_id(broadcaster_id: impl Into<&'a types::UserIdRef>) -> Self {
+    pub fn broadcaster_id(broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a) -> Self {
         Self {
-            broadcaster_id: broadcaster_id.into(),
+            broadcaster_id: broadcaster_id.to_cow(),
             user_id: Cow::Borrowed(&[]),
             first: None,
             after: None,

--- a/src/helix/endpoints/channels/get_vips.rs
+++ b/src/helix/endpoints/channels/get_vips.rs
@@ -57,7 +57,7 @@ pub struct GetVipsRequest<'a> {
     pub first: Option<usize>,
     /// The cursor used to get the next page of results. The Pagination object in the response contains the cursor’s value. Read more.
     #[cfg_attr(feature = "typed-builder", builder(default))]
-    pub after: Option<helix::Cursor>,
+    pub after: Option<Cow<'a, helix::CursorRef>>,
 }
 
 impl<'a> GetVipsRequest<'a> {
@@ -110,7 +110,9 @@ impl Request for GetVipsRequest<'_> {
 }
 
 impl helix::Paginated for GetVipsRequest<'_> {
-    fn set_pagination(&mut self, cursor: Option<helix::Cursor>) { self.after = cursor; }
+    fn set_pagination(&mut self, cursor: Option<helix::Cursor>) {
+        self.after = cursor.map(|c| c.into_cow())
+    }
 }
 
 impl RequestGet for GetVipsRequest<'_> {}

--- a/src/helix/endpoints/channels/mod.rs
+++ b/src/helix/endpoints/channels/mod.rs
@@ -24,6 +24,7 @@ use crate::{
     types,
 };
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 
 pub mod add_channel_vip;
 pub mod get_channel_editors;

--- a/src/helix/endpoints/channels/modify_channel_information.rs
+++ b/src/helix/endpoints/channels/modify_channel_information.rs
@@ -65,14 +65,14 @@ pub struct ModifyChannelInformationRequest<'a> {
     /// ID of the channel
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: &'a types::UserIdRef,
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
 }
 
 impl<'a> ModifyChannelInformationRequest<'a> {
     /// Modify specified broadcasters channel
-    pub fn broadcaster_id(broadcaster_id: impl Into<&'a types::UserIdRef>) -> Self {
+    pub fn broadcaster_id(broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a) -> Self {
         ModifyChannelInformationRequest {
-            broadcaster_id: broadcaster_id.into(),
+            broadcaster_id: broadcaster_id.to_cow(),
         }
     }
 }
@@ -88,7 +88,7 @@ pub struct ModifyChannelInformationBody<'a> {
     /// Current game ID being played on the channel. Use “0” or “” (an empty string) to unset the game.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(skip_serializing_if = "Option::is_none", borrow)]
-    pub game_id: Option<&'a types::CategoryIdRef>,
+    pub game_id: Option<Cow<'a, types::CategoryIdRef>>,
     /// Language of the channel
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(skip_serializing_if = "Option::is_none", borrow)]
@@ -112,8 +112,11 @@ impl<'a> ModifyChannelInformationBody<'a> {
     pub fn new() -> Self { Default::default() }
 
     /// Current game ID being played on the channel. Use “0” or “” (an empty string) to unset the game.
-    pub fn game_id(&mut self, game_id: impl Into<&'a types::CategoryIdRef>) -> &mut Self {
-        self.game_id = Some(game_id.into());
+    pub fn game_id(
+        &mut self,
+        game_id: impl types::IntoCow<'a, types::CategoryIdRef> + 'a,
+    ) -> &mut Self {
+        self.game_id = Some(game_id.to_cow());
         self
     }
 
@@ -191,7 +194,7 @@ fn test_request() {
     let req = ModifyChannelInformationRequest::broadcaster_id("0");
 
     let body = ModifyChannelInformationBody {
-        title: Some("Hello World!".into()),
+        title: Some("Hello World!"),
         ..Default::default()
     };
 

--- a/src/helix/endpoints/channels/modify_channel_information.rs
+++ b/src/helix/endpoints/channels/modify_channel_information.rs
@@ -87,11 +87,11 @@ pub struct ModifyChannelInformationBody<'a> {
     /// Language of the channel
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(skip_serializing_if = "Option::is_none", borrow)]
-    pub broadcaster_language: Option<&'a str>,
+    pub broadcaster_language: Option<Cow<'a, str>>,
     /// Title of the stream. Value must not be an empty string.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(skip_serializing_if = "Option::is_none", borrow)]
-    pub title: Option<&'a str>,
+    pub title: Option<Cow<'a, str>>,
 }
 
 impl<'a> ModifyChannelInformationBody<'a> {
@@ -116,13 +116,16 @@ impl<'a> ModifyChannelInformationBody<'a> {
     }
 
     /// Language of the channel
-    pub fn broadcaster_language(&mut self, broadcaster_language: impl Into<&'a str>) -> &mut Self {
+    pub fn broadcaster_language(
+        &mut self,
+        broadcaster_language: impl Into<Cow<'a, str>>,
+    ) -> &mut Self {
         self.broadcaster_language = Some(broadcaster_language.into());
         self
     }
 
     /// Title of the stream. Value must not be an empty string.
-    pub fn title(&mut self, title: impl Into<&'a str>) -> &mut Self {
+    pub fn title(&mut self, title: impl Into<Cow<'a, str>>) -> &mut Self {
         self.title = Some(title.into());
         self
     }
@@ -188,10 +191,8 @@ fn test_request() {
     use helix::*;
     let req = ModifyChannelInformationRequest::broadcaster_id("0");
 
-    let body = ModifyChannelInformationBody {
-        title: Some("Hello World!"),
-        ..Default::default()
-    };
+    let mut body = ModifyChannelInformationBody::new();
+    body.title("Hello World!");
 
     dbg!(req.create_request(body, "token", "clientid").unwrap());
 

--- a/src/helix/endpoints/channels/modify_channel_information.rs
+++ b/src/helix/endpoints/channels/modify_channel_information.rs
@@ -21,7 +21,7 @@
 //! ```
 //! # use twitch_api::helix::channels::modify_channel_information;
 //! let body = modify_channel_information::ModifyChannelInformationBody::builder()
-//!     .title("Hello World!".to_string())
+//!     .title("Hello World!")
 //!     .build();
 //! ```
 //!
@@ -43,7 +43,7 @@
 //!     .broadcaster_id("1234")
 //!     .build();
 //! let body = modify_channel_information::ModifyChannelInformationBody::builder()
-//!     .title("Hello World!".to_string())
+//!     .title("Hello World!")
 //!     .build();
 //! let response: modify_channel_information::ModifyChannelInformation = client.req_patch(request, body, &token).await?.data;
 //! # Ok(())

--- a/src/helix/endpoints/channels/modify_channel_information.rs
+++ b/src/helix/endpoints/channels/modify_channel_information.rs
@@ -5,13 +5,12 @@
 //!
 //! ## Request: [ModifyChannelInformationRequest]
 //!
-//! To use this endpoint, construct a [`ModifyChannelInformationRequest`] with the [`ModifyChannelInformationRequest::builder()`] method.
+//! To use this endpoint, construct a [`ModifyChannelInformationRequest`] with the [`ModifyChannelInformationRequest::broadcaster_id()`] method.
 //!
 //! ```rust
 //! use twitch_api::helix::channels::modify_channel_information;
-//! let request = modify_channel_information::ModifyChannelInformationRequest::builder()
-//!     .broadcaster_id("1234")
-//!     .build();
+//! let request =
+//!     modify_channel_information::ModifyChannelInformationRequest::broadcaster_id("1234");
 //! ```
 //!
 //! ## Body: [ModifyChannelInformationBody]
@@ -20,9 +19,8 @@
 //!
 //! ```
 //! # use twitch_api::helix::channels::modify_channel_information;
-//! let body = modify_channel_information::ModifyChannelInformationBody::builder()
-//!     .title("Hello World!")
-//!     .build();
+//! let mut body = modify_channel_information::ModifyChannelInformationBody::new();
+//! body.title("Hello World!");
 //! ```
 //!
 //! ## Response: [ModifyChannelInformation]
@@ -39,12 +37,9 @@
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = modify_channel_information::ModifyChannelInformationRequest::builder()
-//!     .broadcaster_id("1234")
-//!     .build();
-//! let body = modify_channel_information::ModifyChannelInformationBody::builder()
-//!     .title("Hello World!")
-//!     .build();
+//! let request = modify_channel_information::ModifyChannelInformationRequest::broadcaster_id("1234");
+//! let mut body = modify_channel_information::ModifyChannelInformationBody::new();
+//! body.title("Hello World!");
 //! let response: modify_channel_information::ModifyChannelInformation = client.req_patch(request, body, &token).await?.data;
 //! # Ok(())
 //! # }

--- a/src/helix/endpoints/channels/modify_channel_information.rs
+++ b/src/helix/endpoints/channels/modify_channel_information.rs
@@ -61,15 +61,16 @@ use helix::RequestPatch;
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct ModifyChannelInformationRequest {
+pub struct ModifyChannelInformationRequest<'a> {
     /// ID of the channel
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub broadcaster_id: types::UserId,
+    #[serde(borrow)]
+    pub broadcaster_id: &'a types::UserIdRef,
 }
 
-impl ModifyChannelInformationRequest {
+impl<'a> ModifyChannelInformationRequest<'a> {
     /// Modify specified broadcasters channel
-    pub fn broadcaster_id(broadcaster_id: impl Into<types::UserId>) -> Self {
+    pub fn broadcaster_id(broadcaster_id: impl Into<&'a types::UserIdRef>) -> Self {
         ModifyChannelInformationRequest {
             broadcaster_id: broadcaster_id.into(),
         }
@@ -83,22 +84,22 @@ impl ModifyChannelInformationRequest {
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug, Default)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct ModifyChannelInformationBody {
+pub struct ModifyChannelInformationBody<'a> {
     /// Current game ID being played on the channel. Use “0” or “” (an empty string) to unset the game.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub game_id: Option<types::CategoryId>,
+    #[serde(skip_serializing_if = "Option::is_none", borrow)]
+    pub game_id: Option<&'a types::CategoryIdRef>,
     /// Language of the channel
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub broadcaster_language: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", borrow)]
+    pub broadcaster_language: Option<&'a str>,
     /// Title of the stream. Value must not be an empty string.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", borrow)]
+    pub title: Option<&'a str>,
 }
 
-impl ModifyChannelInformationBody {
+impl<'a> ModifyChannelInformationBody<'a> {
     /// Data to set on the stream.
     ///
     ///  # Examples
@@ -111,25 +112,25 @@ impl ModifyChannelInformationBody {
     pub fn new() -> Self { Default::default() }
 
     /// Current game ID being played on the channel. Use “0” or “” (an empty string) to unset the game.
-    pub fn game_id(&mut self, game_id: impl Into<types::CategoryId>) -> &mut Self {
+    pub fn game_id(&mut self, game_id: impl Into<&'a types::CategoryIdRef>) -> &mut Self {
         self.game_id = Some(game_id.into());
         self
     }
 
     /// Language of the channel
-    pub fn broadcaster_language(&mut self, broadcaster_language: impl Into<String>) -> &mut Self {
+    pub fn broadcaster_language(&mut self, broadcaster_language: impl Into<&'a str>) -> &mut Self {
         self.broadcaster_language = Some(broadcaster_language.into());
         self
     }
 
     /// Title of the stream. Value must not be an empty string.
-    pub fn title(&mut self, title: impl Into<String>) -> &mut ModifyChannelInformationBody {
+    pub fn title(&'a mut self, title: impl Into<&'a str>) -> &'a mut ModifyChannelInformationBody {
         self.title = Some(title.into());
         self
     }
 }
 
-impl helix::private::SealedSerialize for ModifyChannelInformationBody {}
+impl helix::private::SealedSerialize for ModifyChannelInformationBody<'_> {}
 
 /// Return Values for [Modify Channel Information](super::modify_channel_information)
 ///
@@ -141,7 +142,7 @@ pub enum ModifyChannelInformation {
     Success,
 }
 
-impl Request for ModifyChannelInformationRequest {
+impl Request for ModifyChannelInformationRequest<'_> {
     type Response = ModifyChannelInformation;
 
     const PATH: &'static str = "channels";
@@ -149,8 +150,8 @@ impl Request for ModifyChannelInformationRequest {
     const SCOPE: &'static [twitch_oauth2::Scope] = &[twitch_oauth2::Scope::UserEditBroadcast];
 }
 
-impl RequestPatch for ModifyChannelInformationRequest {
-    type Body = ModifyChannelInformationBody;
+impl<'a> RequestPatch for ModifyChannelInformationRequest<'a> {
+    type Body = ModifyChannelInformationBody<'a>;
 
     fn parse_inner_response(
         request: Option<Self>,
@@ -190,7 +191,7 @@ fn test_request() {
     let req = ModifyChannelInformationRequest::broadcaster_id("0");
 
     let body = ModifyChannelInformationBody {
-        title: Some("Hello World!".to_string()),
+        title: Some("Hello World!".into()),
         ..Default::default()
     };
 

--- a/src/helix/endpoints/channels/modify_channel_information.rs
+++ b/src/helix/endpoints/channels/modify_channel_information.rs
@@ -124,7 +124,7 @@ impl<'a> ModifyChannelInformationBody<'a> {
     }
 
     /// Title of the stream. Value must not be an empty string.
-    pub fn title(&'a mut self, title: impl Into<&'a str>) -> &'a mut ModifyChannelInformationBody {
+    pub fn title(&mut self, title: impl Into<&'a str>) -> &mut Self {
         self.title = Some(title.into());
         self
     }

--- a/src/helix/endpoints/channels/remove_channel_vip.rs
+++ b/src/helix/endpoints/channels/remove_channel_vip.rs
@@ -5,14 +5,11 @@
 //!
 //! ## Request: [RemoveChannelVipRequest]
 //!
-//! To use this endpoint, construct a [`RemoveChannelVipRequest`] with the [`RemoveChannelVipRequest::builder()`] method.
+//! To use this endpoint, construct a [`RemoveChannelVipRequest`] with the [`RemoveChannelVipRequest::new()`] method.
 //!
 //! ```rust
 //! use twitch_api::helix::channels::remove_channel_vip;
-//! let request = remove_channel_vip::RemoveChannelVipRequest::builder()
-//!     .broadcaster_id("1234")
-//!     .user_id("1337")
-//!     .build();
+//! let request = remove_channel_vip::RemoveChannelVipRequest::new("1234", "1337");
 //! ```
 //!
 //! ## Response: [RemoveChannelVipResponse]
@@ -27,10 +24,7 @@
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = remove_channel_vip::RemoveChannelVipRequest::builder()
-//!     .broadcaster_id("1234")
-//!     .user_id("1337")
-//!     .build();
+//! let request = remove_channel_vip::RemoveChannelVipRequest::new("1234", "1337");
 //! let response: remove_channel_vip::RemoveChannelVipResponse = client.req_delete(request, &token).await?.data;
 //! # Ok(())
 //! # }

--- a/src/helix/endpoints/channels/remove_channel_vip.rs
+++ b/src/helix/endpoints/channels/remove_channel_vip.rs
@@ -48,20 +48,22 @@ use helix::RequestDelete;
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct RemoveChannelVipRequest {
+pub struct RemoveChannelVipRequest<'a> {
     /// The ID of the broadcaster that’s removing VIP status from the user.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub broadcaster_id: types::UserId,
+    #[serde(borrow)]
+    pub broadcaster_id: &'a types::UserIdRef,
     /// The ID of the user to remove as a VIP from the broadcaster’s chat room.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub user_id: types::UserId,
+    #[serde(borrow)]
+    pub user_id: &'a types::UserIdRef,
 }
 
-impl RemoveChannelVipRequest {
+impl<'a> RemoveChannelVipRequest<'a> {
     /// Remove channel VIP
     pub fn new(
-        broadcaster_id: impl Into<types::UserId>,
-        user_id: impl Into<types::UserId>,
+        broadcaster_id: impl Into<&'a types::UserIdRef>,
+        user_id: impl Into<&'a types::UserIdRef>,
     ) -> Self {
         Self {
             broadcaster_id: broadcaster_id.into(),
@@ -80,7 +82,7 @@ pub enum RemoveChannelVipResponse {
     Success,
 }
 
-impl Request for RemoveChannelVipRequest {
+impl Request for RemoveChannelVipRequest<'_> {
     type Response = RemoveChannelVipResponse;
 
     const PATH: &'static str = "channels/vips";
@@ -88,7 +90,7 @@ impl Request for RemoveChannelVipRequest {
     const SCOPE: &'static [twitch_oauth2::Scope] = &[twitch_oauth2::Scope::ChannelManageVips];
 }
 
-impl RequestDelete for RemoveChannelVipRequest {
+impl RequestDelete for RemoveChannelVipRequest<'_> {
     fn parse_inner_response(
         request: Option<Self>,
         uri: &http::Uri,

--- a/src/helix/endpoints/channels/remove_channel_vip.rs
+++ b/src/helix/endpoints/channels/remove_channel_vip.rs
@@ -52,22 +52,22 @@ pub struct RemoveChannelVipRequest<'a> {
     /// The ID of the broadcaster that’s removing VIP status from the user.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: &'a types::UserIdRef,
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
     /// The ID of the user to remove as a VIP from the broadcaster’s chat room.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub user_id: &'a types::UserIdRef,
+    pub user_id: Cow<'a, types::UserIdRef>,
 }
 
 impl<'a> RemoveChannelVipRequest<'a> {
     /// Remove channel VIP
     pub fn new(
-        broadcaster_id: impl Into<&'a types::UserIdRef>,
-        user_id: impl Into<&'a types::UserIdRef>,
+        broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
+        user_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
     ) -> Self {
         Self {
-            broadcaster_id: broadcaster_id.into(),
-            user_id: user_id.into(),
+            broadcaster_id: broadcaster_id.to_cow(),
+            user_id: user_id.to_cow(),
         }
     }
 }

--- a/src/helix/endpoints/channels/start_commercial.rs
+++ b/src/helix/endpoints/channels/start_commercial.rs
@@ -18,10 +18,10 @@
 //!
 //! ```
 //! # use twitch_api::helix::channels::start_commercial;
-//! let body = start_commercial::StartCommercialBody::builder()
-//!     .broadcaster_id("1234")
-//!     .length(twitch_api::types::CommercialLength::Length90)
-//!     .build();
+//! let body = start_commercial::StartCommercialBody::new(
+//!     "1234",
+//!     twitch_api::types::CommercialLength::Length90,
+//! );
 //! ```
 //!
 //! ## Response: [StartCommercialRequest]
@@ -37,10 +37,7 @@
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
 //! let request = start_commercial::StartCommercialRequest::new();
-//! let body = start_commercial::StartCommercialBody::builder()
-//!     .broadcaster_id("1234")
-//!     .length(twitch_api::types::CommercialLength::Length90)
-//!     .build();
+//! let body = start_commercial::StartCommercialBody::new("1234", twitch_api::types::CommercialLength::Length90);
 //! let response: Vec<start_commercial::StartCommercial> = client.req_post(request, body, &token).await?.data;
 //! # Ok(())
 //! # }

--- a/src/helix/endpoints/channels/start_commercial.rs
+++ b/src/helix/endpoints/channels/start_commercial.rs
@@ -19,7 +19,7 @@
 //! ```
 //! # use twitch_api::helix::channels::start_commercial;
 //! let body = start_commercial::StartCommercialBody::builder()
-//!     .broadcaster_id("1234".to_string())
+//!     .broadcaster_id("1234")
 //!     .length(twitch_api::types::CommercialLength::Length90)
 //!     .build();
 //! ```
@@ -38,7 +38,7 @@
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
 //! let request = start_commercial::StartCommercialRequest::new();
 //! let body = start_commercial::StartCommercialBody::builder()
-//!     .broadcaster_id("1234".to_string())
+//!     .broadcaster_id("1234")
 //!     .length(twitch_api::types::CommercialLength::Length90)
 //!     .build();
 //! let response: Vec<start_commercial::StartCommercial> = client.req_post(request, body, &token).await?.data;

--- a/src/helix/endpoints/channels/start_commercial.rs
+++ b/src/helix/endpoints/channels/start_commercial.rs
@@ -79,7 +79,7 @@ pub struct StartCommercialBody<'a> {
     /// ID of the channel requesting a commercial
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: &'a types::UserIdRef,
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
     /// Desired length of the commercial in seconds. Valid options are 30, 60, 90, 120, 150, 180.
     pub length: types::CommercialLength,
 }
@@ -87,11 +87,11 @@ pub struct StartCommercialBody<'a> {
 impl<'a> StartCommercialBody<'a> {
     /// Start a commercial in this broadcasters channel
     pub fn new(
-        broadcaster_id: impl Into<&'a types::UserIdRef>,
+        broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
         length: impl Into<types::CommercialLength>,
     ) -> Self {
         Self {
-            broadcaster_id: broadcaster_id.into(),
+            broadcaster_id: broadcaster_id.to_cow(),
             length: length.into(),
         }
     }

--- a/src/helix/endpoints/chat/get_channel_chat_badges.rs
+++ b/src/helix/endpoints/chat/get_channel_chat_badges.rs
@@ -5,13 +5,11 @@
 //!
 //! ## Request: [GetChannelChatBadgesRequest]
 //!
-//! To use this endpoint, construct a [`GetChannelChatBadgesRequest`] with the [`GetChannelChatBadgesRequest::builder()`] method.
+//! To use this endpoint, construct a [`GetChannelChatBadgesRequest`] with the [`GetChannelChatBadgesRequest::broadcaster_id()`] method.
 //!
 //! ```rust
 //! use twitch_api::helix::chat::get_channel_chat_badges;
-//! let request = get_channel_chat_badges::GetChannelChatBadgesRequest::builder()
-//!     .broadcaster_id("1234")
-//!     .build();
+//! let request = get_channel_chat_badges::GetChannelChatBadgesRequest::broadcaster_id("1234");
 //! ```
 //!
 //! ## Response: [BadgeSet]
@@ -26,9 +24,7 @@
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = get_channel_chat_badges::GetChannelChatBadgesRequest::builder()
-//!     .broadcaster_id("1234")
-//!     .build();
+//! let request = get_channel_chat_badges::GetChannelChatBadgesRequest::broadcaster_id("1234");
 //! let response: Vec<helix::chat::BadgeSet> = client.req_get(request, &token).await?.data;
 //! # Ok(())
 //! # }

--- a/src/helix/endpoints/chat/get_channel_chat_badges.rs
+++ b/src/helix/endpoints/chat/get_channel_chat_badges.rs
@@ -46,15 +46,16 @@ use helix::RequestGet;
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct GetChannelChatBadgesRequest {
+pub struct GetChannelChatBadgesRequest<'a> {
     /// The broadcaster whose chat badges are being requested. Provided broadcaster_id must match the user_id in the user OAuth token.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub broadcaster_id: types::UserId,
+    #[serde(borrow)]
+    pub broadcaster_id: &'a types::UserIdRef,
 }
 
-impl GetChannelChatBadgesRequest {
+impl<'a> GetChannelChatBadgesRequest<'a> {
     /// Get chat badges for the specified broadcaster.
-    pub fn broadcaster_id(broadcaster_id: impl Into<types::UserId>) -> Self {
+    pub fn broadcaster_id(broadcaster_id: impl Into<&'a types::UserIdRef>) -> Self {
         Self {
             broadcaster_id: broadcaster_id.into(),
         }
@@ -66,7 +67,7 @@ impl GetChannelChatBadgesRequest {
 /// [`get-channel-chat-badges`](https://dev.twitch.tv/docs/api/reference#get-channel-chat-badges)
 pub type GetChannelChatBadgesResponse = BadgeSet;
 
-impl Request for GetChannelChatBadgesRequest {
+impl Request for GetChannelChatBadgesRequest<'_> {
     type Response = Vec<GetChannelChatBadgesResponse>;
 
     const PATH: &'static str = "chat/badges";
@@ -74,7 +75,7 @@ impl Request for GetChannelChatBadgesRequest {
     const SCOPE: &'static [twitch_oauth2::Scope] = &[];
 }
 
-impl RequestGet for GetChannelChatBadgesRequest {}
+impl RequestGet for GetChannelChatBadgesRequest<'_> {}
 
 #[cfg(test)]
 #[test]

--- a/src/helix/endpoints/chat/get_channel_chat_badges.rs
+++ b/src/helix/endpoints/chat/get_channel_chat_badges.rs
@@ -50,14 +50,14 @@ pub struct GetChannelChatBadgesRequest<'a> {
     /// The broadcaster whose chat badges are being requested. Provided broadcaster_id must match the user_id in the user OAuth token.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: &'a types::UserIdRef,
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
 }
 
 impl<'a> GetChannelChatBadgesRequest<'a> {
     /// Get chat badges for the specified broadcaster.
-    pub fn broadcaster_id(broadcaster_id: impl Into<&'a types::UserIdRef>) -> Self {
+    pub fn broadcaster_id(broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a) -> Self {
         Self {
-            broadcaster_id: broadcaster_id.into(),
+            broadcaster_id: broadcaster_id.to_cow(),
         }
     }
 }

--- a/src/helix/endpoints/chat/get_channel_chat_badges.rs
+++ b/src/helix/endpoints/chat/get_channel_chat_badges.rs
@@ -10,7 +10,7 @@
 //! ```rust
 //! use twitch_api::helix::chat::get_channel_chat_badges;
 //! let request = get_channel_chat_badges::GetChannelChatBadgesRequest::builder()
-//!     .broadcaster_id("1234".to_string())
+//!     .broadcaster_id("1234")
 //!     .build();
 //! ```
 //!
@@ -27,7 +27,7 @@
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
 //! let request = get_channel_chat_badges::GetChannelChatBadgesRequest::builder()
-//!     .broadcaster_id("1234".to_string())
+//!     .broadcaster_id("1234")
 //!     .build();
 //! let response: Vec<helix::chat::BadgeSet> = client.req_get(request, &token).await?.data;
 //! # Ok(())

--- a/src/helix/endpoints/chat/get_channel_emotes.rs
+++ b/src/helix/endpoints/chat/get_channel_emotes.rs
@@ -10,7 +10,7 @@
 //! ```rust
 //! use twitch_api::helix::chat::get_channel_emotes;
 //! let request = get_channel_emotes::GetChannelEmotesRequest::builder()
-//!     .broadcaster_id("1234".to_string())
+//!     .broadcaster_id("1234")
 //!     .build();
 //! ```
 //!
@@ -27,7 +27,7 @@
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
 //! let request = get_channel_emotes::GetChannelEmotesRequest::builder()
-//!     .broadcaster_id("1234".to_string())
+//!     .broadcaster_id("1234")
 //!     .build();
 //! let response: Vec<helix::chat::ChannelEmote> = client.req_get(request, &token).await?.data;
 //! # Ok(())

--- a/src/helix/endpoints/chat/get_channel_emotes.rs
+++ b/src/helix/endpoints/chat/get_channel_emotes.rs
@@ -5,13 +5,11 @@
 //!
 //! ## Request: [GetChannelEmotesRequest]
 //!
-//! To use this endpoint, construct a [`GetChannelEmotesRequest`] with the [`GetChannelEmotesRequest::builder()`] method.
+//! To use this endpoint, construct a [`GetChannelEmotesRequest`] with the [`GetChannelEmotesRequest::broadcaster_id()`] method.
 //!
 //! ```rust
 //! use twitch_api::helix::chat::get_channel_emotes;
-//! let request = get_channel_emotes::GetChannelEmotesRequest::builder()
-//!     .broadcaster_id("1234")
-//!     .build();
+//! let request = get_channel_emotes::GetChannelEmotesRequest::broadcaster_id("1234");
 //! ```
 //!
 //! ## Response: [ChannelEmote]
@@ -26,9 +24,7 @@
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = get_channel_emotes::GetChannelEmotesRequest::builder()
-//!     .broadcaster_id("1234")
-//!     .build();
+//! let request = get_channel_emotes::GetChannelEmotesRequest::broadcaster_id("1234");
 //! let response: Vec<helix::chat::ChannelEmote> = client.req_get(request, &token).await?.data;
 //! # Ok(())
 //! # }

--- a/src/helix/endpoints/chat/get_channel_emotes.rs
+++ b/src/helix/endpoints/chat/get_channel_emotes.rs
@@ -50,14 +50,14 @@ pub struct GetChannelEmotesRequest<'a> {
     /// The broadcaster whose emotes are being requested.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: &'a types::UserIdRef,
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
 }
 
 impl<'a> GetChannelEmotesRequest<'a> {
     /// Get emotes in a specific broadcasters channel.
-    pub fn broadcaster_id(broadcaster_id: impl Into<&'a types::UserIdRef>) -> Self {
+    pub fn broadcaster_id(broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a) -> Self {
         Self {
-            broadcaster_id: broadcaster_id.into(),
+            broadcaster_id: broadcaster_id.to_cow(),
         }
     }
 }

--- a/src/helix/endpoints/chat/get_channel_emotes.rs
+++ b/src/helix/endpoints/chat/get_channel_emotes.rs
@@ -46,15 +46,16 @@ use helix::RequestGet;
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct GetChannelEmotesRequest {
+pub struct GetChannelEmotesRequest<'a> {
     /// The broadcaster whose emotes are being requested.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub broadcaster_id: types::UserId,
+    #[serde(borrow)]
+    pub broadcaster_id: &'a types::UserIdRef,
 }
 
-impl GetChannelEmotesRequest {
+impl<'a> GetChannelEmotesRequest<'a> {
     /// Get emotes in a specific broadcasters channel.
-    pub fn broadcaster_id(broadcaster_id: impl Into<types::UserId>) -> Self {
+    pub fn broadcaster_id(broadcaster_id: impl Into<&'a types::UserIdRef>) -> Self {
         Self {
             broadcaster_id: broadcaster_id.into(),
         }
@@ -66,7 +67,7 @@ impl GetChannelEmotesRequest {
 /// [`get-channel-emotes`](https://dev.twitch.tv/docs/api/reference#get-channel-emotes)
 pub type GetChannelEmotesResponse = ChannelEmote;
 
-impl Request for GetChannelEmotesRequest {
+impl Request for GetChannelEmotesRequest<'_> {
     type Response = Vec<GetChannelEmotesResponse>;
 
     const PATH: &'static str = "chat/emotes";
@@ -74,7 +75,7 @@ impl Request for GetChannelEmotesRequest {
     const SCOPE: &'static [twitch_oauth2::Scope] = &[];
 }
 
-impl RequestGet for GetChannelEmotesRequest {}
+impl RequestGet for GetChannelEmotesRequest<'_> {}
 
 #[cfg(test)]
 #[test]

--- a/src/helix/endpoints/chat/get_chat_settings.rs
+++ b/src/helix/endpoints/chat/get_chat_settings.rs
@@ -65,7 +65,7 @@ pub struct GetChatSettingsRequest<'a> {
     /// The ID of the broadcaster whose chat settings you want to get.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: &'a types::UserIdRef,
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
     /// Required only to access the [`non_moderator_chat_delay`](ChatSettings::non_moderator_chat_delay)
     /// or [`non_moderator_chat_delay_duration`](ChatSettings::non_moderator_chat_delay_duration) settings.
     /// If you want to access these settings, you need to provide a valid [`moderator_id`](Self::moderator_id)
@@ -79,14 +79,14 @@ pub struct GetChatSettingsRequest<'a> {
     /// set this parameter to the broadcaster’s ID, too.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(borrow)]
-    pub moderator_id: Option<&'a types::UserIdRef>,
+    pub moderator_id: Option<Cow<'a, types::UserIdRef>>,
 }
 
 impl<'a> GetChatSettingsRequest<'a> {
     /// Get chat settings for broadcasters channel
-    pub fn broadcaster_id(broadcaster_id: impl Into<&'a types::UserIdRef>) -> Self {
+    pub fn broadcaster_id(broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a) -> Self {
         Self {
-            broadcaster_id: broadcaster_id.into(),
+            broadcaster_id: broadcaster_id.to_cow(),
             moderator_id: None,
         }
     }
@@ -95,8 +95,11 @@ impl<'a> GetChatSettingsRequest<'a> {
     ///
     /// Required only to access the [`non_moderator_chat_delay`](ChatSettings::non_moderator_chat_delay)
     /// or [`non_moderator_chat_delay_duration`](ChatSettings::non_moderator_chat_delay_duration) settings.
-    pub fn moderator_id(mut self, moderator_id: impl Into<&'a types::UserIdRef>) -> Self {
-        self.moderator_id = Some(moderator_id.into());
+    pub fn moderator_id(
+        mut self,
+        moderator_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
+    ) -> Self {
+        self.moderator_id = Some(moderator_id.to_cow());
         self
     }
 }

--- a/src/helix/endpoints/chat/get_chat_settings.rs
+++ b/src/helix/endpoints/chat/get_chat_settings.rs
@@ -61,10 +61,11 @@ use helix::RequestGet;
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct GetChatSettingsRequest {
+pub struct GetChatSettingsRequest<'a> {
     /// The ID of the broadcaster whose chat settings you want to get.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub broadcaster_id: types::UserId,
+    #[serde(borrow)]
+    pub broadcaster_id: &'a types::UserIdRef,
     /// Required only to access the [`non_moderator_chat_delay`](ChatSettings::non_moderator_chat_delay)
     /// or [`non_moderator_chat_delay_duration`](ChatSettings::non_moderator_chat_delay_duration) settings.
     /// If you want to access these settings, you need to provide a valid [`moderator_id`](Self::moderator_id)
@@ -77,12 +78,13 @@ pub struct GetChatSettingsRequest {
     /// If the broadcaster wants to get their own settings (instead of having the moderator do it),
     /// set this parameter to the broadcaster’s ID, too.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
-    pub moderator_id: Option<types::UserId>,
+    #[serde(borrow)]
+    pub moderator_id: Option<&'a types::UserIdRef>,
 }
 
-impl GetChatSettingsRequest {
+impl<'a> GetChatSettingsRequest<'a> {
     /// Get chat settings for broadcasters channel
-    pub fn broadcaster_id(broadcaster_id: impl Into<types::UserId>) -> Self {
+    pub fn broadcaster_id(broadcaster_id: impl Into<&'a types::UserIdRef>) -> Self {
         Self {
             broadcaster_id: broadcaster_id.into(),
             moderator_id: None,
@@ -93,13 +95,13 @@ impl GetChatSettingsRequest {
     ///
     /// Required only to access the [`non_moderator_chat_delay`](ChatSettings::non_moderator_chat_delay)
     /// or [`non_moderator_chat_delay_duration`](ChatSettings::non_moderator_chat_delay_duration) settings.
-    pub fn moderator_id(mut self, moderator_id: impl Into<types::UserId>) -> Self {
+    pub fn moderator_id(mut self, moderator_id: impl Into<&'a types::UserIdRef>) -> Self {
         self.moderator_id = Some(moderator_id.into());
         self
     }
 }
 
-impl Request for GetChatSettingsRequest {
+impl Request for GetChatSettingsRequest<'_> {
     type Response = ChatSettings;
 
     #[cfg(feature = "twitch_oauth2")]
@@ -110,7 +112,7 @@ impl Request for GetChatSettingsRequest {
     const SCOPE: &'static [twitch_oauth2::Scope] = &[];
 }
 
-impl RequestGet for GetChatSettingsRequest {
+impl RequestGet for GetChatSettingsRequest<'_> {
     fn parse_inner_response(
         request: Option<Self>,
         uri: &http::Uri,

--- a/src/helix/endpoints/chat/get_chat_settings.rs
+++ b/src/helix/endpoints/chat/get_chat_settings.rs
@@ -13,18 +13,16 @@
 //!
 //! ## Request: [GetChatSettingsRequest]
 //!
-//! To use this endpoint, construct a [`GetChatSettingsRequest`] with the [`GetChatSettingsRequest::builder()`] method.
+//! To use this endpoint, construct a [`GetChatSettingsRequest`] with the [`GetChatSettingsRequest::broadcaster_id()`] method.
 //!
 //! ```rust
 //! use twitch_api::{
 //!     helix::{self, chat::get_chat_settings},
 //!     types,
 //! };
-//! let request = get_chat_settings::GetChatSettingsRequest::builder()
-//!     .broadcaster_id("1234567")
+//! let request = get_chat_settings::GetChatSettingsRequest::broadcaster_id("1234567")
 //!     // optional
-//!     .moderator_id(types::UserIdRef::from_str("9876543"))
-//!     .build();
+//!     .moderator_id("9876543");
 //! ```
 //!
 //! ## Response: [ChatSettings]
@@ -39,11 +37,9 @@
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = get_chat_settings::GetChatSettingsRequest::builder()
-//!     .broadcaster_id("1234567")
+//! let request = get_chat_settings::GetChatSettingsRequest::broadcaster_id("1234567")
 //!     // optional
-//!     .moderator_id(types::UserIdRef::from_str("9876543"))
-//!     .build();
+//!     .moderator_id("9876543");
 //! let response: helix::chat::ChatSettings = client.req_get(request, &token).await?.data;
 //! # Ok(())
 //! # }

--- a/src/helix/endpoints/chat/get_chat_settings.rs
+++ b/src/helix/endpoints/chat/get_chat_settings.rs
@@ -21,9 +21,9 @@
 //!     types,
 //! };
 //! let request = get_chat_settings::GetChatSettingsRequest::builder()
-//!     .broadcaster_id("1234567".to_owned())
+//!     .broadcaster_id("1234567")
 //!     // optional
-//!     .moderator_id(types::UserId::from("9876543"))
+//!     .moderator_id(types::UserIdRef::from_str("9876543"))
 //!     .build();
 //! ```
 //!
@@ -40,9 +40,9 @@
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
 //! let request = get_chat_settings::GetChatSettingsRequest::builder()
-//!     .broadcaster_id("1234567".to_owned())
+//!     .broadcaster_id("1234567")
 //!     // optional
-//!     .moderator_id(types::UserId::from("9876543"))
+//!     .moderator_id(types::UserIdRef::from_str("9876543"))
 //!     .build();
 //! let response: helix::chat::ChatSettings = client.req_get(request, &token).await?.data;
 //! # Ok(())

--- a/src/helix/endpoints/chat/get_chatters.rs
+++ b/src/helix/endpoints/chat/get_chatters.rs
@@ -56,13 +56,13 @@ pub struct GetChattersRequest<'a> {
     /// The ID of the broadcaster whose list of chatters you want to get.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: &'a types::UserIdRef,
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
     /// The ID of the moderator or the specified broadcaster that’s requesting the list of chatters. This ID must match the user ID associated with the user access token.
     ///
     /// The moderator must have permission to moderate the broadcaster’s chat room.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub moderator_id: &'a types::UserIdRef,
+    pub moderator_id: Cow<'a, types::UserIdRef>,
     /// The maximum number of items to return per page in the response. The minimum page size is 1 item per page and the maximum is 1,000. The default is 100.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     pub first: Option<usize>,
@@ -78,12 +78,12 @@ impl<'a> GetChattersRequest<'a> {
     ///
     /// The moderator has to be the token owner and can moderate the chat
     pub fn new(
-        broadcaster_id: impl Into<&'a types::UserIdRef>,
-        moderator_id: impl Into<&'a types::UserIdRef>,
+        broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
+        moderator_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
     ) -> Self {
         Self {
-            broadcaster_id: broadcaster_id.into(),
-            moderator_id: moderator_id.into(),
+            broadcaster_id: broadcaster_id.to_cow(),
+            moderator_id: moderator_id.to_cow(),
             first: None,
             after: None,
         }

--- a/src/helix/endpoints/chat/get_chatters.rs
+++ b/src/helix/endpoints/chat/get_chatters.rs
@@ -14,8 +14,8 @@
 //! ```rust
 //! use twitch_api::helix::chat::get_chatters;
 //! let request = get_chatters::GetChattersRequest::builder()
-//!     .broadcaster_id("1234".to_string())
-//!     .moderator_id("4321".to_string())
+//!     .broadcaster_id("1234")
+//!     .moderator_id("4321")
 //!     .build();
 //! ```
 //!
@@ -32,8 +32,8 @@
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
 //! let request = get_chatters::GetChattersRequest::builder()
-//!     .broadcaster_id("1234".to_string())
-//!     .moderator_id("4321".to_string())
+//!     .broadcaster_id("1234")
+//!     .moderator_id("4321")
 //!     .build();
 //! let response: Vec<helix::chat::Chatter> = client.req_get(request, &token).await?.data;
 //! # Ok(())

--- a/src/helix/endpoints/chat/get_chatters.rs
+++ b/src/helix/endpoints/chat/get_chatters.rs
@@ -62,7 +62,7 @@ pub struct GetChattersRequest<'a> {
     pub first: Option<usize>,
     /// The cursor used to get the next page of results. The Pagination object in the response contains the cursor’s value.
     #[cfg_attr(feature = "typed-builder", builder(default))]
-    pub after: Option<helix::Cursor>,
+    pub after: Option<Cow<'a, helix::CursorRef>>,
 }
 
 impl<'a> GetChattersRequest<'a> {
@@ -91,7 +91,9 @@ impl<'a> GetChattersRequest<'a> {
 }
 
 impl helix::Paginated for GetChattersRequest<'_> {
-    fn set_pagination(&mut self, cursor: Option<helix::Cursor>) { self.after = cursor }
+    fn set_pagination(&mut self, cursor: Option<helix::Cursor>) {
+        self.after = cursor.map(|c| c.into_cow())
+    }
 }
 
 /// Return Values for [Get Chatters](super::get_chatters)

--- a/src/helix/endpoints/chat/get_chatters.rs
+++ b/src/helix/endpoints/chat/get_chatters.rs
@@ -52,15 +52,17 @@ use helix::RequestGet;
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct GetChattersRequest {
+pub struct GetChattersRequest<'a> {
     /// The ID of the broadcaster whose list of chatters you want to get.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub broadcaster_id: types::UserId,
+    #[serde(borrow)]
+    pub broadcaster_id: &'a types::UserIdRef,
     /// The ID of the moderator or the specified broadcaster that’s requesting the list of chatters. This ID must match the user ID associated with the user access token.
     ///
     /// The moderator must have permission to moderate the broadcaster’s chat room.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub moderator_id: types::UserId,
+    #[serde(borrow)]
+    pub moderator_id: &'a types::UserIdRef,
     /// The maximum number of items to return per page in the response. The minimum page size is 1 item per page and the maximum is 1,000. The default is 100.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     pub first: Option<usize>,
@@ -69,15 +71,15 @@ pub struct GetChattersRequest {
     pub after: Option<helix::Cursor>,
 }
 
-impl GetChattersRequest {
+impl<'a> GetChattersRequest<'a> {
     /// Get chatters in broadcasters channel
     ///
     /// # Notes
     ///
     /// The moderator has to be the token owner and can moderate the chat
     pub fn new(
-        broadcaster_id: impl Into<types::UserId>,
-        moderator_id: impl Into<types::UserId>,
+        broadcaster_id: impl Into<&'a types::UserIdRef>,
+        moderator_id: impl Into<&'a types::UserIdRef>,
     ) -> Self {
         Self {
             broadcaster_id: broadcaster_id.into(),
@@ -94,7 +96,7 @@ impl GetChattersRequest {
     }
 }
 
-impl helix::Paginated for GetChattersRequest {
+impl helix::Paginated for GetChattersRequest<'_> {
     fn set_pagination(&mut self, cursor: Option<helix::Cursor>) { self.after = cursor }
 }
 
@@ -109,7 +111,7 @@ pub struct Chatter {
     pub user_login: types::UserName,
 }
 
-impl Request for GetChattersRequest {
+impl Request for GetChattersRequest<'_> {
     type Response = Vec<Chatter>;
 
     const PATH: &'static str = "chat/chatters";
@@ -117,7 +119,7 @@ impl Request for GetChattersRequest {
     const SCOPE: &'static [twitch_oauth2::Scope] = &[];
 }
 
-impl RequestGet for GetChattersRequest {}
+impl RequestGet for GetChattersRequest<'_> {}
 
 #[cfg(test)]
 #[test]

--- a/src/helix/endpoints/chat/get_chatters.rs
+++ b/src/helix/endpoints/chat/get_chatters.rs
@@ -9,14 +9,11 @@
 //!
 //! ## Request: [GetChattersRequest]
 //!
-//! To use this endpoint, construct a [`GetChattersRequest`] with the [`GetChattersRequest::builder()`] method.
+//! To use this endpoint, construct a [`GetChattersRequest`] with the [`GetChattersRequest::new()`] method.
 //!
 //! ```rust
 //! use twitch_api::helix::chat::get_chatters;
-//! let request = get_chatters::GetChattersRequest::builder()
-//!     .broadcaster_id("1234")
-//!     .moderator_id("4321")
-//!     .build();
+//! let request = get_chatters::GetChattersRequest::new("1234", "4321");
 //! ```
 //!
 //! ## Response: [Chatter]
@@ -31,10 +28,7 @@
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = get_chatters::GetChattersRequest::builder()
-//!     .broadcaster_id("1234")
-//!     .moderator_id("4321")
-//!     .build();
+//! let request = get_chatters::GetChattersRequest::new("1234", "4321");
 //! let response: Vec<helix::chat::Chatter> = client.req_get(request, &token).await?.data;
 //! # Ok(())
 //! # }

--- a/src/helix/endpoints/chat/get_emote_sets.rs
+++ b/src/helix/endpoints/chat/get_emote_sets.rs
@@ -40,7 +40,6 @@
 
 use super::*;
 use helix::RequestGet;
-use std::borrow::Cow;
 
 /// Query Parameters for [Get Channel Emotes](super::get_emote_sets)
 ///

--- a/src/helix/endpoints/chat/get_emote_sets.rs
+++ b/src/helix/endpoints/chat/get_emote_sets.rs
@@ -10,7 +10,7 @@
 //! ```rust
 //! use twitch_api::helix::chat::get_emote_sets;
 //! let request = get_emote_sets::GetEmoteSetsRequest::builder()
-//!     .emote_set_id(vec!["1234".into()])
+//!     .emote_set_id(&["1234".into()][..])
 //!     .build();
 //! ```
 //!
@@ -20,14 +20,15 @@
 //!
 //! ```rust, no_run
 //! use twitch_api::helix::{self, chat::get_emote_sets};
-//! # use twitch_api::client;
+//! # use twitch_api::{client, types};
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
+//! let ids: &[&types::EmoteSetIdRef] = &["1234".into()];
 //! let request = get_emote_sets::GetEmoteSetsRequest::builder()
-//!     .emote_set_id(vec!["1234".into()])
+//!     .emote_set_id(ids)
 //!     .build();
 //! let response: Vec<helix::chat::get_emote_sets::Emote> = client.req_get(request, &token).await?.data;
 //! # Ok(())
@@ -50,7 +51,10 @@ use std::borrow::Cow;
 pub struct GetEmoteSetsRequest<'a> {
     // FIXME: twitch doc specifies maximum as 25, but it actually is 10
     /// The broadcaster whose emotes are being requested. Minimum: 1. Maximum: 10
-    #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
+    #[cfg_attr(
+        feature = "typed-builder",
+        builder(default_code = "Cow::Borrowed(&[])", setter(into))
+    )]
     #[serde(borrow)]
     pub emote_set_id: Cow<'a, [&'a types::EmoteSetIdRef]>,
 }
@@ -99,13 +103,14 @@ impl Emote {
     ///
     /// ```rust, no_run
     /// use twitch_api::helix::{self, chat::get_channel_emotes};
-    /// # use twitch_api::client;
+    /// # use twitch_api::{client, types};
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
     /// # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
     /// # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-    /// let emotes = client.get_emote_sets(["301590448"], &token).await?;
+    /// let ids: &[&types::EmoteSetIdRef] = &["301590448".into()];
+    /// let emotes = client.get_emote_sets(ids, &token).await?;
     /// assert_eq!(emotes[0].url().size_3x().dark_mode().render(), "https://static-cdn.jtvnw.net/emoticons/v2/emotesv2_dc24652ada1e4c84a5e3ceebae4de709/default/dark/3.0");
     /// # Ok(())
     /// # }

--- a/src/helix/endpoints/chat/get_emote_sets.rs
+++ b/src/helix/endpoints/chat/get_emote_sets.rs
@@ -9,9 +9,8 @@
 //!
 //! ```rust
 //! use twitch_api::helix::chat::get_emote_sets;
-//! let request = get_emote_sets::GetEmoteSetsRequest::builder()
-//!     .emote_set_id(&["1234".into()][..])
-//!     .build();
+//! let ids: &[&twitch_types::EmoteSetIdRef] = &["1234".into()];
+//! let request = get_emote_sets::GetEmoteSetsRequest::emote_set_ids(ids);
 //! ```
 //!
 //! ## Response: [Emote]
@@ -26,10 +25,8 @@
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let ids: &[&types::EmoteSetIdRef] = &["1234".into()];
-//! let request = get_emote_sets::GetEmoteSetsRequest::builder()
-//!     .emote_set_id(ids)
-//!     .build();
+//! let ids: &[&twitch_types::EmoteSetIdRef] = &["1234".into()];
+//! let request = get_emote_sets::GetEmoteSetsRequest::emote_set_ids(ids);
 //! let response: Vec<helix::chat::get_emote_sets::Emote> = client.req_get(request, &token).await?.data;
 //! # Ok(())
 //! # }

--- a/src/helix/endpoints/chat/get_user_chat_color.rs
+++ b/src/helix/endpoints/chat/get_user_chat_color.rs
@@ -40,7 +40,6 @@
 
 use super::*;
 use helix::RequestGet;
-use std::borrow::Cow;
 
 /// Query Parameters for [Get Chatters](super::get_user_chat_color)
 ///

--- a/src/helix/endpoints/chat/get_user_chat_color.rs
+++ b/src/helix/endpoints/chat/get_user_chat_color.rs
@@ -10,7 +10,7 @@
 //! ```rust
 //! use twitch_api::helix::chat::get_user_chat_color;
 //! let request = get_user_chat_color::GetUserChatColorRequest::builder()
-//!     .user_id(vec!["4321".into()])
+//!     .user_id(&["4321".into()][..])
 //!     .build();
 //! ```
 //!
@@ -20,14 +20,15 @@
 //!
 //! ```rust, no_run
 //! use twitch_api::helix::{self, chat::get_user_chat_color};
-//! # use twitch_api::client;
+//! # use twitch_api::{client, types};
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
+//! let ids: &[&types::UserIdRef] = &["4321".into()];
 //! let request = get_user_chat_color::GetUserChatColorRequest::builder()
-//!     .user_id(vec!["4321".into()])
+//!     .user_id(ids)
 //!     .build();
 //! let response: Vec<helix::chat::UserChatColor> = client.req_get(request, &token).await?.data;
 //! # Ok(())
@@ -49,6 +50,10 @@ use std::borrow::Cow;
 #[non_exhaustive]
 pub struct GetUserChatColorRequest<'a> {
     /// The ID of the user whose color you want to get.
+    #[cfg_attr(
+        feature = "typed-builder",
+        builder(default_code = "Cow::Borrowed(&[])", setter(into))
+    )]
     #[serde(borrow)]
     pub user_id: Cow<'a, [&'a types::UserIdRef]>,
 }

--- a/src/helix/endpoints/chat/mod.rs
+++ b/src/helix/endpoints/chat/mod.rs
@@ -5,6 +5,7 @@ use crate::{
     types::{self, EmoteUrlBuilder},
 };
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 
 pub mod get_channel_chat_badges;
 pub mod get_channel_emotes;

--- a/src/helix/endpoints/chat/mod.rs
+++ b/src/helix/endpoints/chat/mod.rs
@@ -114,7 +114,7 @@ impl ChannelEmote {
     /// # Examples
     ///
     /// ```rust, no_run
-    /// # use twitch_api::{client, helix};
+    /// # use twitch_api::{client, helix, types};
     /// # #[tokio::main]
     /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
     /// # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();

--- a/src/helix/endpoints/chat/send_chat_announcement.rs
+++ b/src/helix/endpoints/chat/send_chat_announcement.rs
@@ -91,7 +91,7 @@ impl<'a> SendChatAnnouncementRequest<'a> {
 pub struct SendChatAnnouncementBody<'a> {
     /// The announcement to make in the broadcaster’s chat room. Announcements are limited to a maximum of 500 characters; announcements longer than 500 characters are truncated.
     #[serde(borrow)]
-    pub message: &'a str,
+    pub message: Cow<'a, str>,
     // FIXME: Enumify?
     /// The color used to highlight the announcement. Possible case-sensitive values are:
     ///
@@ -109,11 +109,11 @@ pub struct SendChatAnnouncementBody<'a> {
 impl<'a> SendChatAnnouncementBody<'a> {
     /// Create a new announcement with specified color
     pub fn new<E>(
-        message: &'a str,
+        message: impl Into<Cow<'a, str>>,
         color: impl std::convert::TryInto<AnnouncementColor, Error = E>,
     ) -> Result<Self, E> {
         Ok(Self {
-            message,
+            message: message.into(),
             color: color.try_into()?,
         })
     }

--- a/src/helix/endpoints/chat/send_chat_announcement.rs
+++ b/src/helix/endpoints/chat/send_chat_announcement.rs
@@ -22,8 +22,7 @@
 //! ```
 //! # use twitch_api::helix::chat::send_chat_announcement;
 //! let body =
-//!     send_chat_announcement::SendChatAnnouncementBody::new("Hello chat!".to_owned(), "purple")
-//!         .unwrap();
+//!     send_chat_announcement::SendChatAnnouncementBody::new("Hello chat!", "purple").unwrap();
 //! ```
 //!
 //! ## Response: [SendChatAnnouncementResponse]
@@ -44,7 +43,7 @@
 //!     .moderator_id("5678")
 //!     .build();
 //! let body = send_chat_announcement::SendChatAnnouncementBody::new(
-//!     "Hello chat!".to_owned(),
+//!     "Hello chat!",
 //!     "purple",
 //! ).unwrap();
 //! let response: helix::chat::SendChatAnnouncementResponse = client.req_post(request, body, &token).await?.data;

--- a/src/helix/endpoints/chat/send_chat_announcement.rs
+++ b/src/helix/endpoints/chat/send_chat_announcement.rs
@@ -66,24 +66,24 @@ pub struct SendChatAnnouncementRequest<'a> {
     /// The ID of the broadcaster that owns the chat room to send the announcement to.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: &'a types::UserIdRef,
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
     /// The ID of a user who has permission to moderate the broadcaster’s chat room.
     ///
     /// This ID must match the user ID in the OAuth token, which can be a moderator or the broadcaster.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub moderator_id: &'a types::UserIdRef,
+    pub moderator_id: Cow<'a, types::UserIdRef>,
 }
 
 impl<'a> SendChatAnnouncementRequest<'a> {
     /// Send announcement in channel as this moderator
     pub fn new(
-        broadcaster_id: impl Into<&'a types::UserIdRef>,
-        moderator_id: impl Into<&'a types::UserIdRef>,
+        broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
+        moderator_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
     ) -> Self {
         Self {
-            broadcaster_id: broadcaster_id.into(),
-            moderator_id: moderator_id.into(),
+            broadcaster_id: broadcaster_id.to_cow(),
+            moderator_id: moderator_id.to_cow(),
         }
     }
 }

--- a/src/helix/endpoints/chat/send_chat_announcement.rs
+++ b/src/helix/endpoints/chat/send_chat_announcement.rs
@@ -5,14 +5,11 @@
 //!
 //! ## Request: [SendChatAnnouncementRequest]
 //!
-//! To use this endpoint, construct a [`SendChatAnnouncementRequest`] with the [`SendChatAnnouncementRequest::builder()`] method.
+//! To use this endpoint, construct a [`SendChatAnnouncementRequest`] with the [`SendChatAnnouncementRequest::new()`] method.
 //!
 //! ```rust
 //! use twitch_api::helix::chat::send_chat_announcement;
-//! let request = send_chat_announcement::SendChatAnnouncementRequest::builder()
-//!     .broadcaster_id("1234")
-//!     .moderator_id("5678")
-//!     .build();
+//! let request = send_chat_announcement::SendChatAnnouncementRequest::new("1234", "5678");
 //! ```
 //!
 //! ## Body: [SendChatAnnouncementBody]
@@ -38,10 +35,7 @@
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = send_chat_announcement::SendChatAnnouncementRequest::builder()
-//!     .broadcaster_id("1234")
-//!     .moderator_id("5678")
-//!     .build();
+//! let request = send_chat_announcement::SendChatAnnouncementRequest::new("1234", "5678");
 //! let body = send_chat_announcement::SendChatAnnouncementBody::new(
 //!     "Hello chat!",
 //!     "purple",

--- a/src/helix/endpoints/chat/update_chat_settings.rs
+++ b/src/helix/endpoints/chat/update_chat_settings.rs
@@ -5,14 +5,11 @@
 //!
 //! ## Request: [UpdateChatSettingsRequest]
 //!
-//! To use this endpoint, construct an [`UpdateChatSettingsRequest`] with the [`UpdateChatSettingsRequest::builder()`] method.
+//! To use this endpoint, construct an [`UpdateChatSettingsRequest`] with the [`UpdateChatSettingsRequest::new()`] method.
 //!
 //! ```rust
 //! use twitch_api::helix::chat::update_chat_settings;
-//! let request = update_chat_settings::UpdateChatSettingsRequest::builder()
-//!     .broadcaster_id("1234")
-//!     .moderator_id("5678")
-//!     .build();
+//! let request = update_chat_settings::UpdateChatSettingsRequest::new("1234", "5678");
 //! ```
 //!
 //! ## Body: [UpdateChatSettingsBody]
@@ -41,10 +38,7 @@
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = update_chat_settings::UpdateChatSettingsRequest::builder()
-//!     .broadcaster_id("1234")
-//!     .moderator_id("5678")
-//!     .build();
+//! let request = update_chat_settings::UpdateChatSettingsRequest::new("1234", "5678");
 //! let body = update_chat_settings::UpdateChatSettingsBody::builder()
 //!     .slow_mode(true)
 //!     .slow_mode_wait_time(10)

--- a/src/helix/endpoints/chat/update_chat_settings.rs
+++ b/src/helix/endpoints/chat/update_chat_settings.rs
@@ -71,26 +71,26 @@ pub struct UpdateChatSettingsRequest<'a> {
     /// The ID of the broadcaster whose chat settings you want to update.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: &'a types::UserIdRef,
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
     /// The ID of a user that has permission to moderate the broadcaster’s chat room.
     /// This ID must match the user ID associated with the user OAuth token.
     ///
     /// If the broadcaster is making the update, also set this parameter to the broadcaster’s ID.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub moderator_id: &'a types::UserIdRef,
+    pub moderator_id: Cow<'a, types::UserIdRef>,
 }
 
 ///FIXME: The moderator_id parameter is redundant, we should make this a client ext function
 impl<'a> UpdateChatSettingsRequest<'a> {
     /// Update the chat settings for the specified broadcaster as the specified moderator
     pub fn new(
-        broadcaster_id: impl Into<&'a types::UserIdRef>,
-        moderator_id: impl Into<&'a types::UserIdRef>,
+        broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
+        moderator_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
     ) -> Self {
         Self {
-            broadcaster_id: broadcaster_id.into(),
-            moderator_id: moderator_id.into(),
+            broadcaster_id: broadcaster_id.to_cow(),
+            moderator_id: moderator_id.to_cow(),
         }
     }
 }

--- a/src/helix/endpoints/chat/update_chat_settings.rs
+++ b/src/helix/endpoints/chat/update_chat_settings.rs
@@ -67,24 +67,26 @@ use helix::RequestPatch;
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct UpdateChatSettingsRequest {
+pub struct UpdateChatSettingsRequest<'a> {
     /// The ID of the broadcaster whose chat settings you want to update.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub broadcaster_id: types::UserId,
+    #[serde(borrow)]
+    pub broadcaster_id: &'a types::UserIdRef,
     /// The ID of a user that has permission to moderate the broadcaster’s chat room.
     /// This ID must match the user ID associated with the user OAuth token.
     ///
     /// If the broadcaster is making the update, also set this parameter to the broadcaster’s ID.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub moderator_id: types::UserId,
+    #[serde(borrow)]
+    pub moderator_id: &'a types::UserIdRef,
 }
 
 ///FIXME: The moderator_id parameter is redundant, we should make this a client ext function
-impl UpdateChatSettingsRequest {
+impl<'a> UpdateChatSettingsRequest<'a> {
     /// Update the chat settings for the specified broadcaster as the specified moderator
     pub fn new(
-        broadcaster_id: impl Into<types::UserId>,
-        moderator_id: impl Into<types::UserId>,
+        broadcaster_id: impl Into<&'a types::UserIdRef>,
+        moderator_id: impl Into<&'a types::UserIdRef>,
     ) -> Self {
         Self {
             broadcaster_id: broadcaster_id.into(),
@@ -175,7 +177,7 @@ impl helix::private::SealedSerialize for UpdateChatSettingsBody {}
 /// [`update-chat-settings`](https://dev.twitch.tv/docs/api/reference#update-chat-settings)
 pub type UpdateChatSettingsResponse = ChatSettings;
 
-impl Request for UpdateChatSettingsRequest {
+impl Request for UpdateChatSettingsRequest<'_> {
     type Response = ChatSettings;
 
     const PATH: &'static str = "chat/settings";
@@ -184,7 +186,7 @@ impl Request for UpdateChatSettingsRequest {
         &[twitch_oauth2::Scope::ModeratorManageChatSettings];
 }
 
-impl RequestPatch for UpdateChatSettingsRequest {
+impl RequestPatch for UpdateChatSettingsRequest<'_> {
     type Body = UpdateChatSettingsBody;
 
     fn parse_inner_response(

--- a/src/helix/endpoints/chat/update_user_chat_color.rs
+++ b/src/helix/endpoints/chat/update_user_chat_color.rs
@@ -53,21 +53,21 @@ pub struct UpdateUserChatColorRequest<'a> {
     /// The ID of the user whose chat color you want to update.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub user_id: &'a types::UserIdRef,
+    pub user_id: Cow<'a, types::UserIdRef>,
     /// The color to use for the user’s name in chat.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    #[serde(borrow = "'static")]
-    pub color: types::NamedUserColor<'static>,
+    #[serde(borrow)]
+    pub color: types::NamedUserColor<'a>,
 }
 
 impl<'a> UpdateUserChatColorRequest<'a> {
     /// Update the users chat color
     pub fn new(
-        user_id: impl Into<&'a types::UserIdRef>,
+        user_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
         color: types::NamedUserColor<'static>,
     ) -> Self {
         Self {
-            user_id: user_id.into(),
+            user_id: user_id.to_cow(),
             color,
         }
     }

--- a/src/helix/endpoints/chat/update_user_chat_color.rs
+++ b/src/helix/endpoints/chat/update_user_chat_color.rs
@@ -10,10 +10,10 @@
 //!
 //! ```rust
 //! use twitch_api::helix::chat::update_user_chat_color;
-//! let request = update_user_chat_color::UpdateUserChatColorRequest::builder()
-//!     .user_id("123")
-//!     .color(twitch_types::NamedUserColor::Blue)
-//!     .build();
+//! let request = update_user_chat_color::UpdateUserChatColorRequest::new(
+//!     "123",
+//!     twitch_types::NamedUserColor::Blue,
+//! );
 //! ```
 //!
 //! ## Response: [UpdateUserChatColorResponse]
@@ -28,11 +28,10 @@
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = update_user_chat_color::UpdateUserChatColorRequest::builder()
-//!     .user_id("123")
-//!     .color(twitch_types::NamedUserColor::Blue)
-//!     .build();
-//!
+//! let request = update_user_chat_color::UpdateUserChatColorRequest::new(
+//!     "123",
+//!     twitch_types::NamedUserColor::Blue,
+//! );
 //! let response: helix::chat::UpdateUserChatColorResponse = client.req_put(request, helix::EmptyBody, &token).await?.data;
 //! # Ok(())
 //! # }

--- a/src/helix/endpoints/chat/update_user_chat_color.rs
+++ b/src/helix/endpoints/chat/update_user_chat_color.rs
@@ -49,19 +49,23 @@ use helix::RequestPut;
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct UpdateUserChatColorRequest {
+pub struct UpdateUserChatColorRequest<'a> {
     /// The ID of the user whose chat color you want to update.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub user_id: types::UserId,
+    #[serde(borrow)]
+    pub user_id: &'a types::UserIdRef,
     /// The color to use for the user’s name in chat.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow = "'static")]
     pub color: types::NamedUserColor<'static>,
 }
 
-impl UpdateUserChatColorRequest {
+impl<'a> UpdateUserChatColorRequest<'a> {
     /// Update the users chat color
-    pub fn new(user_id: impl Into<types::UserId>, color: types::NamedUserColor<'static>) -> Self {
+    pub fn new(
+        user_id: impl Into<&'a types::UserIdRef>,
+        color: types::NamedUserColor<'static>,
+    ) -> Self {
         Self {
             user_id: user_id.into(),
             color,
@@ -80,7 +84,7 @@ pub enum UpdateUserChatColorResponse {
     Success,
 }
 
-impl Request for UpdateUserChatColorRequest {
+impl Request for UpdateUserChatColorRequest<'_> {
     type Response = UpdateUserChatColorResponse;
 
     const PATH: &'static str = "chat/color";
@@ -88,7 +92,7 @@ impl Request for UpdateUserChatColorRequest {
     const SCOPE: &'static [twitch_oauth2::Scope] = &[twitch_oauth2::Scope::UserManageChatColor];
 }
 
-impl RequestPut for UpdateUserChatColorRequest {
+impl RequestPut for UpdateUserChatColorRequest<'_> {
     type Body = helix::EmptyBody;
 
     fn parse_inner_response<'d>(

--- a/src/helix/endpoints/clips/get_clips.rs
+++ b/src/helix/endpoints/clips/get_clips.rs
@@ -39,7 +39,6 @@
 
 use super::*;
 use helix::RequestGet;
-use std::borrow::Cow;
 
 /// Query Parameters for [Get Clips](super::get_clips)
 ///
@@ -51,11 +50,11 @@ pub struct GetClipsRequest<'a> {
     /// ID of the broadcaster for whom clips are returned. The number of clips returned is determined by the first query-string parameter (default: 20). Results are ordered by view count.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: Option<&'a types::UserIdRef>,
+    pub broadcaster_id: Option<Cow<'a, types::UserIdRef>>,
     /// ID of the game for which clips are returned. The number of clips returned is determined by the first query-string parameter (default: 20). Results are ordered by view count.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(borrow)]
-    pub game_id: Option<&'a types::CategoryIdRef>,
+    pub game_id: Option<Cow<'a, types::CategoryIdRef>>,
     // FIXME: add types::ClipId
     /// ID of the clip being queried. Limit: 100.
     #[cfg_attr(feature = "typed-builder", builder(default))]
@@ -72,14 +71,14 @@ pub struct GetClipsRequest<'a> {
     /// Ending date/time for returned clips, in RFC3339 format. (Note that the seconds value is ignored.) If this is specified, started_at also must be specified; otherwise, the time period is ignored.
     #[cfg_attr(feature = "typed-builder", builder(default))]
     #[serde(borrow)]
-    pub ended_at: Option<&'a types::TimestampRef>,
+    pub ended_at: Option<Cow<'a, types::TimestampRef>>,
     /// Maximum number of objects to return. Maximum: 100. Default: 20.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     pub first: Option<usize>,
     /// Starting date/time for returned clips, in RFC3339 format. (Note that the seconds value is ignored.) If this is specified, ended_at also should be specified; otherwise, the ended_at date/time will be 1 week after the started_at value.
     #[cfg_attr(feature = "typed-builder", builder(default))]
     #[serde(borrow)]
-    pub started_at: Option<&'a types::TimestampRef>,
+    pub started_at: Option<Cow<'a, types::TimestampRef>>,
 }
 
 impl<'a> GetClipsRequest<'a> {
@@ -102,17 +101,17 @@ impl<'a> GetClipsRequest<'a> {
     }
 
     /// Broadcaster for whom clips are returned.
-    pub fn broadcaster_id(broadcaster_id: impl Into<&'a types::UserIdRef>) -> Self {
+    pub fn broadcaster_id(broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a) -> Self {
         Self {
-            broadcaster_id: Some(broadcaster_id.into()),
+            broadcaster_id: Some(broadcaster_id.to_cow()),
             ..Self::empty()
         }
     }
 
     /// Game for which clips are returned.
-    pub fn game_id(game_id: impl Into<&'a types::CategoryIdRef>) -> Self {
+    pub fn game_id(game_id: impl types::IntoCow<'a, types::CategoryIdRef> + 'a) -> Self {
         Self {
-            game_id: Some(game_id.into()),
+            game_id: Some(game_id.to_cow()),
             ..Self::empty()
         }
     }
@@ -126,14 +125,20 @@ impl<'a> GetClipsRequest<'a> {
     }
 
     /// Ending date/time for the returned clips
-    pub fn started_at(&mut self, started_at: impl Into<&'a types::TimestampRef>) -> &mut Self {
-        self.started_at = Some(started_at.into());
+    pub fn started_at(
+        &mut self,
+        started_at: impl types::IntoCow<'a, types::TimestampRef> + 'a,
+    ) -> &mut Self {
+        self.started_at = Some(started_at.to_cow());
         self
     }
 
     /// Ending date/time for the returned clips
-    pub fn ended_at(&mut self, ended_at: impl Into<&'a types::TimestampRef>) -> &mut Self {
-        self.ended_at = Some(ended_at.into());
+    pub fn ended_at(
+        &mut self,
+        ended_at: impl types::IntoCow<'a, types::TimestampRef> + 'a,
+    ) -> &mut Self {
+        self.ended_at = Some(ended_at.to_cow());
         self
     }
 }

--- a/src/helix/endpoints/clips/get_clips.rs
+++ b/src/helix/endpoints/clips/get_clips.rs
@@ -59,11 +59,11 @@ pub struct GetClipsRequest<'a> {
     // one of above is needed.
     /// Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. This applies only to queries specifying broadcaster_id or game_id. The cursor value specified here is from the pagination response field of a prior query.
     #[cfg_attr(feature = "typed-builder", builder(default))]
-    pub after: Option<helix::Cursor>,
+    pub after: Option<Cow<'a, helix::CursorRef>>,
     /// Cursor for backward pagination: tells the server where to start fetching the next set of results, in a multi-page response. This applies only to queries specifying broadcaster_id or game_id. The cursor value specified here is from the pagination response field of a prior query.
     #[cfg_attr(feature = "typed-builder", builder(default))]
     #[serde(borrow)]
-    pub before: Option<&'a helix::CursorRef>,
+    pub before: Option<Cow<'a, helix::CursorRef>>,
     /// Ending date/time for returned clips, in RFC3339 format. (Note that the seconds value is ignored.) If this is specified, started_at also must be specified; otherwise, the time period is ignored.
     #[cfg_attr(feature = "typed-builder", builder(default))]
     #[serde(borrow)]
@@ -199,7 +199,9 @@ impl Request for GetClipsRequest<'_> {
 impl RequestGet for GetClipsRequest<'_> {}
 
 impl helix::Paginated for GetClipsRequest<'_> {
-    fn set_pagination(&mut self, cursor: Option<helix::Cursor>) { self.after = cursor }
+    fn set_pagination(&mut self, cursor: Option<helix::Cursor>) {
+        self.after = cursor.map(|c| c.into_cow())
+    }
 }
 
 #[cfg(test)]

--- a/src/helix/endpoints/clips/get_clips.rs
+++ b/src/helix/endpoints/clips/get_clips.rs
@@ -39,6 +39,7 @@
 
 use super::*;
 use helix::RequestGet;
+use std::borrow::Cow;
 
 /// Query Parameters for [Get Clips](super::get_clips)
 ///
@@ -46,36 +47,42 @@ use helix::RequestGet;
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct GetClipsRequest {
+pub struct GetClipsRequest<'a> {
     /// ID of the broadcaster for whom clips are returned. The number of clips returned is determined by the first query-string parameter (default: 20). Results are ordered by view count.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
-    pub broadcaster_id: Option<types::UserId>,
+    #[serde(borrow)]
+    pub broadcaster_id: Option<&'a types::UserIdRef>,
     /// ID of the game for which clips are returned. The number of clips returned is determined by the first query-string parameter (default: 20). Results are ordered by view count.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
-    pub game_id: Option<types::CategoryId>,
+    #[serde(borrow)]
+    pub game_id: Option<&'a types::CategoryIdRef>,
     // FIXME: add types::ClipId
     /// ID of the clip being queried. Limit: 100.
     #[cfg_attr(feature = "typed-builder", builder(default))]
-    pub id: Vec<types::ClipId>,
+    #[serde(borrow)]
+    pub id: Cow<'a, [&'a types::ClipIdRef]>,
     // one of above is needed.
     /// Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. This applies only to queries specifying broadcaster_id or game_id. The cursor value specified here is from the pagination response field of a prior query.
     #[cfg_attr(feature = "typed-builder", builder(default))]
     pub after: Option<helix::Cursor>,
     /// Cursor for backward pagination: tells the server where to start fetching the next set of results, in a multi-page response. This applies only to queries specifying broadcaster_id or game_id. The cursor value specified here is from the pagination response field of a prior query.
     #[cfg_attr(feature = "typed-builder", builder(default))]
-    pub before: Option<helix::Cursor>,
+    #[serde(borrow)]
+    pub before: Option<&'a helix::CursorRef>,
     /// Ending date/time for returned clips, in RFC3339 format. (Note that the seconds value is ignored.) If this is specified, started_at also must be specified; otherwise, the time period is ignored.
     #[cfg_attr(feature = "typed-builder", builder(default))]
-    pub ended_at: Option<types::Timestamp>,
+    #[serde(borrow)]
+    pub ended_at: Option<&'a types::TimestampRef>,
     /// Maximum number of objects to return. Maximum: 100. Default: 20.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     pub first: Option<usize>,
     /// Starting date/time for returned clips, in RFC3339 format. (Note that the seconds value is ignored.) If this is specified, ended_at also should be specified; otherwise, the ended_at date/time will be 1 week after the started_at value.
     #[cfg_attr(feature = "typed-builder", builder(default))]
-    pub started_at: Option<types::Timestamp>,
+    #[serde(borrow)]
+    pub started_at: Option<&'a types::TimestampRef>,
 }
 
-impl GetClipsRequest {
+impl<'a> GetClipsRequest<'a> {
     /// An empty request
     ///
     /// # Notes
@@ -85,7 +92,7 @@ impl GetClipsRequest {
         Self {
             broadcaster_id: Default::default(),
             game_id: Default::default(),
-            id: Default::default(),
+            id: Cow::Borrowed(&[]),
             after: Default::default(),
             before: Default::default(),
             ended_at: Default::default(),
@@ -95,7 +102,7 @@ impl GetClipsRequest {
     }
 
     /// Broadcaster for whom clips are returned.
-    pub fn broadcaster_id(broadcaster_id: impl Into<types::UserId>) -> Self {
+    pub fn broadcaster_id(broadcaster_id: impl Into<&'a types::UserIdRef>) -> Self {
         Self {
             broadcaster_id: Some(broadcaster_id.into()),
             ..Self::empty()
@@ -103,37 +110,29 @@ impl GetClipsRequest {
     }
 
     /// Game for which clips are returned.
-    pub fn game_id(game_id: impl Into<types::CategoryId>) -> Self {
+    pub fn game_id(game_id: impl Into<&'a types::CategoryIdRef>) -> Self {
         Self {
             game_id: Some(game_id.into()),
             ..Self::empty()
         }
     }
 
-    /// ID of clip being queried
-    pub fn clip_id(clip_id: impl Into<types::ClipId>) -> Self {
-        Self {
-            id: vec![clip_id.into()],
-            ..Self::empty()
-        }
-    }
-
     /// IDs of clips being queried
-    pub fn clip_ids(clip_ids: impl IntoIterator<Item = impl Into<types::ClipId>>) -> Self {
+    pub fn clip_ids(clip_ids: impl Into<Cow<'a, [&'a types::ClipIdRef]>>) -> Self {
         Self {
-            id: clip_ids.into_iter().map(Into::into).collect(),
+            id: clip_ids.into(),
             ..Self::empty()
         }
     }
 
     /// Ending date/time for the returned clips
-    pub fn started_at(&mut self, started_at: impl Into<types::Timestamp>) -> &mut Self {
+    pub fn started_at(&mut self, started_at: impl Into<&'a types::TimestampRef>) -> &mut Self {
         self.started_at = Some(started_at.into());
         self
     }
 
     /// Ending date/time for the returned clips
-    pub fn ended_at(&mut self, ended_at: impl Into<types::Timestamp>) -> &mut Self {
+    pub fn ended_at(&mut self, ended_at: impl Into<&'a types::TimestampRef>) -> &mut Self {
         self.ended_at = Some(ended_at.into());
         self
     }
@@ -182,7 +181,7 @@ pub struct Clip {
     pub vod_offset: Option<i64>,
 }
 
-impl Request for GetClipsRequest {
+impl Request for GetClipsRequest<'_> {
     type Response = Vec<Clip>;
 
     const PATH: &'static str = "clips";
@@ -190,9 +189,9 @@ impl Request for GetClipsRequest {
     const SCOPE: &'static [twitch_oauth2::Scope] = &[];
 }
 
-impl RequestGet for GetClipsRequest {}
+impl RequestGet for GetClipsRequest<'_> {}
 
-impl helix::Paginated for GetClipsRequest {
+impl helix::Paginated for GetClipsRequest<'_> {
     fn set_pagination(&mut self, cursor: Option<helix::Cursor>) { self.after = cursor }
 }
 
@@ -200,7 +199,8 @@ impl helix::Paginated for GetClipsRequest {
 #[test]
 fn test_request() {
     use helix::*;
-    let req = GetClipsRequest::clip_id(String::from("AwkwardHelplessSalamanderSwiftRage"));
+
+    let req = GetClipsRequest::clip_ids(vec!["AwkwardHelplessSalamanderSwiftRage".into()]);
 
     // From twitch docs
     let data = br#"

--- a/src/helix/endpoints/clips/get_clips.rs
+++ b/src/helix/endpoints/clips/get_clips.rs
@@ -5,13 +5,11 @@
 //!
 //! ## Request: [GetClipsRequest]
 //!
-//! To use this endpoint, construct a [`GetClipsRequest`] with the [`GetClipsRequest::builder()`] method.
+//! To use this endpoint, construct a [`GetClipsRequest`] with the [`GetClipsRequest::broadcaster_id()`] method.
 //!
 //! ```rust
 //! use twitch_api::helix::clips::get_clips;
-//! let request = get_clips::GetClipsRequest::builder()
-//!     .broadcaster_id(Some("1234".into()))
-//!     .build();
+//! let request = get_clips::GetClipsRequest::broadcaster_id("1234");
 //! ```
 //!
 //! ## Response: [Clip]
@@ -26,9 +24,7 @@
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = get_clips::GetClipsRequest::builder()
-//!     .broadcaster_id(Some("1234".into()))
-//!     .build();
+//! let request = get_clips::GetClipsRequest::broadcaster_id("1234");
 //! let response: Vec<get_clips::Clip> = client.req_get(request, &token).await?.data;
 //! # Ok(())
 //! # }
@@ -139,6 +135,12 @@ impl<'a> GetClipsRequest<'a> {
         ended_at: impl types::IntoCow<'a, types::TimestampRef> + 'a,
     ) -> &mut Self {
         self.ended_at = Some(ended_at.to_cow());
+        self
+    }
+
+    /// Set amount of results returned per page.
+    pub fn first(mut self, first: usize) -> Self {
+        self.first = Some(first);
         self
     }
 }

--- a/src/helix/endpoints/clips/mod.rs
+++ b/src/helix/endpoints/clips/mod.rs
@@ -10,10 +10,7 @@
 //! # let _: &HelixClient<twitch_api::DummyHttpClient> = &client;
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let req = GetClipsRequest::builder()
-//!     .game_id(Some("1234".into()))
-//!     .first(100) // max 100, 20 if left unspecified
-//!     .build();
+//! let req = GetClipsRequest::game_id("1234").first(100); // max 100, 20 if left unspecified
 //!
 //! println!("{:?}", &client.req_get(req, &token).await?.data.get(0));
 //! # Ok(())

--- a/src/helix/endpoints/clips/mod.rs
+++ b/src/helix/endpoints/clips/mod.rs
@@ -24,6 +24,7 @@ use crate::{
     types,
 };
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 
 pub mod get_clips;
 

--- a/src/helix/endpoints/eventsub/create_eventsub_subscription.rs
+++ b/src/helix/endpoints/eventsub/create_eventsub_subscription.rs
@@ -53,7 +53,7 @@ pub struct CreateEventSubSubscriptionBody<E: EventSubscription> {
     pub transport: Transport,
 }
 
-impl<E: EventSubscription> helix::HelixRequestBody for CreateEventSubSubscriptionBody<E> {
+impl<'a, E: EventSubscription> helix::HelixRequestBody for CreateEventSubSubscriptionBody<E> {
     fn try_to_body(&self) -> Result<hyper::body::Bytes, helix::BodyError> {
         #[derive(PartialEq, Serialize, Debug)]
         struct IEventSubRequestBody<'a> {
@@ -76,8 +76,8 @@ impl<E: EventSubscription> helix::HelixRequestBody for CreateEventSubSubscriptio
 // FIXME: Builder?
 impl<E: EventSubscription> CreateEventSubSubscriptionBody<E> {
     /// Create a new [`CreateEventSubSubscriptionBody`]
-    pub fn new(subscription: E, transport: Transport) -> CreateEventSubSubscriptionBody<E> {
-        CreateEventSubSubscriptionBody {
+    pub fn new(subscription: E, transport: Transport) -> Self {
+        Self {
             subscription,
             transport,
         }
@@ -194,14 +194,13 @@ fn test_request() {
     let req: CreateEventSubSubscriptionRequest<UserUpdateV1> =
         CreateEventSubSubscriptionRequest::default();
 
-    let body = CreateEventSubSubscriptionBody::new(
-        UserUpdateV1::new("1234"),
-        eventsub::Transport {
-            method: eventsub::TransportMethod::Webhook,
-            callback: "example.com".to_string(),
-            secret: "heyhey13".to_string(),
-        },
-    );
+    let sub = UserUpdateV1::new("1234");
+    let transport = eventsub::Transport {
+        method: eventsub::TransportMethod::Webhook,
+        callback: "example.com".to_string(),
+        secret: "heyhey13".to_string(),
+    };
+    let body = CreateEventSubSubscriptionBody::new(sub, transport);
 
     dbg!(req.create_request(body, "token", "clientid").unwrap());
 

--- a/src/helix/endpoints/eventsub/delete_eventsub_subscription.rs
+++ b/src/helix/endpoints/eventsub/delete_eventsub_subscription.rs
@@ -9,18 +9,19 @@ use helix::RequestDelete;
 #[derive(PartialEq, Eq, Serialize, Clone, Debug)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct DeleteEventSubSubscriptionRequest {
+pub struct DeleteEventSubSubscriptionRequest<'a> {
     /// The subscription ID for the subscription you want to delete.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub id: types::EventSubId,
+    #[serde(borrow)]
+    pub id: &'a types::EventSubIdRef,
 }
 
-impl DeleteEventSubSubscriptionRequest {
+impl<'a> DeleteEventSubSubscriptionRequest<'a> {
     /// Delete this eventsub subscription.
-    pub fn id(id: impl Into<types::EventSubId>) -> Self { Self { id: id.into() } }
+    pub fn id(id: impl Into<&'a types::EventSubIdRef>) -> Self { Self { id: id.into() } }
 }
 
-impl Request for DeleteEventSubSubscriptionRequest {
+impl Request for DeleteEventSubSubscriptionRequest<'_> {
     type Response = DeleteEventSubSubscription;
 
     const PATH: &'static str = "eventsub/subscriptions";
@@ -38,7 +39,7 @@ pub enum DeleteEventSubSubscription {
     Success,
 }
 
-impl RequestDelete for DeleteEventSubSubscriptionRequest {
+impl RequestDelete for DeleteEventSubSubscriptionRequest<'_> {
     fn parse_inner_response(
         request: Option<Self>,
         uri: &http::Uri,

--- a/src/helix/endpoints/eventsub/delete_eventsub_subscription.rs
+++ b/src/helix/endpoints/eventsub/delete_eventsub_subscription.rs
@@ -13,12 +13,14 @@ pub struct DeleteEventSubSubscriptionRequest<'a> {
     /// The subscription ID for the subscription you want to delete.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub id: &'a types::EventSubIdRef,
+    pub id: Cow<'a, types::EventSubIdRef>,
 }
 
 impl<'a> DeleteEventSubSubscriptionRequest<'a> {
     /// Delete this eventsub subscription.
-    pub fn id(id: impl Into<&'a types::EventSubIdRef>) -> Self { Self { id: id.into() } }
+    pub fn id(id: impl types::IntoCow<'a, types::EventSubIdRef> + 'a) -> Self {
+        Self { id: id.to_cow() }
+    }
 }
 
 impl Request for DeleteEventSubSubscriptionRequest<'_> {

--- a/src/helix/endpoints/eventsub/get_eventsub_subscriptions.rs
+++ b/src/helix/endpoints/eventsub/get_eventsub_subscriptions.rs
@@ -27,7 +27,7 @@ pub struct GetEventSubSubscriptionsRequest<'a> {
     // FIXME: https://github.com/twitchdev/issues/issues/272
     /// Cursor for forward pagination
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
-    pub after: Option<helix::Cursor>,
+    pub after: Option<Cow<'a, helix::CursorRef>>,
     // FIXME: https://github.com/twitchdev/issues/issues/271
     /// Maximum number of objects to return. Maximum: 100. Default: 20.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
@@ -124,7 +124,9 @@ impl RequestGet for GetEventSubSubscriptionsRequest<'_> {
 }
 
 impl helix::Paginated for GetEventSubSubscriptionsRequest<'_> {
-    fn set_pagination(&mut self, cursor: Option<helix::Cursor>) { self.after = cursor }
+    fn set_pagination(&mut self, cursor: Option<helix::Cursor>) {
+        self.after = cursor.map(|c| c.into_cow())
+    }
 }
 
 #[cfg(test)]

--- a/src/helix/endpoints/eventsub/get_eventsub_subscriptions.rs
+++ b/src/helix/endpoints/eventsub/get_eventsub_subscriptions.rs
@@ -23,7 +23,7 @@ pub struct GetEventSubSubscriptionsRequest<'a> {
     /// matches a user ID that you specified in the Condition object when you created the subscription.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(borrow)]
-    pub user_id: Option<&'a types::UserIdRef>,
+    pub user_id: Option<Cow<'a, types::UserIdRef>>,
     // FIXME: https://github.com/twitchdev/issues/issues/272
     /// Cursor for forward pagination
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]

--- a/src/helix/endpoints/eventsub/get_eventsub_subscriptions.rs
+++ b/src/helix/endpoints/eventsub/get_eventsub_subscriptions.rs
@@ -10,7 +10,7 @@ use helix::RequestGet;
 #[derive(PartialEq, Eq, Serialize, Clone, Debug, Default)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct GetEventSubSubscriptionsRequest {
+pub struct GetEventSubSubscriptionsRequest<'a> {
     /// Include this parameter to filter subscriptions by their status.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     pub status: Option<eventsub::Status>,
@@ -22,7 +22,8 @@ pub struct GetEventSubSubscriptionsRequest {
     /// The response contains subscriptions where the user ID
     /// matches a user ID that you specified in the Condition object when you created the subscription.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
-    pub user_id: Option<types::UserId>,
+    #[serde(borrow)]
+    pub user_id: Option<&'a types::UserIdRef>,
     // FIXME: https://github.com/twitchdev/issues/issues/272
     /// Cursor for forward pagination
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
@@ -33,7 +34,7 @@ pub struct GetEventSubSubscriptionsRequest {
     pub first: Option<usize>,
 }
 
-impl GetEventSubSubscriptionsRequest {
+impl GetEventSubSubscriptionsRequest<'_> {
     /// Get eventsub subscriptions by this status
     pub fn status(status: impl Into<eventsub::Status>) -> Self {
         Self {
@@ -51,7 +52,7 @@ impl GetEventSubSubscriptionsRequest {
     }
 }
 
-impl Request for GetEventSubSubscriptionsRequest {
+impl Request for GetEventSubSubscriptionsRequest<'_> {
     type Response = EventSubSubscriptions;
 
     const PATH: &'static str = "eventsub/subscriptions";
@@ -76,7 +77,7 @@ pub struct EventSubSubscriptions {
     pub subscriptions: Vec<eventsub::EventSubSubscription>,
 }
 
-impl RequestGet for GetEventSubSubscriptionsRequest {
+impl RequestGet for GetEventSubSubscriptionsRequest<'_> {
     fn parse_inner_response(
         request: Option<Self>,
         uri: &http::Uri,
@@ -122,7 +123,7 @@ impl RequestGet for GetEventSubSubscriptionsRequest {
     }
 }
 
-impl helix::Paginated for GetEventSubSubscriptionsRequest {
+impl helix::Paginated for GetEventSubSubscriptionsRequest<'_> {
     fn set_pagination(&mut self, cursor: Option<helix::Cursor>) { self.after = cursor }
 }
 

--- a/src/helix/endpoints/eventsub/mod.rs
+++ b/src/helix/endpoints/eventsub/mod.rs
@@ -5,6 +5,7 @@ use crate::{
     types,
 };
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 
 pub mod create_eventsub_subscription;
 pub mod delete_eventsub_subscription;

--- a/src/helix/endpoints/games/get_games.rs
+++ b/src/helix/endpoints/games/get_games.rs
@@ -36,7 +36,6 @@
 
 use super::*;
 use helix::RequestGet;
-use std::borrow::Cow;
 
 /// Query Parameters for [Get Games](super::get_games)
 ///

--- a/src/helix/endpoints/games/get_games.rs
+++ b/src/helix/endpoints/games/get_games.rs
@@ -9,7 +9,7 @@
 //!
 //! ```rust
 //! use twitch_api::helix::games::get_games;
-//! let request = get_games::GetGamesRequest::id("4321");
+//! let request = get_games::GetGamesRequest::ids(&["4321".into()][..]);
 //! ```
 //!
 //! ## Response: [Game](types::TwitchCategory)
@@ -18,13 +18,14 @@
 //!
 //! ```rust, no_run
 //! use twitch_api::helix::{self, games::get_games};
-//! # use twitch_api::client;
+//! # use twitch_api::{client, types};
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = get_games::GetGamesRequest::id("4321");
+//! let ids: &[&types::CategoryIdRef] = &["4321".into()];
+//! let request = get_games::GetGamesRequest::ids(ids);
 //! let response: Vec<get_games::Game> = client.req_get(request, &token).await?.data;
 //! # Ok(())
 //! # }
@@ -45,11 +46,17 @@ use std::borrow::Cow;
 #[non_exhaustive]
 pub struct GetGamesRequest<'a> {
     /// Game ID. At most 100 id values can be specified.
-    #[cfg_attr(feature = "typed-builder", builder(default))]
+    #[cfg_attr(
+        feature = "typed-builder",
+        builder(default_code = "Cow::Borrowed(&[])", setter(into))
+    )]
     #[serde(borrow)]
     pub id: Cow<'a, [&'a types::CategoryIdRef]>,
     /// Game name. The name must be an exact match. For instance, “Pokemon” will not return a list of Pokemon games; instead, query the specific Pokemon game(s) in which you are interested. At most 100 name values can be specified.
-    #[cfg_attr(feature = "typed-builder", builder(default))]
+    #[cfg_attr(
+        feature = "typed-builder",
+        builder(default_code = "Cow::Borrowed(&[])", setter(into))
+    )]
     #[serde(borrow)]
     pub name: Cow<'a, [&'a str]>,
 }

--- a/src/helix/endpoints/games/get_top_games.rs
+++ b/src/helix/endpoints/games/get_top_games.rs
@@ -45,19 +45,20 @@ use helix::RequestGet;
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug, Default)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct GetTopGamesRequest {
+pub struct GetTopGamesRequest<'a> {
     /// Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     pub after: Option<helix::Cursor>,
     /// Cursor for backward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
-    pub before: Option<helix::Cursor>,
+    #[serde(borrow)]
+    pub before: Option<&'a helix::CursorRef>,
     /// Maximum number of objects to return. Maximum: 100. Default: 20.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     pub first: Option<usize>,
 }
 
-impl GetTopGamesRequest {
+impl GetTopGamesRequest<'_> {
     /// Set amount of results returned per page.
     pub fn first(mut self, first: usize) -> Self {
         self.first = Some(first);
@@ -70,7 +71,7 @@ impl GetTopGamesRequest {
 /// [`get-top-games`](https://dev.twitch.tv/docs/api/reference#get-top-games)
 pub type Game = types::TwitchCategory;
 
-impl Request for GetTopGamesRequest {
+impl Request for GetTopGamesRequest<'_> {
     type Response = Vec<Game>;
 
     const PATH: &'static str = "games/top";
@@ -78,9 +79,9 @@ impl Request for GetTopGamesRequest {
     const SCOPE: &'static [twitch_oauth2::Scope] = &[];
 }
 
-impl RequestGet for GetTopGamesRequest {}
+impl RequestGet for GetTopGamesRequest<'_> {}
 
-impl helix::Paginated for GetTopGamesRequest {
+impl helix::Paginated for GetTopGamesRequest<'_> {
     fn set_pagination(&mut self, cursor: Option<helix::Cursor>) { self.after = cursor }
 }
 

--- a/src/helix/endpoints/games/get_top_games.rs
+++ b/src/helix/endpoints/games/get_top_games.rs
@@ -48,11 +48,11 @@ use helix::RequestGet;
 pub struct GetTopGamesRequest<'a> {
     /// Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
-    pub after: Option<helix::Cursor>,
+    pub after: Option<Cow<'a, helix::CursorRef>>,
     /// Cursor for backward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(borrow)]
-    pub before: Option<&'a helix::CursorRef>,
+    pub before: Option<Cow<'a, helix::CursorRef>>,
     /// Maximum number of objects to return. Maximum: 100. Default: 20.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     pub first: Option<usize>,
@@ -82,7 +82,9 @@ impl Request for GetTopGamesRequest<'_> {
 impl RequestGet for GetTopGamesRequest<'_> {}
 
 impl helix::Paginated for GetTopGamesRequest<'_> {
-    fn set_pagination(&mut self, cursor: Option<helix::Cursor>) { self.after = cursor }
+    fn set_pagination(&mut self, cursor: Option<helix::Cursor>) {
+        self.after = cursor.map(|c| c.into_cow())
+    }
 }
 
 #[cfg(test)]

--- a/src/helix/endpoints/games/mod.rs
+++ b/src/helix/endpoints/games/mod.rs
@@ -3,8 +3,8 @@ use crate::{
     helix::{self, Request},
     types,
 };
-
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 
 pub mod get_games;
 pub mod get_top_games;

--- a/src/helix/endpoints/goals/get_creator_goals.rs
+++ b/src/helix/endpoints/goals/get_creator_goals.rs
@@ -56,7 +56,7 @@ pub struct GetCreatorGoalsRequest<'a> {
     /// Retreive a single event by event ID
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(borrow)]
-    pub id: Option<&'a str>,
+    pub id: Option<Cow<'a, str>>,
 }
 
 impl<'a> GetCreatorGoalsRequest<'a> {

--- a/src/helix/endpoints/goals/get_creator_goals.rs
+++ b/src/helix/endpoints/goals/get_creator_goals.rs
@@ -46,10 +46,11 @@ use helix::RequestGet;
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct GetCreatorGoalsRequest {
+pub struct GetCreatorGoalsRequest<'a> {
     /// Must match the User ID in the Bearer token.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub broadcaster_id: types::UserId,
+    #[serde(borrow)]
+    pub broadcaster_id: &'a types::UserIdRef,
     /// Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
     #[cfg_attr(feature = "typed-builder", builder(default))]
     pub cursor: Option<helix::Cursor>,
@@ -58,12 +59,13 @@ pub struct GetCreatorGoalsRequest {
     pub first: Option<usize>,
     /// Retreive a single event by event ID
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
-    pub id: Option<String>,
+    #[serde(borrow)]
+    pub id: Option<&'a str>,
 }
 
-impl GetCreatorGoalsRequest {
+impl<'a> GetCreatorGoalsRequest<'a> {
     /// Gets the broadcaster’s list of active goals.
-    pub fn broadcaster_id(broadcaster_id: impl Into<types::UserId>) -> Self {
+    pub fn broadcaster_id(broadcaster_id: impl Into<&'a types::UserIdRef>) -> Self {
         Self {
             broadcaster_id: broadcaster_id.into(),
             cursor: Default::default(),
@@ -107,7 +109,7 @@ pub struct CreatorGoal {
     pub created_at: types::Timestamp,
 }
 
-impl Request for GetCreatorGoalsRequest {
+impl Request for GetCreatorGoalsRequest<'_> {
     type Response = Vec<CreatorGoal>;
 
     const PATH: &'static str = "goals";
@@ -115,7 +117,7 @@ impl Request for GetCreatorGoalsRequest {
     const SCOPE: &'static [twitch_oauth2::Scope] = &[twitch_oauth2::Scope::ChannelReadGoals];
 }
 
-impl RequestGet for GetCreatorGoalsRequest {}
+impl RequestGet for GetCreatorGoalsRequest<'_> {}
 
 #[cfg(test)]
 #[test]

--- a/src/helix/endpoints/goals/get_creator_goals.rs
+++ b/src/helix/endpoints/goals/get_creator_goals.rs
@@ -10,7 +10,7 @@
 //! ```rust
 //! use twitch_api::helix::goals::get_creator_goals;
 //! let request = get_creator_goals::GetCreatorGoalsRequest::builder()
-//!     .broadcaster_id("4321".to_string())
+//!     .broadcaster_id("4321")
 //!     .build();
 //! ```
 //!
@@ -27,7 +27,7 @@
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
 //! let request = get_creator_goals::GetCreatorGoalsRequest::builder()
-//!     .broadcaster_id("4321".to_string())
+//!     .broadcaster_id("4321")
 //!     .build();
 //! let response: Vec<get_creator_goals::CreatorGoal> = client.req_get(request, &token).await?.data;
 //! # Ok(())

--- a/src/helix/endpoints/goals/get_creator_goals.rs
+++ b/src/helix/endpoints/goals/get_creator_goals.rs
@@ -50,7 +50,7 @@ pub struct GetCreatorGoalsRequest<'a> {
     /// Must match the User ID in the Bearer token.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: &'a types::UserIdRef,
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
     /// Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
     #[cfg_attr(feature = "typed-builder", builder(default))]
     pub cursor: Option<helix::Cursor>,
@@ -65,9 +65,9 @@ pub struct GetCreatorGoalsRequest<'a> {
 
 impl<'a> GetCreatorGoalsRequest<'a> {
     /// Gets the broadcaster’s list of active goals.
-    pub fn broadcaster_id(broadcaster_id: impl Into<&'a types::UserIdRef>) -> Self {
+    pub fn broadcaster_id(broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a) -> Self {
         Self {
-            broadcaster_id: broadcaster_id.into(),
+            broadcaster_id: broadcaster_id.to_cow(),
             cursor: Default::default(),
             first: Default::default(),
             id: Default::default(),

--- a/src/helix/endpoints/goals/get_creator_goals.rs
+++ b/src/helix/endpoints/goals/get_creator_goals.rs
@@ -5,13 +5,11 @@
 //!
 //! ## Request: [GetCreatorGoalsRequest]
 //!
-//! To use this endpoint, construct a [`GetCreatorGoalsRequest`] with the [`GetCreatorGoalsRequest::builder()`] method.
+//! To use this endpoint, construct a [`GetCreatorGoalsRequest`] with the [`GetCreatorGoalsRequest::broadcaster_id()`] method.
 //!
 //! ```rust
 //! use twitch_api::helix::goals::get_creator_goals;
-//! let request = get_creator_goals::GetCreatorGoalsRequest::builder()
-//!     .broadcaster_id("4321")
-//!     .build();
+//! let request = get_creator_goals::GetCreatorGoalsRequest::broadcaster_id("4321");
 //! ```
 //!
 //! ## Response: [CreatorGoal](types::TwitchCategory)
@@ -26,9 +24,7 @@
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = get_creator_goals::GetCreatorGoalsRequest::builder()
-//!     .broadcaster_id("4321")
-//!     .build();
+//! let request = get_creator_goals::GetCreatorGoalsRequest::broadcaster_id("4321");
 //! let response: Vec<get_creator_goals::CreatorGoal> = client.req_get(request, &token).await?.data;
 //! # Ok(())
 //! # }

--- a/src/helix/endpoints/goals/mod.rs
+++ b/src/helix/endpoints/goals/mod.rs
@@ -5,8 +5,8 @@ use crate::{
     helix::{self, Request},
     types,
 };
-
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 
 pub mod get_creator_goals;
 

--- a/src/helix/endpoints/hypetrain/get_hypetrain_events.rs
+++ b/src/helix/endpoints/hypetrain/get_hypetrain_events.rs
@@ -61,7 +61,7 @@ pub struct GetHypeTrainEventsRequest<'a> {
     )]
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(borrow)]
-    pub id: Option<&'a str>,
+    pub id: Option<Cow<'a, str>>,
 }
 
 impl<'a> GetHypeTrainEventsRequest<'a> {

--- a/src/helix/endpoints/hypetrain/get_hypetrain_events.rs
+++ b/src/helix/endpoints/hypetrain/get_hypetrain_events.rs
@@ -11,7 +11,7 @@
 //! ```rust
 //! use twitch_api::helix::hypetrain::get_hypetrain_events;
 //! let request = get_hypetrain_events::GetHypeTrainEventsRequest::builder()
-//!     .broadcaster_id("4321".to_string())
+//!     .broadcaster_id("4321")
 //!     .build();
 //! ```
 //!
@@ -28,7 +28,7 @@
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
 //! let request = get_hypetrain_events::GetHypeTrainEventsRequest::builder()
-//!     .broadcaster_id("4321".to_string())
+//!     .broadcaster_id("4321")
 //!     .build();
 //! let response: Vec<get_hypetrain_events::HypeTrainEvent> = client.req_get(request, &token).await?.data;
 //! # Ok(())

--- a/src/helix/endpoints/hypetrain/get_hypetrain_events.rs
+++ b/src/helix/endpoints/hypetrain/get_hypetrain_events.rs
@@ -51,7 +51,7 @@ pub struct GetHypeTrainEventsRequest<'a> {
     /// Must match the User ID in the Bearer token.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: &'a types::UserIdRef,
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
     /// Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
     #[cfg_attr(feature = "typed-builder", builder(default))]
     pub cursor: Option<helix::Cursor>,
@@ -70,9 +70,9 @@ pub struct GetHypeTrainEventsRequest<'a> {
 
 impl<'a> GetHypeTrainEventsRequest<'a> {
     /// Get hypetrain evens
-    pub fn broadcaster_id(broadcaster_id: impl Into<&'a types::UserIdRef>) -> Self {
+    pub fn broadcaster_id(broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a) -> Self {
         Self {
-            broadcaster_id: broadcaster_id.into(),
+            broadcaster_id: broadcaster_id.to_cow(),
             cursor: Default::default(),
             first: Default::default(),
             id: Default::default(),

--- a/src/helix/endpoints/hypetrain/get_hypetrain_events.rs
+++ b/src/helix/endpoints/hypetrain/get_hypetrain_events.rs
@@ -6,13 +6,11 @@
 //!
 //! ## Request: [GetHypeTrainEventsRequest]
 //!
-//! To use this endpoint, construct a [`GetHypeTrainEventsRequest`] with the [`GetHypeTrainEventsRequest::builder()`] method.
+//! To use this endpoint, construct a [`GetHypeTrainEventsRequest`] with the [`GetHypeTrainEventsRequest::broadcaster_id()`] method.
 //!
 //! ```rust
 //! use twitch_api::helix::hypetrain::get_hypetrain_events;
-//! let request = get_hypetrain_events::GetHypeTrainEventsRequest::builder()
-//!     .broadcaster_id("4321")
-//!     .build();
+//! let request = get_hypetrain_events::GetHypeTrainEventsRequest::broadcaster_id("4321");
 //! ```
 //!
 //! ## Response: [HypeTrainEvent](types::TwitchCategory)
@@ -27,9 +25,7 @@
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = get_hypetrain_events::GetHypeTrainEventsRequest::builder()
-//!     .broadcaster_id("4321")
-//!     .build();
+//! let request = get_hypetrain_events::GetHypeTrainEventsRequest::broadcaster_id("4321");
 //! let response: Vec<get_hypetrain_events::HypeTrainEvent> = client.req_get(request, &token).await?.data;
 //! # Ok(())
 //! # }

--- a/src/helix/endpoints/hypetrain/get_hypetrain_events.rs
+++ b/src/helix/endpoints/hypetrain/get_hypetrain_events.rs
@@ -47,10 +47,11 @@ use helix::RequestGet;
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct GetHypeTrainEventsRequest {
+pub struct GetHypeTrainEventsRequest<'a> {
     /// Must match the User ID in the Bearer token.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub broadcaster_id: types::UserId,
+    #[serde(borrow)]
+    pub broadcaster_id: &'a types::UserIdRef,
     /// Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
     #[cfg_attr(feature = "typed-builder", builder(default))]
     pub cursor: Option<helix::Cursor>,
@@ -63,12 +64,13 @@ pub struct GetHypeTrainEventsRequest {
         note = "this does nothing, see https://discuss.dev.twitch.tv/t/get-hype-train-events-api-endpoint-id-query-parameter-deprecation/37613"
     )]
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
-    pub id: Option<String>,
+    #[serde(borrow)]
+    pub id: Option<&'a str>,
 }
 
-impl GetHypeTrainEventsRequest {
+impl<'a> GetHypeTrainEventsRequest<'a> {
     /// Get hypetrain evens
-    pub fn broadcaster_id(broadcaster_id: impl Into<types::UserId>) -> Self {
+    pub fn broadcaster_id(broadcaster_id: impl Into<&'a types::UserIdRef>) -> Self {
         Self {
             broadcaster_id: broadcaster_id.into(),
             cursor: Default::default(),
@@ -134,7 +136,7 @@ pub struct HypeTrainEventData {
     pub id: types::HypeTrainId,
 }
 
-impl Request for GetHypeTrainEventsRequest {
+impl Request for GetHypeTrainEventsRequest<'_> {
     type Response = Vec<HypeTrainEvent>;
 
     const PATH: &'static str = "hypetrain/events";
@@ -142,9 +144,9 @@ impl Request for GetHypeTrainEventsRequest {
     const SCOPE: &'static [twitch_oauth2::Scope] = &[];
 }
 
-impl RequestGet for GetHypeTrainEventsRequest {}
+impl RequestGet for GetHypeTrainEventsRequest<'_> {}
 
-impl helix::Paginated for GetHypeTrainEventsRequest {
+impl helix::Paginated for GetHypeTrainEventsRequest<'_> {
     fn set_pagination(&mut self, cursor: Option<helix::Cursor>) { self.cursor = cursor }
 }
 

--- a/src/helix/endpoints/hypetrain/mod.rs
+++ b/src/helix/endpoints/hypetrain/mod.rs
@@ -5,8 +5,8 @@ use crate::{
     helix::{self, Request},
     types,
 };
-
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 
 pub mod get_hypetrain_events;
 

--- a/src/helix/endpoints/moderation/add_blocked_term.rs
+++ b/src/helix/endpoints/moderation/add_blocked_term.rs
@@ -63,24 +63,24 @@ pub struct AddBlockedTermRequest<'a> {
     /// The ID of the broadcaster that owns the list of blocked terms.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: &'a types::UserIdRef,
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
     /// The ID of a user that has permission to moderate the broadcaster’s chat room. This ID must match the user ID associated with the user OAuth token.
     ///
     /// If the broadcaster wants to add the blocked term (instead of having the moderator do it), set this parameter to the broadcaster’s ID, too.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub moderator_id: &'a types::UserIdRef,
+    pub moderator_id: Cow<'a, types::UserIdRef>,
 }
 
 impl<'a> AddBlockedTermRequest<'a> {
     /// Where to add blocked term
     pub fn new(
-        broadcaster_id: impl Into<&'a types::UserIdRef>,
-        moderator_id: impl Into<&'a types::UserIdRef>,
+        broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
+        moderator_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
     ) -> Self {
         Self {
-            broadcaster_id: broadcaster_id.into(),
-            moderator_id: moderator_id.into(),
+            broadcaster_id: broadcaster_id.to_cow(),
+            moderator_id: moderator_id.to_cow(),
         }
     }
 }

--- a/src/helix/endpoints/moderation/add_blocked_term.rs
+++ b/src/helix/endpoints/moderation/add_blocked_term.rs
@@ -5,14 +5,11 @@
 //!
 //! ## Request: [AddBlockedTermRequest]
 //!
-//! To use this endpoint, construct a [`AddBlockedTermRequest`] with the [`AddBlockedTermRequest::builder()`] method.
+//! To use this endpoint, construct a [`AddBlockedTermRequest`] with the [`AddBlockedTermRequest::new()`] method.
 //!
 //! ```rust
 //! use twitch_api::helix::moderation::add_blocked_term;
-//! let request = add_blocked_term::AddBlockedTermRequest::builder()
-//!     .broadcaster_id("1234")
-//!     .moderator_id("5678")
-//!     .build();
+//! let request = add_blocked_term::AddBlockedTermRequest::new("1234", "5678");
 //! ```
 //!
 //! ## Body: [AddBlockedTermBody]
@@ -38,10 +35,7 @@
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = add_blocked_term::AddBlockedTermRequest::builder()
-//!     .broadcaster_id("1234")
-//!     .moderator_id("5678")
-//!     .build();
+//! let request = add_blocked_term::AddBlockedTermRequest::new("1234", "5678");
 //! let body = add_blocked_term::AddBlockedTermBody::new("A phrase I'm not fond of");
 //! let response: &helix::moderation::BlockedTerm = client.req_post(request, body, &token).await?.data.first().unwrap();
 //! # Ok(())

--- a/src/helix/endpoints/moderation/add_blocked_term.rs
+++ b/src/helix/endpoints/moderation/add_blocked_term.rs
@@ -91,12 +91,12 @@ pub struct AddBlockedTermBody<'a> {
     /// The term must contain a minimum of 2 characters and may contain up to a maximum of 500 characters.
     /// Terms can use a wildcard character (*). The wildcard character must appear at the beginning or end of a word, or set of characters. For example, *foo or foo*.
     #[serde(borrow)]
-    pub text: &'a str,
+    pub text: Cow<'a, str>,
 }
 
 impl<'a> AddBlockedTermBody<'a> {
     /// Create a new [`AddBlockedTermBody`]
-    pub fn new(text: &'a str) -> Self { Self { text } }
+    pub fn new(text: impl Into<Cow<'a, str>>) -> Self { Self { text: text.into() } }
 }
 
 impl helix::private::SealedSerialize for AddBlockedTermBody<'_> {}

--- a/src/helix/endpoints/moderation/add_blocked_term.rs
+++ b/src/helix/endpoints/moderation/add_blocked_term.rs
@@ -21,7 +21,7 @@
 //!
 //! ```
 //! # use twitch_api::helix::moderation::add_blocked_term;
-//! let body = add_blocked_term::AddBlockedTermBody::new("A phrase I'm not fond of".to_string());
+//! let body = add_blocked_term::AddBlockedTermBody::new("A phrase I'm not fond of");
 //! ```
 //!
 //! ## Response: [BlockedTerm]
@@ -42,7 +42,7 @@
 //!     .broadcaster_id("1234")
 //!     .moderator_id("5678")
 //!     .build();
-//! let body = add_blocked_term::AddBlockedTermBody::new("A phrase I'm not fond of".to_string());
+//! let body = add_blocked_term::AddBlockedTermBody::new("A phrase I'm not fond of");
 //! let response: &helix::moderation::BlockedTerm = client.req_post(request, body, &token).await?.data.first().unwrap();
 //! # Ok(())
 //! # }

--- a/src/helix/endpoints/moderation/add_channel_moderator.rs
+++ b/src/helix/endpoints/moderation/add_channel_moderator.rs
@@ -49,20 +49,22 @@ use helix::RequestPost;
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct AddChannelModeratorRequest {
+pub struct AddChannelModeratorRequest<'a> {
     /// The ID of the broadcaster that owns the chat room.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub broadcaster_id: types::UserId,
+    #[serde(borrow)]
+    pub broadcaster_id: &'a types::UserIdRef,
     /// The ID of the user to add as a moderator in the broadcaster’s chat room.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub moderator_id: types::UserId,
+    #[serde(borrow)]
+    pub moderator_id: &'a types::UserIdRef,
 }
 
-impl AddChannelModeratorRequest {
+impl<'a> AddChannelModeratorRequest<'a> {
     /// Add moderator on channel
     pub fn new(
-        broadcaster_id: impl Into<types::UserId>,
-        moderator_id: impl Into<types::UserId>,
+        broadcaster_id: impl Into<&'a types::UserIdRef>,
+        moderator_id: impl Into<&'a types::UserIdRef>,
     ) -> Self {
         Self {
             broadcaster_id: broadcaster_id.into(),
@@ -82,7 +84,7 @@ pub enum AddChannelModeratorResponse {
     Success,
 }
 
-impl Request for AddChannelModeratorRequest {
+impl Request for AddChannelModeratorRequest<'_> {
     type Response = AddChannelModeratorResponse;
 
     const PATH: &'static str = "moderation/moderators";
@@ -90,7 +92,7 @@ impl Request for AddChannelModeratorRequest {
     const SCOPE: &'static [twitch_oauth2::Scope] = &[twitch_oauth2::Scope::ChannelManageModerators];
 }
 
-impl RequestPost for AddChannelModeratorRequest {
+impl RequestPost for AddChannelModeratorRequest<'_> {
     type Body = helix::EmptyBody;
 
     fn parse_inner_response<'d>(

--- a/src/helix/endpoints/moderation/add_channel_moderator.rs
+++ b/src/helix/endpoints/moderation/add_channel_moderator.rs
@@ -9,10 +9,7 @@
 //!
 //! ```rust
 //! use twitch_api::helix::moderation::add_channel_moderator;
-//! let request = add_channel_moderator::AddChannelModeratorRequest::builder()
-//!     .broadcaster_id("1234")
-//!     .moderator_id("5678")
-//!     .build();
+//! let request = add_channel_moderator::AddChannelModeratorRequest::new("1234", "5678");
 //! ```
 //!
 //! ## Response: [AddChannelModeratorResponse]
@@ -28,10 +25,7 @@
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = add_channel_moderator::AddChannelModeratorRequest::builder()
-//!     .broadcaster_id("1234")
-//!     .moderator_id("5678")
-//!     .build();
+//! let request = add_channel_moderator::AddChannelModeratorRequest::new("1234", "5678");
 //! let response: helix::moderation::AddChannelModeratorResponse = client.req_post(request, helix::EmptyBody, &token).await?.data;
 //! # Ok(())
 //! # }

--- a/src/helix/endpoints/moderation/add_channel_moderator.rs
+++ b/src/helix/endpoints/moderation/add_channel_moderator.rs
@@ -53,22 +53,22 @@ pub struct AddChannelModeratorRequest<'a> {
     /// The ID of the broadcaster that owns the chat room.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: &'a types::UserIdRef,
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
     /// The ID of the user to add as a moderator in the broadcaster’s chat room.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub moderator_id: &'a types::UserIdRef,
+    pub moderator_id: Cow<'a, types::UserIdRef>,
 }
 
 impl<'a> AddChannelModeratorRequest<'a> {
     /// Add moderator on channel
     pub fn new(
-        broadcaster_id: impl Into<&'a types::UserIdRef>,
-        moderator_id: impl Into<&'a types::UserIdRef>,
+        broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
+        moderator_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
     ) -> Self {
         Self {
-            broadcaster_id: broadcaster_id.into(),
-            moderator_id: moderator_id.into(),
+            broadcaster_id: broadcaster_id.to_cow(),
+            moderator_id: moderator_id.to_cow(),
         }
     }
 }

--- a/src/helix/endpoints/moderation/ban_user.rs
+++ b/src/helix/endpoints/moderation/ban_user.rs
@@ -63,7 +63,7 @@ pub struct BanUserRequest<'a> {
     /// The ID of the broadcaster whose chat room the user is being banned from.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: &'a types::UserIdRef,
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
     /// The ID of a user that has permission to moderate the broadcaster’s chat room.
     /// This ID must match the user ID associated with the user OAuth token.
     ///
@@ -71,18 +71,18 @@ pub struct BanUserRequest<'a> {
     /// set this parameter to the broadcaster’s ID, too.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub moderator_id: &'a types::UserIdRef,
+    pub moderator_id: Cow<'a, types::UserIdRef>,
 }
 
 impl<'a> BanUserRequest<'a> {
     /// Ban a user on this channel
     pub fn new(
-        broadcaster_id: impl Into<&'a types::UserIdRef>,
-        moderator_id: impl Into<&'a types::UserIdRef>,
+        broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
+        moderator_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
     ) -> Self {
         Self {
-            broadcaster_id: broadcaster_id.into(),
-            moderator_id: moderator_id.into(),
+            broadcaster_id: broadcaster_id.to_cow(),
+            moderator_id: moderator_id.to_cow(),
         }
     }
 }
@@ -111,20 +111,20 @@ pub struct BanUserBody<'a> {
     /// The ID of the user to ban or put in a timeout.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub user_id: &'a types::UserIdRef,
+    pub user_id: Cow<'a, types::UserIdRef>,
 }
 
 impl<'a> BanUserBody<'a> {
     /// Create a new [`BanUserBody`]
     pub fn new(
-        user_id: impl Into<&'a types::UserIdRef>,
+        user_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
         reason: &'a str,
         duration: impl Into<Option<u32>>,
     ) -> Self {
         Self {
             duration: duration.into(),
             reason,
-            user_id: user_id.into(),
+            user_id: user_id.to_cow(),
         }
     }
 }

--- a/src/helix/endpoints/moderation/ban_user.rs
+++ b/src/helix/endpoints/moderation/ban_user.rs
@@ -5,14 +5,11 @@
 //!
 //! ## Request: [BanUserRequest]
 //!
-//! To use this endpoint, construct a [`BanUserRequest`] with the [`BanUserRequest::builder()`] method.
+//! To use this endpoint, construct a [`BanUserRequest`] with the [`BanUserRequest::new()`] method.
 //!
 //! ```rust
 //! use twitch_api::helix::moderation::ban_user;
-//! let request = ban_user::BanUserRequest::builder()
-//!     .broadcaster_id("1234")
-//!     .moderator_id("5678")
-//!     .build();
+//! let request = ban_user::BanUserRequest::new("1234", "5678");
 //! ```
 //!
 //! ## Body: [BanUserBody]
@@ -38,10 +35,7 @@
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = ban_user::BanUserRequest::builder()
-//!     .broadcaster_id("1234")
-//!     .moderator_id("5678")
-//!     .build();
+//! let request = ban_user::BanUserRequest::new("1234", "5678");
 //! let body = ban_user::BanUserBody::new("9876", "no reason", 120);
 //! let response: ban_user::BanUser = client.req_post(request, body, &token).await?.data;
 //! # Ok(())

--- a/src/helix/endpoints/moderation/ban_user.rs
+++ b/src/helix/endpoints/moderation/ban_user.rs
@@ -21,7 +21,7 @@
 //!
 //! ```
 //! # use twitch_api::helix::moderation::ban_user;
-//! let body = ban_user::BanUserBody::new("9876", "no reason".to_string(), 120);
+//! let body = ban_user::BanUserBody::new("9876", "no reason", 120);
 //! ```
 //!
 //! ## Response: [BanUser]
@@ -42,7 +42,7 @@
 //!     .broadcaster_id("1234")
 //!     .moderator_id("5678")
 //!     .build();
-//! let body = ban_user::BanUserBody::new("9876", "no reason".to_string(), 120);
+//! let body = ban_user::BanUserBody::new("9876", "no reason", 120);
 //! let response: ban_user::BanUser = client.req_post(request, body, &token).await?.data;
 //! # Ok(())
 //! # }

--- a/src/helix/endpoints/moderation/ban_user.rs
+++ b/src/helix/endpoints/moderation/ban_user.rs
@@ -101,7 +101,7 @@ pub struct BanUserBody<'a> {
     /// The reason the user is being banned or put in a timeout. The text is user defined and limited to a maximum of 500 characters.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub reason: &'a str,
+    pub reason: Cow<'a, str>,
     /// The ID of the user to ban or put in a timeout.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
@@ -112,12 +112,12 @@ impl<'a> BanUserBody<'a> {
     /// Create a new [`BanUserBody`]
     pub fn new(
         user_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
-        reason: &'a str,
+        reason: impl Into<Cow<'a, str>>,
         duration: impl Into<Option<u32>>,
     ) -> Self {
         Self {
             duration: duration.into(),
-            reason,
+            reason: reason.into(),
             user_id: user_id.to_cow(),
         }
     }

--- a/src/helix/endpoints/moderation/check_automod_status.rs
+++ b/src/helix/endpoints/moderation/check_automod_status.rs
@@ -44,11 +44,11 @@
 //! let request = check_automod_status::CheckAutoModStatusRequest::builder()
 //!     .broadcaster_id("1234")
 //!     .build();
-//! let body = vec![check_automod_status::CheckAutoModStatusBody::builder()
+//! let body = &[&check_automod_status::CheckAutoModStatusBody::builder()
 //!     .msg_id("test1")
 //!     .msg_text("automod please approve this!")
 //!     .build()];
-//! let response: Vec<check_automod_status::CheckAutoModStatus> = client.req_post(request, body, &token).await?.data;
+//! let response: Vec<check_automod_status::CheckAutoModStatus> = client.req_post(request, &body[..], &token).await?.data;
 //! # Ok(())
 //! # }
 //! ```

--- a/src/helix/endpoints/moderation/check_automod_status.rs
+++ b/src/helix/endpoints/moderation/check_automod_status.rs
@@ -69,14 +69,14 @@ pub struct CheckAutoModStatusRequest<'a> {
     /// Must match the User ID in the Bearer token.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: &'a types::UserIdRef,
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
 }
 
 impl<'a> CheckAutoModStatusRequest<'a> {
     /// Check automod status in this broadcasters channel.
-    pub fn broadcaster_id(broadcaster_id: impl Into<&'a types::UserIdRef>) -> Self {
+    pub fn broadcaster_id(broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a) -> Self {
         Self {
-            broadcaster_id: broadcaster_id.into(),
+            broadcaster_id: broadcaster_id.to_cow(),
         }
     }
 }
@@ -91,7 +91,7 @@ pub struct CheckAutoModStatusBody<'a> {
     /// Developer-generated identifier for mapping messages to results.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub msg_id: &'a types::MsgIdRef,
+    pub msg_id: Cow<'a, types::MsgIdRef>,
     /// Message text.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
@@ -103,14 +103,14 @@ pub struct CheckAutoModStatusBody<'a> {
         builder(setter(into, strip_option), default)
     )]
     #[serde(skip_serializing_if = "Option::is_none", borrow)]
-    pub user_id: Option<&'a types::UserIdRef>,
+    pub user_id: Option<Cow<'a, types::UserIdRef>>,
 }
 
 impl<'a> CheckAutoModStatusBody<'a> {
     /// Create a new [`CheckAutoModStatusBody`]
-    pub fn new(msg_id: impl Into<&'a types::MsgIdRef>, msg_text: &'a str) -> Self {
+    pub fn new(msg_id: impl types::IntoCow<'a, types::MsgIdRef> + 'a, msg_text: &'a str) -> Self {
         Self {
-            msg_id: msg_id.into(),
+            msg_id: msg_id.to_cow(),
             msg_text,
             user_id: None,
         }

--- a/src/helix/endpoints/moderation/check_automod_status.rs
+++ b/src/helix/endpoints/moderation/check_automod_status.rs
@@ -6,13 +6,11 @@
 //!
 //! ## Request: [CheckAutoModStatusRequest]
 //!
-//! To use this endpoint, construct a [`CheckAutoModStatusRequest`] with the [`CheckAutoModStatusRequest::builder()`] method.
+//! To use this endpoint, construct a [`CheckAutoModStatusRequest`] with the [`CheckAutoModStatusRequest::broadcaster_id()`] method.
 //!
 //! ```rust
 //! use twitch_api::helix::moderation::check_automod_status;
-//! let request = check_automod_status::CheckAutoModStatusRequest::builder()
-//!     .broadcaster_id("1234")
-//!     .build();
+//! let request = check_automod_status::CheckAutoModStatusRequest::broadcaster_id("1234");
 //! ```
 //!
 //! ## Body: [CheckAutoModStatusBody]
@@ -21,10 +19,8 @@
 //!
 //! ```
 //! # use twitch_api::helix::moderation::check_automod_status;
-//! let body = check_automod_status::CheckAutoModStatusBody::builder()
-//!     .msg_id("test1")
-//!     .msg_text("automod please approve this!")
-//!     .build();
+//! let body =
+//!     check_automod_status::CheckAutoModStatusBody::new("test1", "automod please approve this!");
 //! ```
 //!
 //! ## Response: [CheckAutoModStatus]
@@ -41,14 +37,10 @@
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = check_automod_status::CheckAutoModStatusRequest::builder()
-//!     .broadcaster_id("1234")
-//!     .build();
-//! let body = &[&check_automod_status::CheckAutoModStatusBody::builder()
-//!     .msg_id("test1")
-//!     .msg_text("automod please approve this!")
-//!     .build()];
-//! let response: Vec<check_automod_status::CheckAutoModStatus> = client.req_post(request, &body[..], &token).await?.data;
+//! let request = check_automod_status::CheckAutoModStatusRequest::broadcaster_id("1234");
+//! let body =
+//!     check_automod_status::CheckAutoModStatusBody::new("test1", "automod please approve this!");
+//! let response: Vec<check_automod_status::CheckAutoModStatus> = client.req_post(request, &[&body].as_slice(), &token).await?.data;
 //! # Ok(())
 //! # }
 //! ```

--- a/src/helix/endpoints/moderation/check_automod_status.rs
+++ b/src/helix/endpoints/moderation/check_automod_status.rs
@@ -87,7 +87,7 @@ pub struct CheckAutoModStatusBody<'a> {
     /// Message text.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub msg_text: &'a str,
+    pub msg_text: Cow<'a, str>,
     /// User ID of the sender.
     #[deprecated(since = "0.7.0", note = "user_id in automod check is no longer read")]
     #[cfg_attr(
@@ -100,10 +100,13 @@ pub struct CheckAutoModStatusBody<'a> {
 
 impl<'a> CheckAutoModStatusBody<'a> {
     /// Create a new [`CheckAutoModStatusBody`]
-    pub fn new(msg_id: impl types::IntoCow<'a, types::MsgIdRef> + 'a, msg_text: &'a str) -> Self {
+    pub fn new(
+        msg_id: impl types::IntoCow<'a, types::MsgIdRef> + 'a,
+        msg_text: impl Into<Cow<'a, str>>,
+    ) -> Self {
         Self {
             msg_id: msg_id.to_cow(),
-            msg_text,
+            msg_text: msg_text.into(),
             user_id: None,
         }
     }

--- a/src/helix/endpoints/moderation/delete_chat_messages.rs
+++ b/src/helix/endpoints/moderation/delete_chat_messages.rs
@@ -49,15 +49,17 @@ use helix::RequestDelete;
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct DeleteChatMessagesRequest {
+pub struct DeleteChatMessagesRequest<'a> {
     /// The ID of the broadcaster that owns the chat room to remove messages from.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub broadcaster_id: types::UserId,
+    #[serde(borrow)]
+    pub broadcaster_id: &'a types::UserIdRef,
     /// The ID of a user that has permission to moderate the broadcaster’s chat room.
     ///
     /// This ID must match the user ID in the OAuth token. If the broadcaster wants to remove messages themselves, set this parameter to the broadcaster’s ID, too.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub moderator_id: types::UserId,
+    #[serde(borrow)]
+    pub moderator_id: &'a types::UserIdRef,
     /// The ID of the message to remove.
     ///
     /// The id tag in the PRIVMSG contains the message’s ID (see [PRIVMSG Tags](https://dev.twitch.tv/docs/irc/tags#privmsg-tags)).
@@ -70,14 +72,15 @@ pub struct DeleteChatMessagesRequest {
     ///
     /// If not specified, the request removes all messages in the broadcaster’s chat room.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
-    pub message_id: Option<types::MsgId>,
+    #[serde(borrow)]
+    pub message_id: Option<&'a types::MsgIdRef>,
 }
 
-impl DeleteChatMessagesRequest {
+impl<'a> DeleteChatMessagesRequest<'a> {
     /// Remove chat message(s)
     pub fn new(
-        broadcaster_id: impl Into<types::UserId>,
-        moderator_id: impl Into<types::UserId>,
+        broadcaster_id: impl Into<&'a types::UserIdRef>,
+        moderator_id: impl Into<&'a types::UserIdRef>,
     ) -> Self {
         Self {
             broadcaster_id: broadcaster_id.into(),
@@ -87,7 +90,7 @@ impl DeleteChatMessagesRequest {
     }
 
     /// A specific message to remove
-    pub fn message_id(mut self, message_id: impl Into<types::MsgId>) -> Self {
+    pub fn message_id(mut self, message_id: impl Into<&'a types::MsgIdRef>) -> Self {
         self.message_id = Some(message_id.into());
         self
     }
@@ -103,7 +106,7 @@ pub enum DeleteChatMessagesResponse {
     Success,
 }
 
-impl Request for DeleteChatMessagesRequest {
+impl Request for DeleteChatMessagesRequest<'_> {
     type Response = DeleteChatMessagesResponse;
 
     #[cfg(feature = "twitch_oauth2")]
@@ -114,7 +117,7 @@ impl Request for DeleteChatMessagesRequest {
         &[twitch_oauth2::Scope::ModeratorManageChatMessages];
 }
 
-impl RequestDelete for DeleteChatMessagesRequest {
+impl RequestDelete for DeleteChatMessagesRequest<'_> {
     fn parse_inner_response(
         request: Option<Self>,
         uri: &http::Uri,

--- a/src/helix/endpoints/moderation/delete_chat_messages.rs
+++ b/src/helix/endpoints/moderation/delete_chat_messages.rs
@@ -5,15 +5,12 @@
 //!
 //! ## Request: [DeleteChatMessagesRequest]
 //!
-//! To use this endpoint, construct a [`DeleteChatMessagesRequest`] with the [`DeleteChatMessagesRequest::builder()`] method.
+//! To use this endpoint, construct a [`DeleteChatMessagesRequest`] with the [`DeleteChatMessagesRequest::new()`] method.
 //!
 //! ```rust
 //! use twitch_api::helix::moderation::delete_chat_messages;
-//! let request = delete_chat_messages::DeleteChatMessagesRequest::builder()
-//!     .broadcaster_id("1234")
-//!     .moderator_id("5678")
-//!     .message_id(Some("abc-123-def".into()))
-//!     .build();
+//! let request = delete_chat_messages::DeleteChatMessagesRequest::new("1234", "5678")
+//!     .message_id("abc-123-def");
 //! ```
 //!
 //! ## Response: [DeleteChatMessagesResponse]
@@ -28,11 +25,8 @@
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = delete_chat_messages::DeleteChatMessagesRequest::builder()
-//!     .broadcaster_id("1234")
-//!     .moderator_id("5678")
-//!     .message_id(Some("abc-123-def".into()))
-//!     .build();
+//! let request = delete_chat_messages::DeleteChatMessagesRequest::new("1234", "5678")
+//!     .message_id("abc-123-def");
 //! let response: delete_chat_messages::DeleteChatMessagesResponse = client.req_delete(request, &token).await?.data;
 //! # Ok(())
 //! # }

--- a/src/helix/endpoints/moderation/delete_chat_messages.rs
+++ b/src/helix/endpoints/moderation/delete_chat_messages.rs
@@ -53,13 +53,13 @@ pub struct DeleteChatMessagesRequest<'a> {
     /// The ID of the broadcaster that owns the chat room to remove messages from.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: &'a types::UserIdRef,
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
     /// The ID of a user that has permission to moderate the broadcaster’s chat room.
     ///
     /// This ID must match the user ID in the OAuth token. If the broadcaster wants to remove messages themselves, set this parameter to the broadcaster’s ID, too.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub moderator_id: &'a types::UserIdRef,
+    pub moderator_id: Cow<'a, types::UserIdRef>,
     /// The ID of the message to remove.
     ///
     /// The id tag in the PRIVMSG contains the message’s ID (see [PRIVMSG Tags](https://dev.twitch.tv/docs/irc/tags#privmsg-tags)).
@@ -73,25 +73,25 @@ pub struct DeleteChatMessagesRequest<'a> {
     /// If not specified, the request removes all messages in the broadcaster’s chat room.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(borrow)]
-    pub message_id: Option<&'a types::MsgIdRef>,
+    pub message_id: Option<Cow<'a, types::MsgIdRef>>,
 }
 
 impl<'a> DeleteChatMessagesRequest<'a> {
     /// Remove chat message(s)
     pub fn new(
-        broadcaster_id: impl Into<&'a types::UserIdRef>,
-        moderator_id: impl Into<&'a types::UserIdRef>,
+        broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
+        moderator_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
     ) -> Self {
         Self {
-            broadcaster_id: broadcaster_id.into(),
-            moderator_id: moderator_id.into(),
+            broadcaster_id: broadcaster_id.to_cow(),
+            moderator_id: moderator_id.to_cow(),
             message_id: None,
         }
     }
 
     /// A specific message to remove
-    pub fn message_id(mut self, message_id: impl Into<&'a types::MsgIdRef>) -> Self {
-        self.message_id = Some(message_id.into());
+    pub fn message_id(mut self, message_id: impl types::IntoCow<'a, types::MsgIdRef> + 'a) -> Self {
+        self.message_id = Some(message_id.to_cow());
         self
     }
 }

--- a/src/helix/endpoints/moderation/get_banned_users.rs
+++ b/src/helix/endpoints/moderation/get_banned_users.rs
@@ -55,11 +55,11 @@ pub struct GetBannedUsersRequest<'a> {
     pub user_id: Cow<'a, [&'a types::UserIdRef]>,
     /// Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
     #[cfg_attr(feature = "typed-builder", builder(default))]
-    pub after: Option<helix::Cursor>,
+    pub after: Option<Cow<'a, helix::CursorRef>>,
     /// Cursor for backward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
     #[cfg_attr(feature = "typed-builder", builder(default))]
     #[serde(borrow)]
-    pub before: Option<&'a helix::CursorRef>,
+    pub before: Option<Cow<'a, helix::CursorRef>>,
     /// Number of values to be returned per page. Limit: 100. Default: 20.
     #[cfg_attr(feature = "typed-builder", builder(setter(into), default))]
     pub first: Option<usize>,
@@ -128,7 +128,9 @@ impl Request for GetBannedUsersRequest<'_> {
 impl RequestGet for GetBannedUsersRequest<'_> {}
 
 impl helix::Paginated for GetBannedUsersRequest<'_> {
-    fn set_pagination(&mut self, cursor: Option<helix::Cursor>) { self.after = cursor }
+    fn set_pagination(&mut self, cursor: Option<helix::Cursor>) {
+        self.after = cursor.map(|c| c.into_cow())
+    }
 }
 
 #[cfg(test)]

--- a/src/helix/endpoints/moderation/get_banned_users.rs
+++ b/src/helix/endpoints/moderation/get_banned_users.rs
@@ -39,7 +39,6 @@
 
 use super::*;
 use helix::RequestGet;
-use std::borrow::Cow;
 
 /// Query Parameters for [Get Banned Users](super::get_banned_users)
 ///
@@ -51,7 +50,7 @@ pub struct GetBannedUsersRequest<'a> {
     /// Must match the User ID in the Bearer token.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: &'a types::UserIdRef,
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
     /// Filters the results and only returns a status object for users who are banned in this channel and have a matching user_id.
     /// Format: Repeated Query Parameter, eg. /moderation/banned?broadcaster_id=1&user_id=2&user_id=3
     /// Maximum: 100
@@ -72,9 +71,9 @@ pub struct GetBannedUsersRequest<'a> {
 
 impl<'a> GetBannedUsersRequest<'a> {
     /// Get banned users in a broadcasters channel.
-    pub fn broadcaster_id(broadcaster_id: impl Into<&'a types::UserIdRef>) -> Self {
+    pub fn broadcaster_id(broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a) -> Self {
         Self {
-            broadcaster_id: broadcaster_id.into(),
+            broadcaster_id: broadcaster_id.to_cow(),
             user_id: Cow::Borrowed(&[]),
             after: Default::default(),
             before: Default::default(),

--- a/src/helix/endpoints/moderation/get_banned_users.rs
+++ b/src/helix/endpoints/moderation/get_banned_users.rs
@@ -5,13 +5,11 @@
 //!
 //! ## Request: [GetBannedUsersRequest]
 //!
-//! To use this endpoint, construct a [`GetBannedUsersRequest`] with the [`GetBannedUsersRequest::builder()`] method.
+//! To use this endpoint, construct a [`GetBannedUsersRequest`] with the [`GetBannedUsersRequest::broadcaster_id()`] method.
 //!
 //! ```rust
 //! use twitch_api::helix::moderation::get_banned_users;
-//! let request = get_banned_users::GetBannedUsersRequest::builder()
-//!     .broadcaster_id("1234")
-//!     .build();
+//! let request = get_banned_users::GetBannedUsersRequest::broadcaster_id("1234");
 //! ```
 //!
 //! ## Response: [BannedUser]
@@ -26,9 +24,7 @@
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = get_banned_users::GetBannedUsersRequest::builder()
-//!     .broadcaster_id("1234")
-//!     .build();
+//! let request = get_banned_users::GetBannedUsersRequest::broadcaster_id("1234");
 //! let response: Vec<get_banned_users::BannedUser> = client.req_get(request, &token).await?.data;
 //! # Ok(())
 //! # }

--- a/src/helix/endpoints/moderation/get_banned_users.rs
+++ b/src/helix/endpoints/moderation/get_banned_users.rs
@@ -39,6 +39,7 @@
 
 use super::*;
 use helix::RequestGet;
+use std::borrow::Cow;
 
 /// Query Parameters for [Get Banned Users](super::get_banned_users)
 ///
@@ -46,47 +47,44 @@ use helix::RequestGet;
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct GetBannedUsersRequest {
+pub struct GetBannedUsersRequest<'a> {
     /// Must match the User ID in the Bearer token.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub broadcaster_id: types::UserId,
+    #[serde(borrow)]
+    pub broadcaster_id: &'a types::UserIdRef,
     /// Filters the results and only returns a status object for users who are banned in this channel and have a matching user_id.
     /// Format: Repeated Query Parameter, eg. /moderation/banned?broadcaster_id=1&user_id=2&user_id=3
     /// Maximum: 100
     #[cfg_attr(feature = "typed-builder", builder(default))]
-    pub user_id: Vec<types::UserId>,
+    #[serde(borrow)]
+    pub user_id: Cow<'a, [&'a types::UserIdRef]>,
     /// Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
     #[cfg_attr(feature = "typed-builder", builder(default))]
     pub after: Option<helix::Cursor>,
     /// Cursor for backward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
     #[cfg_attr(feature = "typed-builder", builder(default))]
-    pub before: Option<helix::Cursor>,
+    #[serde(borrow)]
+    pub before: Option<&'a helix::CursorRef>,
     /// Number of values to be returned per page. Limit: 100. Default: 20.
     #[cfg_attr(feature = "typed-builder", builder(setter(into), default))]
     pub first: Option<usize>,
 }
 
-impl GetBannedUsersRequest {
+impl<'a> GetBannedUsersRequest<'a> {
     /// Get banned users in a broadcasters channel.
-    pub fn broadcaster_id(broadcaster_id: impl Into<types::UserId>) -> Self {
+    pub fn broadcaster_id(broadcaster_id: impl Into<&'a types::UserIdRef>) -> Self {
         Self {
             broadcaster_id: broadcaster_id.into(),
-            user_id: Default::default(),
+            user_id: Cow::Borrowed(&[]),
             after: Default::default(),
             before: Default::default(),
             first: Default::default(),
         }
     }
 
-    /// Check if supplied user is banned.
-    pub fn user(mut self, user_id: impl Into<types::UserId>) -> Self {
-        self.user_id = vec![user_id.into()];
-        self
-    }
-
     /// Check if supplied users are banned.
-    pub fn users(mut self, user_ids: impl IntoIterator<Item = impl Into<types::UserId>>) -> Self {
-        self.user_id = user_ids.into_iter().map(Into::into).collect();
+    pub fn users(mut self, user_ids: impl Into<Cow<'a, [&'a types::UserIdRef]>>) -> Self {
+        self.user_id = user_ids.into();
         self
     }
 
@@ -124,7 +122,7 @@ pub struct BannedUser {
     pub moderator_name: types::DisplayName,
 }
 
-impl Request for GetBannedUsersRequest {
+impl Request for GetBannedUsersRequest<'_> {
     type Response = Vec<BannedUser>;
 
     const PATH: &'static str = "moderation/banned";
@@ -132,9 +130,9 @@ impl Request for GetBannedUsersRequest {
     const SCOPE: &'static [twitch_oauth2::Scope] = &[twitch_oauth2::Scope::ModerationRead];
 }
 
-impl RequestGet for GetBannedUsersRequest {}
+impl RequestGet for GetBannedUsersRequest<'_> {}
 
-impl helix::Paginated for GetBannedUsersRequest {
+impl helix::Paginated for GetBannedUsersRequest<'_> {
     fn set_pagination(&mut self, cursor: Option<helix::Cursor>) { self.after = cursor }
 }
 

--- a/src/helix/endpoints/moderation/get_blocked_terms.rs
+++ b/src/helix/endpoints/moderation/get_blocked_terms.rs
@@ -52,12 +52,12 @@ pub struct GetBlockedTerms<'a> {
     /// The ID of the broadcaster whose blocked terms you’re getting.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: &'a types::UserIdRef,
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
     /// The ID of a user that has permission to moderate the broadcaster’s chat room. This ID must match the user ID associated with the user OAuth token.
     /// If the broadcaster wants to get their own block terms (instead of having the moderator do it), set this parameter to the broadcaster’s ID, too.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub moderator_id: &'a types::UserIdRef,
+    pub moderator_id: Cow<'a, types::UserIdRef>,
     /// The maximum number of blocked terms to return per page in the response. The minimum page size is 1 blocked term per page and the maximum is 100. The default is 20.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     pub first: Option<u32>,
@@ -69,12 +69,12 @@ pub struct GetBlockedTerms<'a> {
 impl<'a> GetBlockedTerms<'a> {
     /// Get blocked terms in a broadcasters channel as specified moderator
     pub fn new(
-        broadcaster_id: impl Into<&'a types::UserIdRef>,
-        moderator_id: impl Into<&'a types::UserIdRef>,
+        broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
+        moderator_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
     ) -> Self {
         Self {
-            broadcaster_id: broadcaster_id.into(),
-            moderator_id: moderator_id.into(),
+            broadcaster_id: broadcaster_id.to_cow(),
+            moderator_id: moderator_id.to_cow(),
             after: Default::default(),
             first: Default::default(),
         }

--- a/src/helix/endpoints/moderation/get_blocked_terms.rs
+++ b/src/helix/endpoints/moderation/get_blocked_terms.rs
@@ -57,7 +57,7 @@ pub struct GetBlockedTerms<'a> {
     pub first: Option<u32>,
     /// The cursor used to get the next page of results. The Pagination object in the response contains the cursor’s value.
     #[cfg_attr(feature = "typed-builder", builder(default))]
-    pub after: Option<helix::Cursor>,
+    pub after: Option<Cow<'a, helix::CursorRef>>,
 }
 
 impl<'a> GetBlockedTerms<'a> {
@@ -98,7 +98,9 @@ impl Request for GetBlockedTerms<'_> {
 impl RequestGet for GetBlockedTerms<'_> {}
 
 impl helix::Paginated for GetBlockedTerms<'_> {
-    fn set_pagination(&mut self, cursor: Option<helix::Cursor>) { self.after = cursor }
+    fn set_pagination(&mut self, cursor: Option<helix::Cursor>) {
+        self.after = cursor.map(|c| c.into_cow())
+    }
 }
 
 #[cfg(test)]

--- a/src/helix/endpoints/moderation/get_blocked_terms.rs
+++ b/src/helix/endpoints/moderation/get_blocked_terms.rs
@@ -5,14 +5,11 @@
 //!
 //! ## Request: [GetBlockedTerms]
 //!
-//! To use this endpoint, construct a [`GetBlockedTerms`] with the [`GetBlockedTerms::builder()`] method.
+//! To use this endpoint, construct a [`GetBlockedTerms`] with the [`GetBlockedTerms::new()`] method.
 //!
 //! ```rust
 //! use twitch_api::helix::moderation::get_blocked_terms;
-//! let request = get_blocked_terms::GetBlockedTerms::builder()
-//!     .broadcaster_id("1234")
-//!     .moderator_id("5678")
-//!     .build();
+//! let request = get_blocked_terms::GetBlockedTerms::new("1234", "5678");
 //! ```
 //!
 //! ## Response: [BlockedTerm]
@@ -27,10 +24,7 @@
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = get_blocked_terms::GetBlockedTerms::builder()
-//!     .broadcaster_id("1234")
-//!     .moderator_id("5678")
-//!     .build();
+//! let request = get_blocked_terms::GetBlockedTerms::new("1234", "5678");
 //! let response: Vec<helix::moderation::BlockedTerm> = client.req_get(request, &token).await?.data;
 //! # Ok(())
 //! # }

--- a/src/helix/endpoints/moderation/get_blocked_terms.rs
+++ b/src/helix/endpoints/moderation/get_blocked_terms.rs
@@ -48,14 +48,16 @@ use helix::RequestGet;
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct GetBlockedTerms {
+pub struct GetBlockedTerms<'a> {
     /// The ID of the broadcaster whose blocked terms you’re getting.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub broadcaster_id: types::UserId,
+    #[serde(borrow)]
+    pub broadcaster_id: &'a types::UserIdRef,
     /// The ID of a user that has permission to moderate the broadcaster’s chat room. This ID must match the user ID associated with the user OAuth token.
     /// If the broadcaster wants to get their own block terms (instead of having the moderator do it), set this parameter to the broadcaster’s ID, too.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub moderator_id: types::UserId,
+    #[serde(borrow)]
+    pub moderator_id: &'a types::UserIdRef,
     /// The maximum number of blocked terms to return per page in the response. The minimum page size is 1 blocked term per page and the maximum is 100. The default is 20.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     pub first: Option<u32>,
@@ -64,11 +66,11 @@ pub struct GetBlockedTerms {
     pub after: Option<helix::Cursor>,
 }
 
-impl GetBlockedTerms {
+impl<'a> GetBlockedTerms<'a> {
     /// Get blocked terms in a broadcasters channel as specified moderator
     pub fn new(
-        broadcaster_id: impl Into<types::UserId>,
-        moderator_id: impl Into<types::UserId>,
+        broadcaster_id: impl Into<&'a types::UserIdRef>,
+        moderator_id: impl Into<&'a types::UserIdRef>,
     ) -> Self {
         Self {
             broadcaster_id: broadcaster_id.into(),
@@ -90,7 +92,7 @@ impl GetBlockedTerms {
 /// [`get-blocked-terms`](https://dev.twitch.tv/docs/api/reference#get-blocked-terms)
 pub type GetBlockedTermsResponse = BlockedTerm;
 
-impl Request for GetBlockedTerms {
+impl Request for GetBlockedTerms<'_> {
     type Response = Vec<BlockedTerm>;
 
     const PATH: &'static str = "moderation/blocked_terms";
@@ -99,9 +101,9 @@ impl Request for GetBlockedTerms {
         &[twitch_oauth2::Scope::ModeratorReadBlockedTerms];
 }
 
-impl RequestGet for GetBlockedTerms {}
+impl RequestGet for GetBlockedTerms<'_> {}
 
-impl helix::Paginated for GetBlockedTerms {
+impl helix::Paginated for GetBlockedTerms<'_> {
     fn set_pagination(&mut self, cursor: Option<helix::Cursor>) { self.after = cursor }
 }
 

--- a/src/helix/endpoints/moderation/get_moderators.rs
+++ b/src/helix/endpoints/moderation/get_moderators.rs
@@ -54,7 +54,7 @@ pub struct GetModeratorsRequest<'a> {
     pub user_id: Cow<'a, [&'a types::UserIdRef]>,
     /// Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
     #[cfg_attr(feature = "typed-builder", builder(default))]
-    pub after: Option<helix::Cursor>,
+    pub after: Option<Cow<'a, helix::CursorRef>>,
     /// Number of values to be returned per page. Limit: 100. Default: 20.
     #[cfg_attr(feature = "typed-builder", builder(setter(into), default))]
     pub first: Option<usize>,
@@ -110,7 +110,9 @@ impl Request for GetModeratorsRequest<'_> {
 impl RequestGet for GetModeratorsRequest<'_> {}
 
 impl helix::Paginated for GetModeratorsRequest<'_> {
-    fn set_pagination(&mut self, cursor: Option<helix::Cursor>) { self.after = cursor }
+    fn set_pagination(&mut self, cursor: Option<helix::Cursor>) {
+        self.after = cursor.map(|c| c.into_cow())
+    }
 }
 
 #[cfg(test)]

--- a/src/helix/endpoints/moderation/get_moderators.rs
+++ b/src/helix/endpoints/moderation/get_moderators.rs
@@ -9,9 +9,7 @@
 //!
 //! ```rust
 //! use twitch_api::helix::moderation::get_moderators;
-//! let request = get_moderators::GetModeratorsRequest::builder()
-//!     .broadcaster_id("1234")
-//!     .build();
+//! let request = get_moderators::GetModeratorsRequest::broadcaster_id("1234");
 //! ```
 //!
 //! ## Response: [Moderator]
@@ -26,9 +24,7 @@
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = get_moderators::GetModeratorsRequest::builder()
-//!     .broadcaster_id("1234")
-//!     .build();
+//! let request = get_moderators::GetModeratorsRequest::broadcaster_id("1234");
 //! let response: Vec<get_moderators::Moderator> = client.req_get(request, &token).await?.data;
 //! # Ok(())
 //! # }

--- a/src/helix/endpoints/moderation/get_moderators.rs
+++ b/src/helix/endpoints/moderation/get_moderators.rs
@@ -38,7 +38,6 @@
 //! and parse the [`http::Response`] with [`GetModeratorsRequest::parse_response(None, &request.get_uri(), response)`](GetModeratorsRequest::parse_response)
 use super::*;
 use helix::RequestGet;
-use std::borrow::Cow;
 
 // Format: Repeated Query Parameter, eg. /moderation/banned?broadcaster_id=1&user_id=2&user_id=3
 // Maximum: 100
@@ -52,7 +51,7 @@ pub struct GetModeratorsRequest<'a> {
     /// Must match the User ID in the Bearer token.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: &'a types::UserIdRef,
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
     /// Filters the results and only returns a status object for users who are moderators in this channel and have a matching user_id.
     #[cfg_attr(feature = "typed-builder", builder(setter(into), default))]
     #[serde(borrow)]
@@ -67,9 +66,9 @@ pub struct GetModeratorsRequest<'a> {
 
 impl<'a> GetModeratorsRequest<'a> {
     /// Get moderators in a broadcasters channel.
-    pub fn broadcaster_id(broadcaster_id: impl Into<&'a types::UserIdRef>) -> Self {
+    pub fn broadcaster_id(broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a) -> Self {
         Self {
-            broadcaster_id: broadcaster_id.into(),
+            broadcaster_id: broadcaster_id.to_cow(),
             user_id: Cow::Borrowed(&[]),
             after: Default::default(),
             first: Default::default(),

--- a/src/helix/endpoints/moderation/manage_held_automod_messages.rs
+++ b/src/helix/endpoints/moderation/manage_held_automod_messages.rs
@@ -83,11 +83,11 @@ pub struct ManageHeldAutoModMessagesBody<'a> {
     /// The moderator who is approving or rejecting the held message. Must match the user_id in the user OAuth token.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub user_id: &'a types::UserIdRef,
+    pub user_id: Cow<'a, types::UserIdRef>,
     /// ID of the message to be allowed or denied. These message IDs are retrieved from IRC or PubSub. Only one message ID can be provided.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub msg_id: &'a types::MsgIdRef,
+    pub msg_id: Cow<'a, types::MsgIdRef>,
     /// The action to take for the message. Must be "ALLOW" or "DENY".
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     pub action: AutoModAction,
@@ -104,13 +104,13 @@ impl<'a> ManageHeldAutoModMessagesBody<'a> {
     /// let body = ManageHeldAutoModMessagesBody::new("1234", "5678", true);
     /// ```
     pub fn new(
-        user_id: impl Into<&'a types::UserIdRef>,
-        msg_id: impl Into<&'a types::MsgIdRef>,
+        user_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
+        msg_id: impl types::IntoCow<'a, types::MsgIdRef> + 'a,
         action: impl Into<AutoModAction>,
     ) -> Self {
         Self {
-            user_id: user_id.into(),
-            msg_id: msg_id.into(),
+            user_id: user_id.to_cow(),
+            msg_id: msg_id.to_cow(),
             action: action.into(),
         }
     }

--- a/src/helix/endpoints/moderation/manage_held_automod_messages.rs
+++ b/src/helix/endpoints/moderation/manage_held_automod_messages.rs
@@ -5,7 +5,7 @@
 //!
 //! ## Request: [ManageHeldAutoModMessagesRequest]
 //!
-//! To use this endpoint, construct a [`ManageHeldAutoModMessagesRequest`] with the [`ManageHeldAutoModMessagesRequest::builder()`] method.
+//! To use this endpoint, construct a [`ManageHeldAutoModMessagesRequest`] with the [`ManageHeldAutoModMessagesRequest::new()`] method.
 //!
 //! ```rust
 //! use twitch_api::helix::moderation::manage_held_automod_messages;
@@ -18,11 +18,11 @@
 //!
 //! ```
 //! # use twitch_api::helix::moderation::manage_held_automod_messages;
-//! let body = manage_held_automod_messages::ManageHeldAutoModMessagesBody::builder()
-//!     .action(true)
-//!     .user_id("9327994")
-//!     .msg_id("836013710")
-//!     .build();
+//! let body = manage_held_automod_messages::ManageHeldAutoModMessagesBody::new(
+//!     "9327994",
+//!     "836013710",
+//!     true,
+//! );
 //! ```
 //!
 //! ## Response: [ManageHeldAutoModMessages]
@@ -40,11 +40,11 @@
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
 //! let request = manage_held_automod_messages::ManageHeldAutoModMessagesRequest::new();
-//! let body = manage_held_automod_messages::ManageHeldAutoModMessagesBody::builder()
-//!     .action(true)
-//!     .user_id("9327994")
-//!     .msg_id("836013710")
-//!     .build();
+//! let body = manage_held_automod_messages::ManageHeldAutoModMessagesBody::new(
+//!     "9327994",
+//!     "836013710",
+//!     true,
+//! );
 //! let response: manage_held_automod_messages::ManageHeldAutoModMessages = client.req_post(request, body, &token).await?.data;
 //! # Ok(())
 //! # }

--- a/src/helix/endpoints/moderation/manage_held_automod_messages.rs
+++ b/src/helix/endpoints/moderation/manage_held_automod_messages.rs
@@ -53,23 +53,24 @@
 //! You can also get the [`http::Request`] with [`request.create_request(&token, &client_id)`](helix::RequestPost::create_request)
 //! and parse the [`http::Response`] with [`ManageHeldAutoModMessagesRequest::parse_response(None, &request.get_uri(), response)`](ManageHeldAutoModMessagesRequest::parse_response)
 
+use std::marker::PhantomData;
+
 use super::*;
 use helix::RequestPost;
 /// Query Parameters for [Manage Held AutoMod Messages](super::manage_held_automod_messages)
 ///
 /// [`manage-held-automod-messages`](https://dev.twitch.tv/docs/api/reference#manage-held-automod-messages)
-#[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
+#[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug, Default)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct ManageHeldAutoModMessagesRequest {}
-
-impl ManageHeldAutoModMessagesRequest {
-    /// Create a new [`ManageHeldAutoModMessagesRequest`]
-    pub fn new() -> Self { Self {} }
+pub struct ManageHeldAutoModMessagesRequest<'a> {
+    #[serde(skip)]
+    _marker: PhantomData<&'a ()>,
 }
 
-impl Default for ManageHeldAutoModMessagesRequest {
-    fn default() -> Self { Self::new() }
+impl ManageHeldAutoModMessagesRequest<'_> {
+    /// Create a new [`ManageHeldAutoModMessagesRequest`]
+    pub fn new() -> Self { Self::default() }
 }
 
 /// Body Parameters for [Manage Held AutoMod Messages](super::manage_held_automod_messages)
@@ -78,19 +79,21 @@ impl Default for ManageHeldAutoModMessagesRequest {
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct ManageHeldAutoModMessagesBody {
+pub struct ManageHeldAutoModMessagesBody<'a> {
     /// The moderator who is approving or rejecting the held message. Must match the user_id in the user OAuth token.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub user_id: types::UserId,
+    #[serde(borrow)]
+    pub user_id: &'a types::UserIdRef,
     /// ID of the message to be allowed or denied. These message IDs are retrieved from IRC or PubSub. Only one message ID can be provided.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub msg_id: types::MsgId,
+    #[serde(borrow)]
+    pub msg_id: &'a types::MsgIdRef,
     /// The action to take for the message. Must be "ALLOW" or "DENY".
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     pub action: AutoModAction,
 }
 
-impl ManageHeldAutoModMessagesBody {
+impl<'a> ManageHeldAutoModMessagesBody<'a> {
     /// Create a new [`ManageHeldAutoModMessagesBody`]
     ///
     /// # Examples
@@ -101,8 +104,8 @@ impl ManageHeldAutoModMessagesBody {
     /// let body = ManageHeldAutoModMessagesBody::new("1234", "5678", true);
     /// ```
     pub fn new(
-        user_id: impl Into<types::UserId>,
-        msg_id: impl Into<types::MsgId>,
+        user_id: impl Into<&'a types::UserIdRef>,
+        msg_id: impl Into<&'a types::MsgIdRef>,
         action: impl Into<AutoModAction>,
     ) -> Self {
         Self {
@@ -114,7 +117,7 @@ impl ManageHeldAutoModMessagesBody {
 }
 
 /// Action to take for a message.
-#[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
+#[derive(PartialEq, Eq, Deserialize, Serialize, Copy, Clone, Debug)]
 #[serde(rename_all = "UPPERCASE")]
 #[non_exhaustive]
 pub enum AutoModAction {
@@ -133,7 +136,7 @@ impl From<bool> for AutoModAction {
     }
 }
 
-impl helix::private::SealedSerialize for ManageHeldAutoModMessagesBody {}
+impl helix::private::SealedSerialize for ManageHeldAutoModMessagesBody<'_> {}
 
 /// Return Values for [Manage Held AutoMod Messages](super::manage_held_automod_messages)
 ///
@@ -146,7 +149,7 @@ pub enum ManageHeldAutoModMessages {
     Success,
 }
 
-impl Request for ManageHeldAutoModMessagesRequest {
+impl Request for ManageHeldAutoModMessagesRequest<'_> {
     type Response = ManageHeldAutoModMessages;
 
     const PATH: &'static str = "moderation/automod/message";
@@ -154,8 +157,8 @@ impl Request for ManageHeldAutoModMessagesRequest {
     const SCOPE: &'static [twitch_oauth2::Scope] = &[twitch_oauth2::Scope::ModerationRead];
 }
 
-impl RequestPost for ManageHeldAutoModMessagesRequest {
-    type Body = ManageHeldAutoModMessagesBody;
+impl<'a> RequestPost for ManageHeldAutoModMessagesRequest<'a> {
+    type Body = ManageHeldAutoModMessagesBody<'a>;
 
     fn parse_inner_response<'d>(
         request: Option<Self>,

--- a/src/helix/endpoints/moderation/mod.rs
+++ b/src/helix/endpoints/moderation/mod.rs
@@ -6,6 +6,7 @@ use crate::{
     types,
 };
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 
 pub mod add_blocked_term;
 pub mod add_channel_moderator;

--- a/src/helix/endpoints/moderation/remove_blocked_term.rs
+++ b/src/helix/endpoints/moderation/remove_blocked_term.rs
@@ -49,25 +49,28 @@ use helix::RequestDelete;
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct RemoveBlockedTermRequest {
+pub struct RemoveBlockedTermRequest<'a> {
     /// The ID of the broadcaster that owns the list of blocked terms.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub broadcaster_id: types::UserId,
+    #[serde(borrow)]
+    pub broadcaster_id: &'a types::UserIdRef,
     /// The ID of a user that has permission to moderate the broadcaster’s chat room. This ID must match the user ID associated with the user OAuth token.
     /// If the broadcaster wants to delete the blocked term (instead of having the moderator do it), set this parameter to the broadcaster’s ID, too.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub moderator_id: types::UserId,
+    #[serde(borrow)]
+    pub moderator_id: &'a types::UserIdRef,
     /// The ID of the blocked term you want to delete.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub id: types::BlockedTermId,
+    #[serde(borrow)]
+    pub id: &'a types::BlockedTermIdRef,
 }
 
-impl RemoveBlockedTermRequest {
+impl<'a> RemoveBlockedTermRequest<'a> {
     /// Remove blocked term
     pub fn new(
-        broadcaster_id: impl Into<types::UserId>,
-        moderator_id: impl Into<types::UserId>,
-        id: impl Into<types::BlockedTermId>,
+        broadcaster_id: impl Into<&'a types::UserIdRef>,
+        moderator_id: impl Into<&'a types::UserIdRef>,
+        id: impl Into<&'a types::BlockedTermIdRef>,
     ) -> Self {
         Self {
             broadcaster_id: broadcaster_id.into(),
@@ -87,7 +90,7 @@ pub enum RemoveBlockedTerm {
     Success,
 }
 
-impl Request for RemoveBlockedTermRequest {
+impl Request for RemoveBlockedTermRequest<'_> {
     type Response = RemoveBlockedTerm;
 
     #[cfg(feature = "twitch_oauth2")]
@@ -98,7 +101,7 @@ impl Request for RemoveBlockedTermRequest {
         &[twitch_oauth2::Scope::ModeratorManageBlockedTerms];
 }
 
-impl RequestDelete for RemoveBlockedTermRequest {
+impl RequestDelete for RemoveBlockedTermRequest<'_> {
     fn parse_inner_response(
         request: Option<Self>,
         uri: &http::Uri,

--- a/src/helix/endpoints/moderation/remove_blocked_term.rs
+++ b/src/helix/endpoints/moderation/remove_blocked_term.rs
@@ -5,15 +5,11 @@
 //!
 //! ## Request: [RemoveBlockedTermRequest]
 //!
-//! To use this endpoint, construct a [`RemoveBlockedTermRequest`] with the [`RemoveBlockedTermRequest::builder()`] method.
+//! To use this endpoint, construct a [`RemoveBlockedTermRequest`] with the [`RemoveBlockedTermRequest::new()`] method.
 //!
 //! ```rust
 //! use twitch_api::helix::moderation::remove_blocked_term;
-//! let request = remove_blocked_term::RemoveBlockedTermRequest::builder()
-//!     .broadcaster_id("1234")
-//!     .moderator_id("5678")
-//!     .id("DEADBEEF")
-//!     .build();
+//! let request = remove_blocked_term::RemoveBlockedTermRequest::new("1234", "5678", "DEADBEEF");
 //! ```
 //!
 //! ## Response: [RemoveBlockedTerm]
@@ -28,11 +24,7 @@
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = remove_blocked_term::RemoveBlockedTermRequest::builder()
-//!     .broadcaster_id("1234")
-//!     .moderator_id("5678")
-//!     .id("DEADBEEF")
-//!     .build();
+//! let request = remove_blocked_term::RemoveBlockedTermRequest::new("1234", "5678", "DEADBEEF");
 //! let response: remove_blocked_term::RemoveBlockedTerm = client.req_delete(request, &token).await?.data;
 //! # Ok(())
 //! # }

--- a/src/helix/endpoints/moderation/remove_blocked_term.rs
+++ b/src/helix/endpoints/moderation/remove_blocked_term.rs
@@ -53,29 +53,29 @@ pub struct RemoveBlockedTermRequest<'a> {
     /// The ID of the broadcaster that owns the list of blocked terms.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: &'a types::UserIdRef,
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
     /// The ID of a user that has permission to moderate the broadcaster’s chat room. This ID must match the user ID associated with the user OAuth token.
     /// If the broadcaster wants to delete the blocked term (instead of having the moderator do it), set this parameter to the broadcaster’s ID, too.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub moderator_id: &'a types::UserIdRef,
+    pub moderator_id: Cow<'a, types::UserIdRef>,
     /// The ID of the blocked term you want to delete.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub id: &'a types::BlockedTermIdRef,
+    pub id: Cow<'a, types::BlockedTermIdRef>,
 }
 
 impl<'a> RemoveBlockedTermRequest<'a> {
     /// Remove blocked term
     pub fn new(
-        broadcaster_id: impl Into<&'a types::UserIdRef>,
-        moderator_id: impl Into<&'a types::UserIdRef>,
-        id: impl Into<&'a types::BlockedTermIdRef>,
+        broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
+        moderator_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
+        id: impl types::IntoCow<'a, types::BlockedTermIdRef> + 'a,
     ) -> Self {
         Self {
-            broadcaster_id: broadcaster_id.into(),
-            moderator_id: moderator_id.into(),
-            id: id.into(),
+            broadcaster_id: broadcaster_id.to_cow(),
+            moderator_id: moderator_id.to_cow(),
+            id: id.to_cow(),
         }
     }
 }

--- a/src/helix/endpoints/moderation/remove_channel_moderator.rs
+++ b/src/helix/endpoints/moderation/remove_channel_moderator.rs
@@ -5,14 +5,11 @@
 //!
 //! ## Request: [RemoveChannelModeratorRequest]
 //!
-//! To use this endpoint, construct a [`RemoveChannelModeratorRequest`] with the [`RemoveChannelModeratorRequest::builder()`] method.
+//! To use this endpoint, construct a [`RemoveChannelModeratorRequest`] with the [`RemoveChannelModeratorRequest::new()`] method.
 //!
 //! ```rust
 //! use twitch_api::helix::moderation::remove_channel_moderator;
-//! let request = remove_channel_moderator::RemoveChannelModeratorRequest::builder()
-//!     .broadcaster_id("1234")
-//!     .moderator_id("5678")
-//!     .build();
+//! let request = remove_channel_moderator::RemoveChannelModeratorRequest::new("1234", "5678");
 //! ```
 //!
 //! ## Response: [RemoveChannelModeratorResponse]
@@ -28,10 +25,7 @@
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = remove_channel_moderator::RemoveChannelModeratorRequest::builder()
-//!     .broadcaster_id("1234")
-//!     .moderator_id("5678")
-//!     .build();
+//! let request = remove_channel_moderator::RemoveChannelModeratorRequest::new("1234", "5678");
 //! let response: helix::moderation::RemoveChannelModeratorResponse = client.req_delete(request, &token).await?.data;
 //! # Ok(())
 //! # }

--- a/src/helix/endpoints/moderation/remove_channel_moderator.rs
+++ b/src/helix/endpoints/moderation/remove_channel_moderator.rs
@@ -53,22 +53,22 @@ pub struct RemoveChannelModeratorRequest<'a> {
     /// The ID of the broadcaster that owns the chat room.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: &'a types::UserIdRef,
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
     /// The ID of the user to remove as a moderator from the broadcaster’s chat room.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub moderator_id: &'a types::UserIdRef,
+    pub moderator_id: Cow<'a, types::UserIdRef>,
 }
 
 impl<'a> RemoveChannelModeratorRequest<'a> {
     /// Remove moderator
     pub fn new(
-        broadcaster_id: impl Into<&'a types::UserIdRef>,
-        moderator_id: impl Into<&'a types::UserIdRef>,
+        broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
+        moderator_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
     ) -> Self {
         Self {
-            broadcaster_id: broadcaster_id.into(),
-            moderator_id: moderator_id.into(),
+            broadcaster_id: broadcaster_id.to_cow(),
+            moderator_id: moderator_id.to_cow(),
         }
     }
 }

--- a/src/helix/endpoints/moderation/remove_channel_moderator.rs
+++ b/src/helix/endpoints/moderation/remove_channel_moderator.rs
@@ -49,20 +49,22 @@ use helix::RequestDelete;
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct RemoveChannelModeratorRequest {
+pub struct RemoveChannelModeratorRequest<'a> {
     /// The ID of the broadcaster that owns the chat room.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub broadcaster_id: types::UserId,
+    #[serde(borrow)]
+    pub broadcaster_id: &'a types::UserIdRef,
     /// The ID of the user to remove as a moderator from the broadcaster’s chat room.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub moderator_id: types::UserId,
+    #[serde(borrow)]
+    pub moderator_id: &'a types::UserIdRef,
 }
 
-impl RemoveChannelModeratorRequest {
+impl<'a> RemoveChannelModeratorRequest<'a> {
     /// Remove moderator
     pub fn new(
-        broadcaster_id: impl Into<types::UserId>,
-        moderator_id: impl Into<types::UserId>,
+        broadcaster_id: impl Into<&'a types::UserIdRef>,
+        moderator_id: impl Into<&'a types::UserIdRef>,
     ) -> Self {
         Self {
             broadcaster_id: broadcaster_id.into(),
@@ -82,7 +84,7 @@ pub enum RemoveChannelModeratorResponse {
     Success,
 }
 
-impl Request for RemoveChannelModeratorRequest {
+impl Request for RemoveChannelModeratorRequest<'_> {
     type Response = RemoveChannelModeratorResponse;
 
     const PATH: &'static str = "moderation/moderators";
@@ -90,7 +92,7 @@ impl Request for RemoveChannelModeratorRequest {
     const SCOPE: &'static [twitch_oauth2::Scope] = &[twitch_oauth2::Scope::ChannelManageModerators];
 }
 
-impl RequestDelete for RemoveChannelModeratorRequest {
+impl RequestDelete for RemoveChannelModeratorRequest<'_> {
     fn parse_inner_response<'d>(
         request: Option<Self>,
         uri: &http::Uri,

--- a/src/helix/endpoints/moderation/unban_user.rs
+++ b/src/helix/endpoints/moderation/unban_user.rs
@@ -5,15 +5,11 @@
 //!
 //! ## Request: [UnbanUserRequest]
 //!
-//! To use this endpoint, construct a [`UnbanUserRequest`] with the [`UnbanUserRequest::builder()`] method.
+//! To use this endpoint, construct a [`UnbanUserRequest`] with the [`UnbanUserRequest::new()`] method.
 //!
 //! ```rust
 //! use twitch_api::helix::moderation::unban_user;
-//! let request = unban_user::UnbanUserRequest::builder()
-//!     .broadcaster_id("1234")
-//!     .moderator_id("5678")
-//!     .user_id("1337")
-//!     .build();
+//! let request = unban_user::UnbanUserRequest::new("1234", "5678", "1337");
 //! ```
 //!
 //! ## Response: [UnbanUserResponse]
@@ -30,11 +26,7 @@
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = unban_user::UnbanUserRequest::builder()
-//!     .broadcaster_id("1234")
-//!     .moderator_id("5678")
-//!     .user_id("1337")
-//!     .build();
+//! let request = unban_user::UnbanUserRequest::new("1234", "5678", "1337");
 //! let response: unban_user::UnbanUserResponse = client.req_delete(request, &token).await?.data;
 //! # Ok(())
 //! # }

--- a/src/helix/endpoints/moderation/unban_user.rs
+++ b/src/helix/endpoints/moderation/unban_user.rs
@@ -51,24 +51,27 @@ use helix::RequestDelete;
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct UnbanUserRequest {
+pub struct UnbanUserRequest<'a> {
     /// The ID of the broadcaster whose chat room the user is banned from chatting in.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub broadcaster_id: types::UserId,
+    #[serde(borrow)]
+    pub broadcaster_id: &'a types::UserIdRef,
     /// The ID of a user that has permission to moderate the broadcaster’s chat room. This ID must match the user ID associated with the user OAuth token.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub moderator_id: types::UserId,
+    #[serde(borrow)]
+    pub moderator_id: &'a types::UserIdRef,
     /// The ID of the user to remove the ban or timeout from.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub user_id: types::UserId,
+    #[serde(borrow)]
+    pub user_id: &'a types::UserIdRef,
 }
 
-impl UnbanUserRequest {
+impl<'a> UnbanUserRequest<'a> {
     /// Remove the ban or timeout that was placed on the specified user.
     pub fn new(
-        broadcaster_id: impl Into<types::UserId>,
-        moderator_id: impl Into<types::UserId>,
-        user_id: impl Into<types::UserId>,
+        broadcaster_id: impl Into<&'a types::UserIdRef>,
+        moderator_id: impl Into<&'a types::UserIdRef>,
+        user_id: impl Into<&'a types::UserIdRef>,
     ) -> Self {
         Self {
             broadcaster_id: broadcaster_id.into(),
@@ -88,7 +91,7 @@ pub enum UnbanUserResponse {
     Success,
 }
 
-impl Request for UnbanUserRequest {
+impl Request for UnbanUserRequest<'_> {
     type Response = UnbanUserResponse;
 
     const PATH: &'static str = "moderation/bans";
@@ -97,7 +100,7 @@ impl Request for UnbanUserRequest {
         &[twitch_oauth2::Scope::ModeratorManageBannedUsers];
 }
 
-impl RequestDelete for UnbanUserRequest {
+impl RequestDelete for UnbanUserRequest<'_> {
     fn parse_inner_response(
         request: Option<Self>,
         uri: &http::Uri,

--- a/src/helix/endpoints/moderation/unban_user.rs
+++ b/src/helix/endpoints/moderation/unban_user.rs
@@ -55,28 +55,28 @@ pub struct UnbanUserRequest<'a> {
     /// The ID of the broadcaster whose chat room the user is banned from chatting in.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: &'a types::UserIdRef,
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
     /// The ID of a user that has permission to moderate the broadcaster’s chat room. This ID must match the user ID associated with the user OAuth token.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub moderator_id: &'a types::UserIdRef,
+    pub moderator_id: Cow<'a, types::UserIdRef>,
     /// The ID of the user to remove the ban or timeout from.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub user_id: &'a types::UserIdRef,
+    pub user_id: Cow<'a, types::UserIdRef>,
 }
 
 impl<'a> UnbanUserRequest<'a> {
     /// Remove the ban or timeout that was placed on the specified user.
     pub fn new(
-        broadcaster_id: impl Into<&'a types::UserIdRef>,
-        moderator_id: impl Into<&'a types::UserIdRef>,
-        user_id: impl Into<&'a types::UserIdRef>,
+        broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
+        moderator_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
+        user_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
     ) -> Self {
         Self {
-            broadcaster_id: broadcaster_id.into(),
-            moderator_id: moderator_id.into(),
-            user_id: user_id.into(),
+            broadcaster_id: broadcaster_id.to_cow(),
+            moderator_id: moderator_id.to_cow(),
+            user_id: user_id.to_cow(),
         }
     }
 }

--- a/src/helix/endpoints/points/create_custom_rewards.rs
+++ b/src/helix/endpoints/points/create_custom_rewards.rs
@@ -63,15 +63,16 @@ use helix::RequestPost;
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct CreateCustomRewardRequest {
+pub struct CreateCustomRewardRequest<'a> {
     /// Provided broadcaster_id must match the user_id in the auth token
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub broadcaster_id: types::UserId,
+    #[serde(borrow)]
+    pub broadcaster_id: &'a types::UserIdRef,
 }
 
-impl CreateCustomRewardRequest {
+impl<'a> CreateCustomRewardRequest<'a> {
     /// Channel to create reward on
-    pub fn broadcaster_id(broadcaster_id: impl Into<types::UserId>) -> Self {
+    pub fn broadcaster_id(broadcaster_id: impl Into<&'a types::UserIdRef>) -> Self {
         Self {
             broadcaster_id: broadcaster_id.into(),
         }
@@ -84,14 +85,15 @@ impl CreateCustomRewardRequest {
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct CreateCustomRewardBody {
+pub struct CreateCustomRewardBody<'a> {
     /// The title of the reward
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub title: String,
+    #[serde(borrow)]
+    pub title: &'a str,
     /// The prompt for the viewer when they are redeeming the reward
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub prompt: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", borrow)]
+    pub prompt: Option<&'a str>,
     /// The cost of the reward
     pub cost: usize,
     /// Is the reward currently enabled, if false the reward won’t show up to viewers. Defaults true
@@ -100,8 +102,8 @@ pub struct CreateCustomRewardBody {
     pub is_enabled: Option<bool>,
     /// Custom background color for the reward. Format: Hex with # prefix. Example: #00E5CB.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub background_color: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", borrow)]
+    pub background_color: Option<&'a str>,
     /// Does the user need to enter information when redeeming the reward. Defaults false
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -136,10 +138,10 @@ pub struct CreateCustomRewardBody {
     pub should_redemptions_skip_request_queue: Option<bool>,
 }
 
-impl CreateCustomRewardBody {
+impl<'a> CreateCustomRewardBody<'a> {
     // FIXME: need to add more here
     /// Reward to create with title.
-    pub fn new(title: String, cost: usize) -> Self {
+    pub fn new(title: &'a str, cost: usize) -> Self {
         Self {
             title,
             prompt: Default::default(),
@@ -158,14 +160,14 @@ impl CreateCustomRewardBody {
     }
 }
 
-impl helix::private::SealedSerialize for CreateCustomRewardBody {}
+impl helix::private::SealedSerialize for CreateCustomRewardBody<'_> {}
 
 /// Return Values for [Create Custom Rewards](super::create_custom_rewards)
 ///
 /// [`create-custom-rewards`](https://dev.twitch.tv/docs/api/reference#create-custom-rewards)
 pub type CreateCustomRewardResponse = super::CustomReward;
 
-impl Request for CreateCustomRewardRequest {
+impl Request for CreateCustomRewardRequest<'_> {
     type Response = CreateCustomRewardResponse;
 
     const PATH: &'static str = "channel_points/custom_rewards";
@@ -174,8 +176,8 @@ impl Request for CreateCustomRewardRequest {
         &[twitch_oauth2::Scope::ChannelManageRedemptions];
 }
 
-impl RequestPost for CreateCustomRewardRequest {
-    type Body = CreateCustomRewardBody;
+impl<'a> RequestPost for CreateCustomRewardRequest<'a> {
+    type Body = CreateCustomRewardBody<'a>;
 
     fn parse_inner_response(
         request: Option<Self>,
@@ -219,7 +221,7 @@ fn test_request() {
     use helix::*;
     let req = CreateCustomRewardRequest::broadcaster_id("274637212");
 
-    let body = CreateCustomRewardBody::new("game analysis 1v1".to_owned(), 50000);
+    let body = CreateCustomRewardBody::new("game analysis 1v1", 50000);
 
     dbg!(req.create_request(body, "token", "clientid").unwrap());
 

--- a/src/helix/endpoints/points/create_custom_rewards.rs
+++ b/src/helix/endpoints/points/create_custom_rewards.rs
@@ -79,11 +79,11 @@ pub struct CreateCustomRewardBody<'a> {
     /// The title of the reward
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub title: &'a str,
+    pub title: Cow<'a, str>,
     /// The prompt for the viewer when they are redeeming the reward
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(skip_serializing_if = "Option::is_none", borrow)]
-    pub prompt: Option<&'a str>,
+    pub prompt: Option<Cow<'a, str>>,
     /// The cost of the reward
     pub cost: usize,
     /// Is the reward currently enabled, if false the reward won’t show up to viewers. Defaults true
@@ -93,7 +93,7 @@ pub struct CreateCustomRewardBody<'a> {
     /// Custom background color for the reward. Format: Hex with # prefix. Example: #00E5CB.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(skip_serializing_if = "Option::is_none", borrow)]
-    pub background_color: Option<&'a str>,
+    pub background_color: Option<Cow<'a, str>>,
     /// Does the user need to enter information when redeeming the reward. Defaults false
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -131,9 +131,9 @@ pub struct CreateCustomRewardBody<'a> {
 impl<'a> CreateCustomRewardBody<'a> {
     // FIXME: need to add more here
     /// Reward to create with title.
-    pub fn new(title: &'a str, cost: usize) -> Self {
+    pub fn new(title: impl Into<Cow<'a, str>>, cost: usize) -> Self {
         Self {
-            title,
+            title: title.into(),
             prompt: Default::default(),
             cost,
             is_enabled: Default::default(),

--- a/src/helix/endpoints/points/create_custom_rewards.rs
+++ b/src/helix/endpoints/points/create_custom_rewards.rs
@@ -67,14 +67,14 @@ pub struct CreateCustomRewardRequest<'a> {
     /// Provided broadcaster_id must match the user_id in the auth token
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: &'a types::UserIdRef,
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
 }
 
 impl<'a> CreateCustomRewardRequest<'a> {
     /// Channel to create reward on
-    pub fn broadcaster_id(broadcaster_id: impl Into<&'a types::UserIdRef>) -> Self {
+    pub fn broadcaster_id(broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a) -> Self {
         Self {
-            broadcaster_id: broadcaster_id.into(),
+            broadcaster_id: broadcaster_id.to_cow(),
         }
     }
 }

--- a/src/helix/endpoints/points/create_custom_rewards.rs
+++ b/src/helix/endpoints/points/create_custom_rewards.rs
@@ -5,13 +5,11 @@
 //!
 //! ## Request: [CreateCustomRewardRequest]
 //!
-//! To use this endpoint, construct a [`CreateCustomRewardRequest`] with the [`CreateCustomRewardRequest::builder()`] method.
+//! To use this endpoint, construct a [`CreateCustomRewardRequest`] with the [`CreateCustomRewardRequest::broadcaster_id()`] method.
 //!
 //! ```rust
 //! use twitch_api::helix::points::create_custom_rewards;
-//! let request = create_custom_rewards::CreateCustomRewardRequest::builder()
-//!     .broadcaster_id("274637212")
-//!     .build();
+//! let request = create_custom_rewards::CreateCustomRewardRequest::broadcaster_id("274637212");
 //! ```
 //!
 //! ## Body: [CreateCustomRewardBody]
@@ -20,10 +18,7 @@
 //!
 //! ```
 //! # use twitch_api::helix::points::create_custom_rewards;
-//! let body = create_custom_rewards::CreateCustomRewardBody::builder()
-//!     .cost(500)
-//!     .title("hydrate!")
-//!     .build();
+//! let mut body = create_custom_rewards::CreateCustomRewardBody::new("hydrate", 500);
 //! ```
 //!
 //! ## Response: [CreateCustomRewardResponse]
@@ -40,13 +35,8 @@
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = create_custom_rewards::CreateCustomRewardRequest::builder()
-//!     .broadcaster_id("274637212")
-//!     .build();
-//! let body = create_custom_rewards::CreateCustomRewardBody::builder()
-//!     .cost(500)
-//!     .title("hydrate!")
-//!     .build();
+//! let request = create_custom_rewards::CreateCustomRewardRequest::broadcaster_id("274637212");
+//! let mut body = create_custom_rewards::CreateCustomRewardBody::new("hydrate", 500);
 //! let response: create_custom_rewards::CreateCustomRewardResponse = client.req_post(request, body, &token).await?.data;
 //! # Ok(())
 //! # }

--- a/src/helix/endpoints/points/delete_custom_reward.rs
+++ b/src/helix/endpoints/points/delete_custom_reward.rs
@@ -48,18 +48,23 @@ use helix::RequestDelete;
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct DeleteCustomRewardRequest {
+pub struct DeleteCustomRewardRequest<'a> {
     /// Provided broadcaster_id must match the user_id in the auth token
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub broadcaster_id: types::UserId,
+    #[serde(borrow)]
+    pub broadcaster_id: &'a types::UserIdRef,
     /// ID of the Custom Reward to delete, must match a Custom Reward on broadcaster_id’s channel.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub id: types::RewardId,
+    #[serde(borrow)]
+    pub id: &'a types::RewardIdRef,
 }
 
-impl DeleteCustomRewardRequest {
+impl<'a> DeleteCustomRewardRequest<'a> {
     /// Reward to delete
-    pub fn new(broadcaster_id: impl Into<types::UserId>, id: impl Into<types::RewardId>) -> Self {
+    pub fn new(
+        broadcaster_id: impl Into<&'a types::UserIdRef>,
+        id: impl Into<&'a types::RewardIdRef>,
+    ) -> Self {
         Self {
             broadcaster_id: broadcaster_id.into(),
             id: id.into(),
@@ -79,7 +84,7 @@ pub enum DeleteCustomReward {
     Success,
 }
 
-impl Request for DeleteCustomRewardRequest {
+impl Request for DeleteCustomRewardRequest<'_> {
     type Response = DeleteCustomReward;
 
     const PATH: &'static str = "channel_points/custom_rewards";
@@ -88,7 +93,7 @@ impl Request for DeleteCustomRewardRequest {
         &[twitch_oauth2::Scope::ChannelManageRedemptions];
 }
 
-impl RequestDelete for DeleteCustomRewardRequest {
+impl RequestDelete for DeleteCustomRewardRequest<'_> {
     fn parse_inner_response(
         request: Option<Self>,
         uri: &http::Uri,

--- a/src/helix/endpoints/points/delete_custom_reward.rs
+++ b/src/helix/endpoints/points/delete_custom_reward.rs
@@ -52,22 +52,22 @@ pub struct DeleteCustomRewardRequest<'a> {
     /// Provided broadcaster_id must match the user_id in the auth token
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: &'a types::UserIdRef,
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
     /// ID of the Custom Reward to delete, must match a Custom Reward on broadcaster_id’s channel.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub id: &'a types::RewardIdRef,
+    pub id: Cow<'a, types::RewardIdRef>,
 }
 
 impl<'a> DeleteCustomRewardRequest<'a> {
     /// Reward to delete
     pub fn new(
-        broadcaster_id: impl Into<&'a types::UserIdRef>,
-        id: impl Into<&'a types::RewardIdRef>,
+        broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
+        id: impl types::IntoCow<'a, types::RewardIdRef> + 'a,
     ) -> Self {
         Self {
-            broadcaster_id: broadcaster_id.into(),
-            id: id.into(),
+            broadcaster_id: broadcaster_id.to_cow(),
+            id: id.to_cow(),
         }
     }
 }

--- a/src/helix/endpoints/points/delete_custom_reward.rs
+++ b/src/helix/endpoints/points/delete_custom_reward.rs
@@ -5,14 +5,11 @@
 //!
 //! ## Request: [DeleteCustomRewardRequest]
 //!
-//! To use this endpoint, construct a [`DeleteCustomRewardRequest`] with the [`DeleteCustomRewardRequest::builder()`] method.
+//! To use this endpoint, construct a [`DeleteCustomRewardRequest`] with the [`DeleteCustomRewardRequest::new()`] method.
 //!
 //! ```rust
 //! use twitch_api::helix::points::delete_custom_reward;
-//! let request = delete_custom_reward::DeleteCustomRewardRequest::builder()
-//!     .broadcaster_id("274637212")
-//!     .id("1234")
-//!     .build();
+//! let request = delete_custom_reward::DeleteCustomRewardRequest::new("274637212", "1234");
 //! ```
 //!
 //! ## Response: [DeleteCustomReward]
@@ -27,10 +24,7 @@
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = delete_custom_reward::DeleteCustomRewardRequest::builder()
-//!     .broadcaster_id("274637212")
-//!     .id("1234")
-//!     .build();
+//! let request = delete_custom_reward::DeleteCustomRewardRequest::new("274637212", "1234");
 //! let response: delete_custom_reward::DeleteCustomReward = client.req_delete(request, &token).await?.data;
 //! # Ok(())
 //! # }

--- a/src/helix/endpoints/points/get_custom_reward.rs
+++ b/src/helix/endpoints/points/get_custom_reward.rs
@@ -12,7 +12,7 @@
 //! ```rust
 //! use twitch_api::helix::points::GetCustomRewardRequest;
 //! let request = GetCustomRewardRequest::builder()
-//!     .broadcaster_id("274637212".to_string())
+//!     .broadcaster_id("274637212")
 //!     .build();
 //! ```
 //!
@@ -30,7 +30,7 @@
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
 //! let request = GetCustomRewardRequest::builder()
-//!     .broadcaster_id("274637212".to_string())
+//!     .broadcaster_id("274637212")
 //!     .build();
 //! let response: Vec<CustomReward> = client.req_get(request, &token).await?.data;
 //! # Ok(())

--- a/src/helix/endpoints/points/get_custom_reward.rs
+++ b/src/helix/endpoints/points/get_custom_reward.rs
@@ -7,13 +7,11 @@
 //!
 //! ## Request: [GetCustomRewardRequest]
 //!
-//! To use this endpoint, construct a [`GetCustomRewardRequest`] with the [`GetCustomRewardRequest::builder()`] method.
+//! To use this endpoint, construct a [`GetCustomRewardRequest`] with the [`GetCustomRewardRequest::broadcaster_id()`] method.
 //!
 //! ```rust
 //! use twitch_api::helix::points::GetCustomRewardRequest;
-//! let request = GetCustomRewardRequest::builder()
-//!     .broadcaster_id("274637212")
-//!     .build();
+//! let request = GetCustomRewardRequest::broadcaster_id("274637212");
 //! ```
 //!
 //! ## Response: [CustomReward]
@@ -29,9 +27,7 @@
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = GetCustomRewardRequest::builder()
-//!     .broadcaster_id("274637212")
-//!     .build();
+//! let request = GetCustomRewardRequest::broadcaster_id("274637212");
 //! let response: Vec<CustomReward> = client.req_get(request, &token).await?.data;
 //! # Ok(())
 //! # }

--- a/src/helix/endpoints/points/get_custom_reward.rs
+++ b/src/helix/endpoints/points/get_custom_reward.rs
@@ -42,7 +42,6 @@
 
 use super::*;
 use helix::RequestGet;
-use std::borrow::Cow;
 
 /// Query Parameters for [Get Custom Reward](super::get_custom_reward)
 ///
@@ -54,7 +53,7 @@ pub struct GetCustomRewardRequest<'a> {
     /// Provided broadcaster_id must match the user_id in the auth token
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: &'a types::UserIdRef,
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
     /// When used, this parameter filters the results and only returns reward objects for the Custom Rewards with matching ID. Maximum: 50
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(borrow)]
@@ -66,9 +65,9 @@ pub struct GetCustomRewardRequest<'a> {
 
 impl<'a> GetCustomRewardRequest<'a> {
     /// Rewards on this broadcasters channel
-    pub fn broadcaster_id(broadcaster_id: impl Into<&'a types::UserIdRef>) -> Self {
+    pub fn broadcaster_id(broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a) -> Self {
         Self {
-            broadcaster_id: broadcaster_id.into(),
+            broadcaster_id: broadcaster_id.to_cow(),
             id: Cow::Borrowed(&[]),
             only_manageable_rewards: Default::default(),
         }

--- a/src/helix/endpoints/points/get_custom_reward_redemption.rs
+++ b/src/helix/endpoints/points/get_custom_reward_redemption.rs
@@ -55,12 +55,12 @@ pub struct GetCustomRewardRedemptionRequest<'a> {
     /// Provided broadcaster_id must match the user_id in the auth token
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: &'a types::UserIdRef,
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
 
     /// When ID is not provided, this parameter returns paginated Custom Reward Redemption objects for redemptions of the Custom Reward with ID reward_id
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub reward_id: Option<&'a types::RewardIdRef>,
+    pub reward_id: Option<Cow<'a, types::RewardIdRef>>,
 
     /// When id is not provided, this param is required and filters the paginated Custom Reward Redemption objects for redemptions with the matching status. Can be one of UNFULFILLED, FULFILLED or CANCELED
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
@@ -77,9 +77,9 @@ pub struct GetCustomRewardRedemptionRequest<'a> {
 
 impl<'a> GetCustomRewardRedemptionRequest<'a> {
     /// Reward to fetch
-    pub fn broadcaster_id(broadcaster_id: impl Into<&'a types::UserIdRef>) -> Self {
+    pub fn broadcaster_id(broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a) -> Self {
         Self {
-            broadcaster_id: broadcaster_id.into(),
+            broadcaster_id: broadcaster_id.to_cow(),
             reward_id: None,
             status: Default::default(),
             after: Default::default(),
@@ -88,8 +88,11 @@ impl<'a> GetCustomRewardRedemptionRequest<'a> {
     }
 
     /// Specific reward to query
-    pub fn reward_id(mut self, reward_id: impl Into<&'a types::RewardIdRef>) -> Self {
-        self.reward_id = Some(reward_id.into());
+    pub fn reward_id(
+        mut self,
+        reward_id: impl types::IntoCow<'a, types::RewardIdRef> + 'a,
+    ) -> Self {
+        self.reward_id = Some(reward_id.to_cow());
         self
     }
 

--- a/src/helix/endpoints/points/get_custom_reward_redemption.rs
+++ b/src/helix/endpoints/points/get_custom_reward_redemption.rs
@@ -68,7 +68,7 @@ pub struct GetCustomRewardRedemptionRequest<'a> {
 
     /// Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. This applies only to queries without ID. If an ID is specified, it supersedes any cursor/offset combinations. The cursor value specified here is from the pagination response field of a prior query.
     #[cfg_attr(feature = "typed-builder", builder(default))]
-    pub after: Option<helix::Cursor>,
+    pub after: Option<Cow<'a, helix::CursorRef>>,
 
     /// Number of results to be returned when getting the paginated Custom Reward Redemption objects for a reward. Limit: 50. Default: 20.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
@@ -174,7 +174,9 @@ impl Request for GetCustomRewardRedemptionRequest<'_> {
 impl RequestGet for GetCustomRewardRedemptionRequest<'_> {}
 
 impl helix::Paginated for GetCustomRewardRedemptionRequest<'_> {
-    fn set_pagination(&mut self, cursor: Option<helix::Cursor>) { self.after = cursor }
+    fn set_pagination(&mut self, cursor: Option<helix::Cursor>) {
+        self.after = cursor.map(|c| c.into_cow())
+    }
 }
 
 #[cfg(test)]

--- a/src/helix/endpoints/points/get_custom_reward_redemption.rs
+++ b/src/helix/endpoints/points/get_custom_reward_redemption.rs
@@ -51,14 +51,16 @@ use helix::RequestGet;
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct GetCustomRewardRedemptionRequest {
+pub struct GetCustomRewardRedemptionRequest<'a> {
     /// Provided broadcaster_id must match the user_id in the auth token
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub broadcaster_id: types::UserId,
+    #[serde(borrow)]
+    pub broadcaster_id: &'a types::UserIdRef,
 
     /// When ID is not provided, this parameter returns paginated Custom Reward Redemption objects for redemptions of the Custom Reward with ID reward_id
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub reward_id: Option<types::RewardId>,
+    #[serde(borrow)]
+    pub reward_id: Option<&'a types::RewardIdRef>,
 
     /// When id is not provided, this param is required and filters the paginated Custom Reward Redemption objects for redemptions with the matching status. Can be one of UNFULFILLED, FULFILLED or CANCELED
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
@@ -73,9 +75,9 @@ pub struct GetCustomRewardRedemptionRequest {
     pub first: Option<usize>,
 }
 
-impl GetCustomRewardRedemptionRequest {
+impl<'a> GetCustomRewardRedemptionRequest<'a> {
     /// Reward to fetch
-    pub fn broadcaster_id(broadcaster_id: impl Into<types::UserId>) -> Self {
+    pub fn broadcaster_id(broadcaster_id: impl Into<&'a types::UserIdRef>) -> Self {
         Self {
             broadcaster_id: broadcaster_id.into(),
             reward_id: None,
@@ -86,7 +88,7 @@ impl GetCustomRewardRedemptionRequest {
     }
 
     /// Specific reward to query
-    pub fn reward_id(mut self, reward_id: impl Into<types::RewardId>) -> Self {
+    pub fn reward_id(mut self, reward_id: impl Into<&'a types::RewardIdRef>) -> Self {
         self.reward_id = Some(reward_id.into());
         self
     }
@@ -157,7 +159,7 @@ pub struct Reward {
     pub cost: i64,
 }
 
-impl Request for GetCustomRewardRedemptionRequest {
+impl Request for GetCustomRewardRedemptionRequest<'_> {
     type Response = Vec<CustomRewardRedemption>;
 
     const PATH: &'static str = "channel_points/custom_rewards/redemptions";
@@ -166,9 +168,9 @@ impl Request for GetCustomRewardRedemptionRequest {
         &[twitch_oauth2::scopes::Scope::ChannelReadRedemptions];
 }
 
-impl RequestGet for GetCustomRewardRedemptionRequest {}
+impl RequestGet for GetCustomRewardRedemptionRequest<'_> {}
 
-impl helix::Paginated for GetCustomRewardRedemptionRequest {
+impl helix::Paginated for GetCustomRewardRedemptionRequest<'_> {
     fn set_pagination(&mut self, cursor: Option<helix::Cursor>) { self.after = cursor }
 }
 

--- a/src/helix/endpoints/points/mod.rs
+++ b/src/helix/endpoints/points/mod.rs
@@ -50,7 +50,7 @@ pub use update_redemption_status::{
     UpdateRedemptionStatusBody, UpdateRedemptionStatusInformation, UpdateRedemptionStatusRequest,
 };
 /// Custom reward redemption statuses: UNFULFILLED, FULFILLED or CANCELED
-#[derive(PartialEq, Eq, serde::Serialize, serde::Deserialize, Clone, Debug)]
+#[derive(PartialEq, Eq, serde::Serialize, serde::Deserialize, Copy, Clone, Debug)]
 pub enum CustomRewardRedemptionStatus {
     /// Unfulfilled reward - the user has claimed it but it is still pending.
     #[serde(rename = "UNFULFILLED")]

--- a/src/helix/endpoints/points/mod.rs
+++ b/src/helix/endpoints/points/mod.rs
@@ -25,6 +25,7 @@ use crate::{
     types,
 };
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 
 pub mod create_custom_rewards;
 pub mod delete_custom_reward;

--- a/src/helix/endpoints/points/update_custom_reward.rs
+++ b/src/helix/endpoints/points/update_custom_reward.rs
@@ -69,18 +69,23 @@ use helix::RequestPatch;
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct UpdateCustomRewardRequest {
+pub struct UpdateCustomRewardRequest<'a> {
     /// Provided broadcaster_id must match the user_id in the auth token
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub broadcaster_id: types::UserId,
+    #[serde(borrow)]
+    pub broadcaster_id: &'a types::UserIdRef,
     /// ID of the Custom Reward to update, must match a Custom Reward on broadcaster_id’s channel.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub id: types::RewardId,
+    #[serde(borrow)]
+    pub id: &'a types::RewardIdRef,
 }
 
-impl UpdateCustomRewardRequest {
+impl<'a> UpdateCustomRewardRequest<'a> {
     /// Update a Custom Reward created on the broadcaster's channel
-    pub fn new(broadcaster_id: impl Into<types::UserId>, id: impl Into<types::RewardId>) -> Self {
+    pub fn new(
+        broadcaster_id: impl Into<&'a types::UserIdRef>,
+        id: impl Into<&'a types::RewardIdRef>,
+    ) -> Self {
         Self {
             broadcaster_id: broadcaster_id.into(),
             id: id.into(),
@@ -94,23 +99,23 @@ impl UpdateCustomRewardRequest {
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug, Default)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct UpdateCustomRewardBody {
+pub struct UpdateCustomRewardBody<'a> {
     /// The title of the reward
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", borrow)]
+    pub title: Option<&'a str>,
     /// The prompt for the viewer when they are redeeming the reward
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub prompt: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", borrow)]
+    pub prompt: Option<&'a str>,
     /// The cost of the reward
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cost: Option<usize>,
     /// Custom background color for the reward. Format: Hex with # prefix. Example: #00E5CB.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub background_color: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", borrow)]
+    pub background_color: Option<&'a str>,
     /// Is the reward currently enabled, if false the reward won’t show up to viewers
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -153,7 +158,7 @@ pub struct UpdateCustomRewardBody {
     pub should_redemptions_skip_request_queue: Option<bool>,
 }
 
-impl helix::private::SealedSerialize for UpdateCustomRewardBody {}
+impl helix::private::SealedSerialize for UpdateCustomRewardBody<'_> {}
 
 /// Return Values for [Update CustomReward](super::update_custom_reward)
 ///
@@ -166,7 +171,7 @@ pub enum UpdateCustomReward {
     Success(CustomReward),
 }
 
-impl Request for UpdateCustomRewardRequest {
+impl Request for UpdateCustomRewardRequest<'_> {
     type Response = UpdateCustomReward;
 
     const PATH: &'static str = "channel_points/custom_rewards";
@@ -175,8 +180,8 @@ impl Request for UpdateCustomRewardRequest {
         &[twitch_oauth2::Scope::ChannelManageRedemptions];
 }
 
-impl RequestPatch for UpdateCustomRewardRequest {
-    type Body = UpdateCustomRewardBody;
+impl<'a> RequestPatch for UpdateCustomRewardRequest<'a> {
+    type Body = UpdateCustomRewardBody<'a>;
 
     fn parse_inner_response(
         request: Option<Self>,

--- a/src/helix/endpoints/points/update_custom_reward.rs
+++ b/src/helix/endpoints/points/update_custom_reward.rs
@@ -7,14 +7,11 @@
 //!
 //! ## Request: [UpdateCustomRewardRequest]
 //!
-//! To use this endpoint, construct an [`UpdateCustomRewardRequest`] with the [`UpdateCustomRewardRequest::builder()`] method.
+//! To use this endpoint, construct an [`UpdateCustomRewardRequest`] with the [`UpdateCustomRewardRequest::new()`] method.
 //!
 //! ```rust
 //! use twitch_api::helix::points::update_custom_reward;
-//! let request = update_custom_reward::UpdateCustomRewardRequest::builder()
-//!     .broadcaster_id("274637212")
-//!     .id("reward-id")
-//!     .build();
+//! let request = update_custom_reward::UpdateCustomRewardRequest::new("274637212", "reward-id");
 //! ```
 //!
 //! ## Body: [UpdateCustomRewardBody]
@@ -23,10 +20,9 @@
 //!
 //! ```
 //! # use twitch_api::helix::points::update_custom_reward;
-//! let body = update_custom_reward::UpdateCustomRewardBody::builder()
-//!     .cost(501)
-//!     .title("hydrate but differently now!")
-//!     .build();
+//! let mut body = update_custom_reward::UpdateCustomRewardBody::default();
+//! body.cost = Some(501);
+//! body.title = Some("hydrate but differently now!".into());
 //! ```
 //!
 //! ## Response: [UpdateCustomReward]
@@ -43,14 +39,10 @@
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = update_custom_reward::UpdateCustomRewardRequest::builder()
-//!     .broadcaster_id("274637212")
-//!     .id("reward-id")
-//!     .build();
-//! let body = update_custom_reward::UpdateCustomRewardBody::builder()
-//!     .cost(501)
-//!     .title("hydrate but differently now!")
-//!     .build();
+//! let request = update_custom_reward::UpdateCustomRewardRequest::new("274637212", "reward-id");
+//! let mut body = update_custom_reward::UpdateCustomRewardBody::default();
+//! body.cost = Some(501);
+//! body.title = Some("hydrate but differently now!".into());
 //! let response: update_custom_reward::UpdateCustomReward = client.req_patch(request, body, &token).await?.data;
 //! # Ok(())
 //! # }
@@ -103,7 +95,7 @@ pub struct UpdateCustomRewardBody<'a> {
     /// The title of the reward
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(skip_serializing_if = "Option::is_none", borrow)]
-    pub title: Option<&'a str>,
+    pub title: Option<Cow<'a, str>>,
     /// The prompt for the viewer when they are redeeming the reward
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(skip_serializing_if = "Option::is_none", borrow)]
@@ -115,7 +107,7 @@ pub struct UpdateCustomRewardBody<'a> {
     /// Custom background color for the reward. Format: Hex with # prefix. Example: #00E5CB.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(skip_serializing_if = "Option::is_none", borrow)]
-    pub background_color: Option<&'a str>,
+    pub background_color: Option<Cow<'a, str>>,
     /// Is the reward currently enabled, if false the reward won’t show up to viewers
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/helix/endpoints/points/update_custom_reward.rs
+++ b/src/helix/endpoints/points/update_custom_reward.rs
@@ -25,7 +25,7 @@
 //! # use twitch_api::helix::points::update_custom_reward;
 //! let body = update_custom_reward::UpdateCustomRewardBody::builder()
 //!     .cost(501)
-//!     .title("hydrate but differently now!".to_string())
+//!     .title("hydrate but differently now!")
 //!     .build();
 //! ```
 //!
@@ -49,7 +49,7 @@
 //!     .build();
 //! let body = update_custom_reward::UpdateCustomRewardBody::builder()
 //!     .cost(501)
-//!     .title("hydrate but differently now!".to_string())
+//!     .title("hydrate but differently now!")
 //!     .build();
 //! let response: update_custom_reward::UpdateCustomReward = client.req_patch(request, body, &token).await?.data;
 //! # Ok(())

--- a/src/helix/endpoints/points/update_custom_reward.rs
+++ b/src/helix/endpoints/points/update_custom_reward.rs
@@ -73,22 +73,22 @@ pub struct UpdateCustomRewardRequest<'a> {
     /// Provided broadcaster_id must match the user_id in the auth token
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: &'a types::UserIdRef,
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
     /// ID of the Custom Reward to update, must match a Custom Reward on broadcaster_id’s channel.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub id: &'a types::RewardIdRef,
+    pub id: Cow<'a, types::RewardIdRef>,
 }
 
 impl<'a> UpdateCustomRewardRequest<'a> {
     /// Update a Custom Reward created on the broadcaster's channel
     pub fn new(
-        broadcaster_id: impl Into<&'a types::UserIdRef>,
-        id: impl Into<&'a types::RewardIdRef>,
+        broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
+        id: impl types::IntoCow<'a, types::RewardIdRef> + 'a,
     ) -> Self {
         Self {
-            broadcaster_id: broadcaster_id.into(),
-            id: id.into(),
+            broadcaster_id: broadcaster_id.to_cow(),
+            id: id.to_cow(),
         }
     }
 }

--- a/src/helix/endpoints/points/update_custom_reward.rs
+++ b/src/helix/endpoints/points/update_custom_reward.rs
@@ -99,7 +99,7 @@ pub struct UpdateCustomRewardBody<'a> {
     /// The prompt for the viewer when they are redeeming the reward
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(skip_serializing_if = "Option::is_none", borrow)]
-    pub prompt: Option<&'a str>,
+    pub prompt: Option<Cow<'a, str>>,
     /// The cost of the reward
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/src/helix/endpoints/points/update_redemption_status.rs
+++ b/src/helix/endpoints/points/update_redemption_status.rs
@@ -12,9 +12,9 @@
 //! ```rust
 //! use twitch_api::helix::points::UpdateRedemptionStatusRequest;
 //! let request = UpdateRedemptionStatusRequest::builder()
-//!     .broadcaster_id("274637212".to_string())
-//!     .reward_id("92af127c-7326-4483-a52b-b0da0be61c01".to_string())
-//!     .id("17fa2df1-ad76-4804-bfa5-a40ef63efe63".to_string())
+//!     .broadcaster_id("274637212")
+//!     .reward_id("92af127c-7326-4483-a52b-b0da0be61c01")
+//!     .id("17fa2df1-ad76-4804-bfa5-a40ef63efe63")
 //!     .build();
 //! ```
 //!
@@ -47,9 +47,9 @@
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
 //! let request = UpdateRedemptionStatusRequest::builder()
-//!     .broadcaster_id("274637212".to_string())
-//!     .reward_id("92af127c-7326-4483-a52b-b0da0be61c01".to_string())
-//!     .id("17fa2df1-ad76-4804-bfa5-a40ef63efe63".to_string())
+//!     .broadcaster_id("274637212")
+//!     .reward_id("92af127c-7326-4483-a52b-b0da0be61c01")
+//!     .id("17fa2df1-ad76-4804-bfa5-a40ef63efe63")
 //!     .build();
 //! let body = UpdateRedemptionStatusBody::builder()
 //!     .status(CustomRewardRedemptionStatus::Canceled)

--- a/src/helix/endpoints/points/update_redemption_status.rs
+++ b/src/helix/endpoints/points/update_redemption_status.rs
@@ -75,26 +75,29 @@ use helix::RequestPatch;
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct UpdateRedemptionStatusRequest {
+pub struct UpdateRedemptionStatusRequest<'a> {
     /// Provided broadcaster_id must match the user_id in the auth token.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub broadcaster_id: types::UserId,
+    #[serde(borrow)]
+    pub broadcaster_id: &'a types::UserIdRef,
 
     /// ID of the Custom Reward the redemptions to be updated are for.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub reward_id: types::RewardId,
+    #[serde(borrow)]
+    pub reward_id: &'a types::RewardIdRef,
 
     /// ID of the Custom Reward Redemption to update, must match a Custom Reward Redemption on broadcaster_id’s channel
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub id: types::RedemptionId,
+    #[serde(borrow)]
+    pub id: &'a types::RedemptionIdRef,
 }
 
-impl UpdateRedemptionStatusRequest {
+impl<'a> UpdateRedemptionStatusRequest<'a> {
     /// Update the status of Custom Reward Redemption object on a channel that are in the UNFULFILLED status.
     pub fn new(
-        broadcaster_id: impl Into<types::UserId>,
-        reward_id: impl Into<types::RewardId>,
-        id: impl Into<types::RedemptionId>,
+        broadcaster_id: impl Into<&'a types::UserIdRef>,
+        reward_id: impl Into<&'a types::RewardIdRef>,
+        id: impl Into<&'a types::RedemptionIdRef>,
     ) -> Self {
         Self {
             broadcaster_id: broadcaster_id.into(),
@@ -132,7 +135,7 @@ pub enum UpdateRedemptionStatusInformation {
     Success(CustomRewardRedemption),
 }
 
-impl Request for UpdateRedemptionStatusRequest {
+impl Request for UpdateRedemptionStatusRequest<'_> {
     type Response = UpdateRedemptionStatusInformation;
 
     const PATH: &'static str = "channel_points/custom_rewards/redemptions";
@@ -141,7 +144,7 @@ impl Request for UpdateRedemptionStatusRequest {
         &[twitch_oauth2::scopes::Scope::ChannelManageBroadcast];
 }
 
-impl RequestPatch for UpdateRedemptionStatusRequest {
+impl RequestPatch for UpdateRedemptionStatusRequest<'_> {
     type Body = UpdateRedemptionStatusBody;
 
     fn parse_inner_response(

--- a/src/helix/endpoints/points/update_redemption_status.rs
+++ b/src/helix/endpoints/points/update_redemption_status.rs
@@ -79,30 +79,30 @@ pub struct UpdateRedemptionStatusRequest<'a> {
     /// Provided broadcaster_id must match the user_id in the auth token.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: &'a types::UserIdRef,
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
 
     /// ID of the Custom Reward the redemptions to be updated are for.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub reward_id: &'a types::RewardIdRef,
+    pub reward_id: Cow<'a, types::RewardIdRef>,
 
     /// ID of the Custom Reward Redemption to update, must match a Custom Reward Redemption on broadcaster_id’s channel
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub id: &'a types::RedemptionIdRef,
+    pub id: Cow<'a, types::RedemptionIdRef>,
 }
 
 impl<'a> UpdateRedemptionStatusRequest<'a> {
     /// Update the status of Custom Reward Redemption object on a channel that are in the UNFULFILLED status.
     pub fn new(
-        broadcaster_id: impl Into<&'a types::UserIdRef>,
-        reward_id: impl Into<&'a types::RewardIdRef>,
-        id: impl Into<&'a types::RedemptionIdRef>,
+        broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
+        reward_id: impl types::IntoCow<'a, types::RewardIdRef> + 'a,
+        id: impl types::IntoCow<'a, types::RedemptionIdRef> + 'a,
     ) -> Self {
         Self {
-            broadcaster_id: broadcaster_id.into(),
-            reward_id: reward_id.into(),
-            id: id.into(),
+            broadcaster_id: broadcaster_id.to_cow(),
+            reward_id: reward_id.to_cow(),
+            id: id.to_cow(),
         }
     }
 }

--- a/src/helix/endpoints/points/update_redemption_status.rs
+++ b/src/helix/endpoints/points/update_redemption_status.rs
@@ -7,15 +7,15 @@
 //!
 //! ## Request: [UpdateRedemptionStatusRequest]
 //!
-//! To use this endpoint, construct a [`UpdateRedemptionStatusRequest`] with the [`UpdateRedemptionStatusRequest::builder()`] method.
+//! To use this endpoint, construct a [`UpdateRedemptionStatusRequest`] with the [`UpdateRedemptionStatusRequest::new()`] method.
 //!
 //! ```rust
 //! use twitch_api::helix::points::UpdateRedemptionStatusRequest;
-//! let request = UpdateRedemptionStatusRequest::builder()
-//!     .broadcaster_id("274637212")
-//!     .reward_id("92af127c-7326-4483-a52b-b0da0be61c01")
-//!     .id("17fa2df1-ad76-4804-bfa5-a40ef63efe63")
-//!     .build();
+//! let request = UpdateRedemptionStatusRequest::new(
+//!     "274637212",
+//!     "92af127c-7326-4483-a52b-b0da0be61c01",
+//!     "17fa2df1-ad76-4804-bfa5-a40ef63efe63",
+//! );
 //! ```
 //!
 //! ## Body: [UpdateRedemptionStatusBody]
@@ -24,9 +24,7 @@
 //!
 //! ```
 //! use twitch_api::helix::points::{CustomRewardRedemptionStatus, UpdateRedemptionStatusBody};
-//! let body = UpdateRedemptionStatusBody::builder()
-//!     .status(CustomRewardRedemptionStatus::Canceled)
-//!     .build();
+//! let body = UpdateRedemptionStatusBody::status(CustomRewardRedemptionStatus::Canceled);
 //! ```
 //!
 //! ## Response: [UpdateRedemptionStatusInformation]
@@ -46,14 +44,12 @@
 //!     helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = UpdateRedemptionStatusRequest::builder()
-//!     .broadcaster_id("274637212")
-//!     .reward_id("92af127c-7326-4483-a52b-b0da0be61c01")
-//!     .id("17fa2df1-ad76-4804-bfa5-a40ef63efe63")
-//!     .build();
-//! let body = UpdateRedemptionStatusBody::builder()
-//!     .status(CustomRewardRedemptionStatus::Canceled)
-//!     .build();
+//! let request = UpdateRedemptionStatusRequest::new(
+//!     "274637212",
+//!     "92af127c-7326-4483-a52b-b0da0be61c01",
+//!     "17fa2df1-ad76-4804-bfa5-a40ef63efe63",
+//! );
+//! let body = UpdateRedemptionStatusBody::status(CustomRewardRedemptionStatus::Canceled);
 //! let response: UpdateRedemptionStatusInformation =
 //!     client.req_patch(request, body, &token).await?.data;
 //! # Ok(())

--- a/src/helix/endpoints/polls/create_poll.rs
+++ b/src/helix/endpoints/polls/create_poll.rs
@@ -21,10 +21,12 @@
 //! let body = create_poll::CreatePollBody::builder()
 //!     .broadcaster_id("141981764")
 //!     .title("Heads or Tails?")
-//!     .choices(vec![
-//!         create_poll::NewPollChoice::new("Heads"),
-//!         create_poll::NewPollChoice::new("Tails"),
-//!     ])
+//!     .choices(
+//!         &[
+//!             create_poll::NewPollChoice::new("Heads"),
+//!             create_poll::NewPollChoice::new("Tails"),
+//!         ][..],
+//!     )
 //!     .channel_points_voting_enabled(true)
 //!     .channel_points_per_vote(100)
 //!     .duration(1800)
@@ -47,10 +49,11 @@
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
 //! let request = create_poll::CreatePollRequest::builder()
 //!     .build();
+//! let choices: &[create_poll::NewPollChoice] = &[create_poll::NewPollChoice::new("Heads"), create_poll::NewPollChoice::new("Tails")];
 //! let body = create_poll::CreatePollBody::builder()
 //!     .broadcaster_id("141981764")
 //!     .title("Heads or Tails?")
-//!     .choices(vec![create_poll::NewPollChoice::new("Heads"), create_poll::NewPollChoice::new("Tails")])
+//!     .choices(choices)
 //!     .channel_points_voting_enabled(true)
 //!     .channel_points_per_vote(100)
 //!     .duration(1800)
@@ -75,6 +78,7 @@ use helix::RequestPost;
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
 pub struct CreatePollRequest<'a> {
+    #[cfg_attr(feature = "typed-builder", builder(default))]
     #[serde(skip)]
     _marker: PhantomData<&'a ()>,
 }
@@ -102,6 +106,10 @@ pub struct CreatePollBody<'a> {
     /// Total duration for the poll (in seconds). Minimum: 15. Maximum: 1800.
     pub duration: i64,
     /// Array of the poll choices. Minimum: 2 choices. Maximum: 5 choices.
+    #[cfg_attr(
+        feature = "typed-builder",
+        builder(default_code = "Cow::Borrowed(&[])", setter(into))
+    )]
     #[serde(borrow)]
     pub choices: Cow<'a, [NewPollChoice<'a>]>,
     /// Indicates if Bits can be used for voting. Default: false

--- a/src/helix/endpoints/polls/create_poll.rs
+++ b/src/helix/endpoints/polls/create_poll.rs
@@ -92,7 +92,7 @@ pub struct CreatePollBody<'a> {
     /// Question displayed for the poll. Maximum: 60 characters.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub title: &'a str,
+    pub title: Cow<'a, str>,
     /// Total duration for the poll (in seconds). Minimum: 15. Maximum: 1800.
     pub duration: i64,
     /// Array of the poll choices. Minimum: 2 choices. Maximum: 5 choices.
@@ -136,13 +136,13 @@ impl<'a> CreatePollBody<'a> {
     /// Poll settings
     pub fn new(
         broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
-        title: &'a str,
+        title: impl Into<Cow<'a, str>>,
         duration: i64,
         choices: impl Into<Cow<'a, [NewPollChoice<'a>]>>,
     ) -> Self {
         Self {
             broadcaster_id: broadcaster_id.to_cow(),
-            title,
+            title: title.into(),
             duration,
             choices: choices.into(),
             bits_voting_enabled: Default::default(),
@@ -162,12 +162,12 @@ impl helix::private::SealedSerialize for CreatePollBody<'_> {}
 pub struct NewPollChoice<'a> {
     /// Text displayed for the choice. Maximum: 25 characters.
     #[serde(borrow)]
-    pub title: &'a str,
+    pub title: Cow<'a, str>,
 }
 
 impl<'a> NewPollChoice<'a> {
     /// Create a new [`NewPollChoice`]
-    pub fn new(title: impl Into<&'a str>) -> Self {
+    pub fn new(title: impl Into<Cow<'a, str>>) -> Self {
         Self {
             title: title.into(),
         }

--- a/src/helix/endpoints/polls/create_poll.rs
+++ b/src/helix/endpoints/polls/create_poll.rs
@@ -17,20 +17,14 @@
 //! We also need to provide a body to the request containing what we want to change.
 //!
 //! ```
-//! # use twitch_api::helix::polls::create_poll;
-//! let body = create_poll::CreatePollBody::builder()
-//!     .broadcaster_id("141981764")
-//!     .title("Heads or Tails?")
-//!     .choices(
-//!         &[
-//!             create_poll::NewPollChoice::new("Heads"),
-//!             create_poll::NewPollChoice::new("Tails"),
-//!         ][..],
-//!     )
-//!     .channel_points_voting_enabled(true)
-//!     .channel_points_per_vote(100)
-//!     .duration(1800)
-//!     .build();
+//! use twitch_api::helix::polls::create_poll;
+//! let choices: &[create_poll::NewPollChoice] = &[
+//!     create_poll::NewPollChoice::new("Heads"),
+//!     create_poll::NewPollChoice::new("Tails"),
+//! ];
+//! let mut body = create_poll::CreatePollBody::new("141981764", "Heads or Tails?", 1800, choices);
+//! body.channel_points_voting_enabled = Some(true);
+//! body.channel_points_per_vote = Some(100);
 //! ```
 //!
 //! ## Response: [CreatePollResponse]
@@ -47,17 +41,14 @@
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = create_poll::CreatePollRequest::builder()
-//!     .build();
-//! let choices: &[create_poll::NewPollChoice] = &[create_poll::NewPollChoice::new("Heads"), create_poll::NewPollChoice::new("Tails")];
-//! let body = create_poll::CreatePollBody::builder()
-//!     .broadcaster_id("141981764")
-//!     .title("Heads or Tails?")
-//!     .choices(choices)
-//!     .channel_points_voting_enabled(true)
-//!     .channel_points_per_vote(100)
-//!     .duration(1800)
-//!     .build();
+//! let request = create_poll::CreatePollRequest::new();
+//! let choices: &[create_poll::NewPollChoice] = &[
+//!     create_poll::NewPollChoice::new("Heads"),
+//!     create_poll::NewPollChoice::new("Tails"),
+//! ];
+//! let mut body = create_poll::CreatePollBody::new("141981764", "Heads or Tails?", 1800, choices);
+//! body.channel_points_voting_enabled = Some(true);
+//! body.channel_points_per_vote = Some(100);
 //! let response: create_poll::CreatePollResponse = client.req_post(request, body, &token).await?.data;
 //! # Ok(())
 //! # }

--- a/src/helix/endpoints/polls/create_poll.rs
+++ b/src/helix/endpoints/polls/create_poll.rs
@@ -66,11 +66,10 @@
 //! You can also get the [`http::Request`] with [`request.create_request(&token, &client_id)`](helix::RequestPost::create_request)
 //! and parse the [`http::Response`] with [`CreatePollRequest::parse_response(None, &request.get_uri(), response)`](CreatePollRequest::parse_response)
 
-use std::borrow::Cow;
-use std::marker::PhantomData;
-
 use super::*;
 use helix::RequestPost;
+use std::marker::PhantomData;
+
 /// Query Parameters for [Create Poll](super::create_poll)
 ///
 /// [`create-poll`](https://dev.twitch.tv/docs/api/reference#create-poll)
@@ -98,7 +97,7 @@ pub struct CreatePollBody<'a> {
     /// The broadcaster running polls. Provided broadcaster_id must match the user_id in the user OAuth token.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: &'a types::UserIdRef,
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
     /// Question displayed for the poll. Maximum: 60 characters.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
@@ -145,13 +144,13 @@ impl<'a> CreatePollBody<'a> {
 
     /// Poll settings
     pub fn new(
-        broadcaster_id: impl Into<&'a types::UserIdRef>,
+        broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
         title: &'a str,
         duration: i64,
         choices: impl Into<Cow<'a, [NewPollChoice<'a>]>>,
     ) -> Self {
         Self {
-            broadcaster_id: broadcaster_id.into(),
+            broadcaster_id: broadcaster_id.to_cow(),
             title,
             duration,
             choices: choices.into(),

--- a/src/helix/endpoints/polls/end_poll.rs
+++ b/src/helix/endpoints/polls/end_poll.rs
@@ -19,11 +19,11 @@
 //!
 //! ```
 //! # use twitch_api::helix::polls::end_poll;
-//! let body = end_poll::EndPollBody::builder()
-//!     .broadcaster_id("274637212")
-//!     .id("92af127c-7326-4483-a52b-b0da0be61c01")
-//!     .status(end_poll::PollStatus::Terminated)
-//!     .build();
+//! let body = end_poll::EndPollBody::new(
+//!     "274637212",
+//!     "92af127c-7326-4483-a52b-b0da0be61c01",
+//!     end_poll::PollStatus::Terminated,
+//! );
 //! ```
 //!
 //! ## Response: [EndPoll]
@@ -41,11 +41,11 @@
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
 //! let request = end_poll::EndPollRequest::new();
-//! let body = end_poll::EndPollBody::builder()
-//!     .broadcaster_id("274637212")
-//!     .id("92af127c-7326-4483-a52b-b0da0be61c01")
-//!     .status(end_poll::PollStatus::Terminated)
-//!     .build();
+//! let body = end_poll::EndPollBody::new(
+//!     "274637212",
+//!     "92af127c-7326-4483-a52b-b0da0be61c01",
+//!     end_poll::PollStatus::Terminated,
+//! );
 //! let response: end_poll::EndPoll = client.req_patch(request, body, &token).await?.data;
 //! # Ok(())
 //! # }

--- a/src/helix/endpoints/polls/end_poll.rs
+++ b/src/helix/endpoints/polls/end_poll.rs
@@ -87,11 +87,11 @@ pub struct EndPollBody<'a> {
     /// The broadcaster running polls. Provided broadcaster_id must match the user_id in the user OAuth token.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: &'a types::UserIdRef,
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
     /// ID of the poll.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub id: &'a types::PollIdRef,
+    pub id: Cow<'a, types::PollIdRef>,
     /// The poll status to be set.
     ///
     /// Valid values:
@@ -103,13 +103,13 @@ pub struct EndPollBody<'a> {
 impl<'a> EndPollBody<'a> {
     /// End a poll that is currently active.
     pub fn new(
-        broadcaster_id: impl Into<&'a types::UserIdRef>,
-        id: impl Into<&'a types::PollIdRef>,
+        broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
+        id: impl types::IntoCow<'a, types::PollIdRef> + 'a,
         status: PollStatus,
     ) -> Self {
         Self {
-            broadcaster_id: broadcaster_id.into(),
-            id: id.into(),
+            broadcaster_id: broadcaster_id.to_cow(),
+            id: id.to_cow(),
             status,
         }
     }

--- a/src/helix/endpoints/polls/get_polls.rs
+++ b/src/helix/endpoints/polls/get_polls.rs
@@ -39,7 +39,6 @@
 
 use super::*;
 use helix::RequestGet;
-use std::borrow::Cow;
 pub use types::{PollChoice, PollStatus};
 
 /// Query Parameters for [Get polls](super::get_polls)
@@ -52,7 +51,7 @@ pub struct GetPollsRequest<'a> {
     /// The broadcaster running polls. Provided broadcaster_id must match the user_id in the user OAuth token.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: &'a types::UserIdRef,
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
     /// ID of a poll. Filters results to one or more specific polls. Not providing one or more IDs will return the full list of polls for the authenticated channel.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(borrow)]
@@ -67,9 +66,9 @@ pub struct GetPollsRequest<'a> {
 
 impl<'a> GetPollsRequest<'a> {
     /// The broadcaster running polls.
-    pub fn broadcaster_id(broadcaster_id: impl Into<&'a types::UserIdRef>) -> Self {
+    pub fn broadcaster_id(broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a) -> Self {
         Self {
-            broadcaster_id: broadcaster_id.into(),
+            broadcaster_id: broadcaster_id.to_cow(),
             id: Default::default(),
             after: Default::default(),
             first: Default::default(),

--- a/src/helix/endpoints/polls/get_polls.rs
+++ b/src/helix/endpoints/polls/get_polls.rs
@@ -7,10 +7,8 @@
 //!
 //! ```rust
 //! use twitch_api::helix::polls::get_polls;
-//! let request = get_polls::GetPollsRequest::builder()
-//!     .id(vec!["ed961efd-8a3f-4cf5-a9d0-e616c590cd2a".into()])
-//!     .broadcaster_id("1234")
-//!     .build();
+//! let request = get_polls::GetPollsRequest::broadcaster_id("1234")
+//!     .ids(vec!["ed961efd-8a3f-4cf5-a9d0-e616c590cd2a".into()]);
 //! ```
 //!
 //! ## Response: [Poll]
@@ -25,10 +23,8 @@
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = get_polls::GetPollsRequest::builder()
-//!     .id(vec!["ed961efd-8a3f-4cf5-a9d0-e616c590cd2a".into()])
-//!     .broadcaster_id("1234")
-//!     .build();
+//! let request = get_polls::GetPollsRequest::broadcaster_id("1234")
+//!     .ids(vec!["ed961efd-8a3f-4cf5-a9d0-e616c590cd2a".into()]);
 //! let response: Vec<get_polls::Poll> = client.req_get(request, &token).await?.data;
 //! # Ok(())
 //! # }

--- a/src/helix/endpoints/polls/get_polls.rs
+++ b/src/helix/endpoints/polls/get_polls.rs
@@ -54,7 +54,7 @@ pub struct GetPollsRequest<'a> {
     pub id: Cow<'a, [&'a types::PollIdRef]>,
     /// Cursor for forward pagination
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
-    pub after: Option<helix::Cursor>,
+    pub after: Option<Cow<'a, helix::CursorRef>>,
     /// Maximum number of objects to return. Maximum: 20. Default: 20.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     pub first: Option<usize>,
@@ -128,7 +128,9 @@ impl Request for GetPollsRequest<'_> {
 impl RequestGet for GetPollsRequest<'_> {}
 
 impl helix::Paginated for GetPollsRequest<'_> {
-    fn set_pagination(&mut self, cursor: Option<helix::Cursor>) { self.after = cursor; }
+    fn set_pagination(&mut self, cursor: Option<helix::Cursor>) {
+        self.after = cursor.map(|c| c.into_cow())
+    }
 }
 
 #[cfg(test)]

--- a/src/helix/endpoints/polls/mod.rs
+++ b/src/helix/endpoints/polls/mod.rs
@@ -6,6 +6,7 @@ use crate::{
     types,
 };
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 
 pub mod create_poll;
 pub mod end_poll;

--- a/src/helix/endpoints/predictions/create_prediction.rs
+++ b/src/helix/endpoints/predictions/create_prediction.rs
@@ -20,15 +20,12 @@
 //!
 //! ```
 //! # use twitch_api::helix::predictions::create_prediction;
-//! let body = create_prediction::CreatePredictionBody::builder()
-//!     .broadcaster_id("141981764")
-//!     .title("Any leeks in the stream?")
-//!     .outcomes(create_prediction::NewPredictionOutcome::new_tuple(
-//!         "Yes, give it time.",
-//!         "Definitely not.",
-//!     ))
-//!     .prediction_window(120)
-//!     .build();
+//! let body = create_prediction::CreatePredictionBody::new(
+//!     "141981764",
+//!     "Any leeks in the stream?",
+//!     create_prediction::NewPredictionOutcome::new_tuple("Yes, give it time.", "Definitely not."),
+//!     120,
+//! );
 //! ```
 //!
 //! ## Response: [CreatePredictionResponse]
@@ -45,14 +42,13 @@
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = create_prediction::CreatePredictionRequest::builder()
-//!     .build();
-//! let body = create_prediction::CreatePredictionBody::builder()
-//!     .broadcaster_id("141981764")
-//!     .title("Any leeks in the stream?")
-//!     .outcomes(create_prediction::NewPredictionOutcome::new_tuple("Yes, give it time.", "Definitely not."))
-//!     .prediction_window(120)
-//!     .build();
+//! let request = create_prediction::CreatePredictionRequest::new();
+//! let body = create_prediction::CreatePredictionBody::new(
+//!     "141981764",
+//!     "Any leeks in the stream?",
+//!     create_prediction::NewPredictionOutcome::new_tuple("Yes, give it time.", "Definitely not."),
+//!     120,
+//! );
 //! let response: create_prediction::CreatePredictionResponse = client.req_post(request, body, &token).await?.data;
 //! # Ok(())
 //! # }

--- a/src/helix/endpoints/predictions/create_prediction.rs
+++ b/src/helix/endpoints/predictions/create_prediction.rs
@@ -61,6 +61,8 @@
 //! You can also get the [`http::Request`] with [`request.create_request(&token, &client_id)`](helix::RequestPost::create_request)
 //! and parse the [`http::Response`] with [`CreatePredictionRequest::parse_response(None, &request.get_uri(), response)`](CreatePredictionRequest::parse_response)
 
+use std::marker::PhantomData;
+
 use super::*;
 use helix::RequestPost;
 
@@ -70,11 +72,14 @@ use helix::RequestPost;
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug, Default)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct CreatePredictionRequest {}
+pub struct CreatePredictionRequest<'a> {
+    #[serde(skip)]
+    _marker: PhantomData<&'a ()>,
+}
 
-impl CreatePredictionRequest {
+impl CreatePredictionRequest<'_> {
     /// Create a new [`CreatePredictionRequest`]
-    pub fn new() -> Self { Self {} }
+    pub fn new() -> Self { Self::default() }
 }
 
 /// Body Parameters for [Create Prediction](super::create_prediction)
@@ -83,25 +88,27 @@ impl CreatePredictionRequest {
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct CreatePredictionBody {
+pub struct CreatePredictionBody<'a> {
     /// The broadcaster running Predictions. Provided broadcaster_id must match the user_id in the user OAuth token.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub broadcaster_id: types::UserId,
+    #[serde(borrow)]
+    pub broadcaster_id: &'a types::UserIdRef,
     /// Title for the Prediction. Maximum: 45 characters.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub title: String,
+    #[serde(borrow)]
+    pub title: &'a str,
     /// Array of outcome objects with titles for the Prediction. Array size must be 2.
-    pub outcomes: (NewPredictionOutcome, NewPredictionOutcome),
+    pub outcomes: (NewPredictionOutcome<'a>, NewPredictionOutcome<'a>),
     /// Total duration for the Prediction (in seconds). Minimum: 1. Maximum: 1800.
     pub prediction_window: i64,
 }
 
-impl CreatePredictionBody {
+impl<'a> CreatePredictionBody<'a> {
     /// Create a Channel Points Prediction for a specific Twitch channel.
     pub fn new(
-        broadcaster_id: impl Into<types::UserId>,
-        title: String,
-        outcomes: (NewPredictionOutcome, NewPredictionOutcome),
+        broadcaster_id: impl Into<&'a types::UserIdRef>,
+        title: &'a str,
+        outcomes: (NewPredictionOutcome<'a>, NewPredictionOutcome<'a>),
         prediction_window: i64,
     ) -> Self {
         Self {
@@ -113,27 +120,28 @@ impl CreatePredictionBody {
     }
 }
 
-impl helix::private::SealedSerialize for CreatePredictionBody {}
+impl helix::private::SealedSerialize for CreatePredictionBody<'_> {}
 
 /// Choice settings for a poll
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct NewPredictionOutcome {
+pub struct NewPredictionOutcome<'a> {
     /// Text displayed for the choice. Maximum: 25 characters.
-    pub title: String,
+    #[serde(borrow)]
+    pub title: &'a str,
 }
 
-impl NewPredictionOutcome {
+impl<'a> NewPredictionOutcome<'a> {
     /// Create a new [`NewPredictionOutcome`]
-    pub fn new(title: impl Into<String>) -> Self {
+    pub fn new(title: impl Into<&'a str>) -> Self {
         Self {
             title: title.into(),
         }
     }
 
     /// Create a two new [`NewPredictionOutcome`]s
-    pub fn new_tuple(blue: impl Into<String>, pink: impl Into<String>) -> (Self, Self) {
+    pub fn new_tuple(blue: impl Into<&'a str>, pink: impl Into<&'a str>) -> (Self, Self) {
         (Self::new(blue), Self::new(pink))
     }
 }
@@ -143,7 +151,7 @@ impl NewPredictionOutcome {
 /// [`create-prediction`](https://dev.twitch.tv/docs/api/reference#create-prediction)
 pub type CreatePredictionResponse = super::Prediction;
 
-impl Request for CreatePredictionRequest {
+impl Request for CreatePredictionRequest<'_> {
     type Response = CreatePredictionResponse;
 
     const PATH: &'static str = "predictions";
@@ -152,8 +160,8 @@ impl Request for CreatePredictionRequest {
         &[twitch_oauth2::Scope::ChannelManagePredictions];
 }
 
-impl RequestPost for CreatePredictionRequest {
-    type Body = CreatePredictionBody;
+impl<'a> RequestPost for CreatePredictionRequest<'a> {
+    type Body = CreatePredictionBody<'a>;
 
     fn parse_inner_response(
         request: Option<Self>,
@@ -199,7 +207,7 @@ fn test_request() {
 
     let body = CreatePredictionBody::new(
         "141981764",
-        "Any leeks in the stream?".to_owned(),
+        "Any leeks in the stream?",
         NewPredictionOutcome::new_tuple("Yes, give it time.", "Definitely not."),
         120,
     );

--- a/src/helix/endpoints/predictions/create_prediction.rs
+++ b/src/helix/endpoints/predictions/create_prediction.rs
@@ -73,6 +73,7 @@ use helix::RequestPost;
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
 pub struct CreatePredictionRequest<'a> {
+    #[cfg_attr(feature = "typed-builder", builder(default))]
     #[serde(skip)]
     _marker: PhantomData<&'a ()>,
 }

--- a/src/helix/endpoints/predictions/create_prediction.rs
+++ b/src/helix/endpoints/predictions/create_prediction.rs
@@ -93,7 +93,7 @@ pub struct CreatePredictionBody<'a> {
     /// The broadcaster running Predictions. Provided broadcaster_id must match the user_id in the user OAuth token.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: &'a types::UserIdRef,
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
     /// Title for the Prediction. Maximum: 45 characters.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
@@ -107,13 +107,13 @@ pub struct CreatePredictionBody<'a> {
 impl<'a> CreatePredictionBody<'a> {
     /// Create a Channel Points Prediction for a specific Twitch channel.
     pub fn new(
-        broadcaster_id: impl Into<&'a types::UserIdRef>,
+        broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
         title: &'a str,
         outcomes: (NewPredictionOutcome<'a>, NewPredictionOutcome<'a>),
         prediction_window: i64,
     ) -> Self {
         Self {
-            broadcaster_id: broadcaster_id.into(),
+            broadcaster_id: broadcaster_id.to_cow(),
             title,
             outcomes,
             prediction_window,

--- a/src/helix/endpoints/predictions/create_prediction.rs
+++ b/src/helix/endpoints/predictions/create_prediction.rs
@@ -93,7 +93,7 @@ pub struct CreatePredictionBody<'a> {
     /// Title for the Prediction. Maximum: 45 characters.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub title: &'a str,
+    pub title: Cow<'a, str>,
     /// Array of outcome objects with titles for the Prediction. Array size must be 2.
     pub outcomes: (NewPredictionOutcome<'a>, NewPredictionOutcome<'a>),
     /// Total duration for the Prediction (in seconds). Minimum: 1. Maximum: 1800.
@@ -104,13 +104,13 @@ impl<'a> CreatePredictionBody<'a> {
     /// Create a Channel Points Prediction for a specific Twitch channel.
     pub fn new(
         broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
-        title: &'a str,
+        title: impl Into<Cow<'a, str>>,
         outcomes: (NewPredictionOutcome<'a>, NewPredictionOutcome<'a>),
         prediction_window: i64,
     ) -> Self {
         Self {
             broadcaster_id: broadcaster_id.to_cow(),
-            title,
+            title: title.into(),
             outcomes,
             prediction_window,
         }
@@ -126,19 +126,19 @@ impl helix::private::SealedSerialize for CreatePredictionBody<'_> {}
 pub struct NewPredictionOutcome<'a> {
     /// Text displayed for the choice. Maximum: 25 characters.
     #[serde(borrow)]
-    pub title: &'a str,
+    pub title: Cow<'a, str>,
 }
 
 impl<'a> NewPredictionOutcome<'a> {
     /// Create a new [`NewPredictionOutcome`]
-    pub fn new(title: impl Into<&'a str>) -> Self {
+    pub fn new(title: impl Into<Cow<'a, str>>) -> Self {
         Self {
             title: title.into(),
         }
     }
 
     /// Create a two new [`NewPredictionOutcome`]s
-    pub fn new_tuple(blue: impl Into<&'a str>, pink: impl Into<&'a str>) -> (Self, Self) {
+    pub fn new_tuple(blue: impl Into<Cow<'a, str>>, pink: impl Into<Cow<'a, str>>) -> (Self, Self) {
         (Self::new(blue), Self::new(pink))
     }
 }

--- a/src/helix/endpoints/predictions/end_prediction.rs
+++ b/src/helix/endpoints/predictions/end_prediction.rs
@@ -54,6 +54,8 @@
 //! You can also get the [`http::Request`] with [`request.create_request(&token, &client_id)`](helix::RequestPost::create_request)
 //! and parse the [`http::Response`] with [`EndPredictionRequest::parse_response(None, &request.get_uri(), response)`](EndPredictionRequest::parse_response)
 
+use std::marker::PhantomData;
+
 use crate::helix::{parse_json, HelixRequestPatchError};
 
 use super::*;
@@ -64,11 +66,14 @@ use helix::RequestPatch;
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug, Default)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct EndPredictionRequest {}
+pub struct EndPredictionRequest<'a> {
+    #[serde(skip)]
+    _marker: PhantomData<&'a ()>,
+}
 
-impl EndPredictionRequest {
+impl EndPredictionRequest<'_> {
     /// Make a new [`EndPredictionRequest`]
-    pub fn new() -> Self { Self {} }
+    pub fn new() -> Self { Self::default() }
 }
 
 /// Body Parameters for [End Prediction](super::end_prediction)
@@ -77,13 +82,15 @@ impl EndPredictionRequest {
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct EndPredictionBody {
+pub struct EndPredictionBody<'a> {
     /// The broadcaster running predictions. Provided broadcaster_id must match the user_id in the user OAuth token.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub broadcaster_id: types::UserId,
+    #[serde(borrow)]
+    pub broadcaster_id: &'a types::UserIdRef,
     /// ID of the prediction.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub id: types::PredictionId,
+    #[serde(borrow)]
+    pub id: &'a types::PredictionIdRef,
     /// The Prediction status to be set. Valid values:
     ///
     /// [`RESOLVED`](types::PredictionStatus): A winning outcome has been chosen and the Channel Points have been distributed to the users who predicted the correct outcome.
@@ -92,14 +99,15 @@ pub struct EndPredictionBody {
     pub status: types::PredictionStatus,
     /// ID of the winning outcome for the Prediction. This parameter is required if status is being set to [`RESOLVED`](types::PredictionStatus).
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
-    pub winning_outcome_id: Option<types::PredictionId>,
+    #[serde(borrow)]
+    pub winning_outcome_id: Option<&'a types::PredictionIdRef>,
 }
 
-impl EndPredictionBody {
+impl<'a> EndPredictionBody<'a> {
     /// End given prediction that is currently active.
     pub fn new(
-        broadcaster_id: impl Into<types::UserId>,
-        id: impl Into<types::PredictionId>,
+        broadcaster_id: impl Into<&'a types::UserIdRef>,
+        id: impl Into<&'a types::PredictionIdRef>,
         status: impl Into<types::PredictionStatus>,
     ) -> Self {
         Self {
@@ -115,14 +123,14 @@ impl EndPredictionBody {
     /// This parameter is required if status is being set to [`RESOLVED`](types::PredictionStatus).
     pub fn winning_outcome_id(
         mut self,
-        winning_outcome_id: impl Into<types::PredictionId>,
+        winning_outcome_id: impl Into<&'a types::PredictionIdRef>,
     ) -> Self {
         self.winning_outcome_id = Some(winning_outcome_id.into());
         self
     }
 }
 
-impl helix::private::SealedSerialize for EndPredictionBody {}
+impl helix::private::SealedSerialize for EndPredictionBody<'_> {}
 
 /// Return Values for [Update CustomReward](super::end_prediction)
 ///
@@ -140,7 +148,7 @@ pub enum EndPrediction {
     AuthFailed,
 }
 
-impl Request for EndPredictionRequest {
+impl Request for EndPredictionRequest<'_> {
     type Response = EndPrediction;
 
     const PATH: &'static str = "predictions";
@@ -149,8 +157,8 @@ impl Request for EndPredictionRequest {
         &[twitch_oauth2::Scope::ChannelManagePredictions];
 }
 
-impl RequestPatch for EndPredictionRequest {
-    type Body = EndPredictionBody;
+impl<'a> RequestPatch for EndPredictionRequest<'a> {
+    type Body = EndPredictionBody<'a>;
 
     fn parse_inner_response(
         request: Option<Self>,

--- a/src/helix/endpoints/predictions/end_prediction.rs
+++ b/src/helix/endpoints/predictions/end_prediction.rs
@@ -86,11 +86,11 @@ pub struct EndPredictionBody<'a> {
     /// The broadcaster running predictions. Provided broadcaster_id must match the user_id in the user OAuth token.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: &'a types::UserIdRef,
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
     /// ID of the prediction.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub id: &'a types::PredictionIdRef,
+    pub id: Cow<'a, types::PredictionIdRef>,
     /// The Prediction status to be set. Valid values:
     ///
     /// [`RESOLVED`](types::PredictionStatus): A winning outcome has been chosen and the Channel Points have been distributed to the users who predicted the correct outcome.
@@ -100,19 +100,19 @@ pub struct EndPredictionBody<'a> {
     /// ID of the winning outcome for the Prediction. This parameter is required if status is being set to [`RESOLVED`](types::PredictionStatus).
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(borrow)]
-    pub winning_outcome_id: Option<&'a types::PredictionIdRef>,
+    pub winning_outcome_id: Option<Cow<'a, types::PredictionIdRef>>,
 }
 
 impl<'a> EndPredictionBody<'a> {
     /// End given prediction that is currently active.
     pub fn new(
-        broadcaster_id: impl Into<&'a types::UserIdRef>,
-        id: impl Into<&'a types::PredictionIdRef>,
+        broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
+        id: impl types::IntoCow<'a, types::PredictionIdRef> + 'a,
         status: impl Into<types::PredictionStatus>,
     ) -> Self {
         Self {
-            broadcaster_id: broadcaster_id.into(),
-            id: id.into(),
+            broadcaster_id: broadcaster_id.to_cow(),
+            id: id.to_cow(),
             status: status.into(),
             winning_outcome_id: None,
         }
@@ -123,9 +123,9 @@ impl<'a> EndPredictionBody<'a> {
     /// This parameter is required if status is being set to [`RESOLVED`](types::PredictionStatus).
     pub fn winning_outcome_id(
         mut self,
-        winning_outcome_id: impl Into<&'a types::PredictionIdRef>,
+        winning_outcome_id: impl types::IntoCow<'a, types::PredictionIdRef> + 'a,
     ) -> Self {
-        self.winning_outcome_id = Some(winning_outcome_id.into());
+        self.winning_outcome_id = Some(winning_outcome_id.to_cow());
         self
     }
 }

--- a/src/helix/endpoints/predictions/get_predictions.rs
+++ b/src/helix/endpoints/predictions/get_predictions.rs
@@ -39,6 +39,7 @@
 
 use super::*;
 use helix::RequestGet;
+use std::borrow::Cow;
 pub use types::{PredictionOutcome, PredictionOutcomeId, PredictionStatus};
 
 /// Query Parameters for [Get predictions](super::get_predictions)
@@ -47,16 +48,18 @@ pub use types::{PredictionOutcome, PredictionOutcomeId, PredictionStatus};
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct GetPredictionsRequest {
+pub struct GetPredictionsRequest<'a> {
     /// The broadcaster running Predictions. Provided broadcaster_id must match the user_id in the user OAuth token.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub broadcaster_id: types::UserId,
+    #[serde(borrow)]
+    pub broadcaster_id: &'a types::UserIdRef,
     /// ID of a Prediction. Filters results to one or more specific Predictions.
     /// Not providing one or more IDs will return the full list of Predictions for the authenticated channel.
     ///
     /// Maximum: 100
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
-    pub id: Vec<types::PredictionId>,
+    #[serde(borrow)]
+    pub id: Cow<'a, [&'a types::PredictionIdRef]>,
     /// Cursor for forward pagination
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     pub after: Option<helix::Cursor>,
@@ -65,26 +68,20 @@ pub struct GetPredictionsRequest {
     pub first: Option<usize>,
 }
 
-impl GetPredictionsRequest {
+impl<'a> GetPredictionsRequest<'a> {
     /// Get information about predictions for this broadcasters channel.
-    pub fn broadcaster_id(broadcaster_id: impl Into<types::UserId>) -> Self {
+    pub fn broadcaster_id(broadcaster_id: impl Into<&'a types::UserIdRef>) -> Self {
         Self {
             broadcaster_id: broadcaster_id.into(),
-            id: Default::default(),
+            id: Cow::Borrowed(&[]),
             after: Default::default(),
             first: Default::default(),
         }
     }
 
-    /// ID of a Prediction.
-    pub fn id(mut self, id: impl Into<types::PredictionId>) -> Self {
-        self.id = vec![id.into()];
-        self
-    }
-
     /// IDs of a Predictions.
-    pub fn ids(mut self, ids: impl IntoIterator<Item = impl Into<types::PredictionId>>) -> Self {
-        self.id = ids.into_iter().map(Into::into).collect();
+    pub fn ids(mut self, ids: impl Into<Cow<'a, [&'a types::PredictionIdRef]>>) -> Self {
+        self.id = ids.into();
         self
     }
 }
@@ -122,7 +119,7 @@ pub struct Prediction {
     pub locked_at: Option<types::Timestamp>,
 }
 
-impl Request for GetPredictionsRequest {
+impl Request for GetPredictionsRequest<'_> {
     type Response = Vec<Prediction>;
 
     const PATH: &'static str = "predictions";
@@ -130,9 +127,9 @@ impl Request for GetPredictionsRequest {
     const SCOPE: &'static [twitch_oauth2::Scope] = &[twitch_oauth2::Scope::ChannelReadPredictions];
 }
 
-impl RequestGet for GetPredictionsRequest {}
+impl RequestGet for GetPredictionsRequest<'_> {}
 
-impl helix::Paginated for GetPredictionsRequest {
+impl helix::Paginated for GetPredictionsRequest<'_> {
     fn set_pagination(&mut self, cursor: Option<helix::Cursor>) { self.after = cursor; }
 }
 
@@ -140,8 +137,9 @@ impl helix::Paginated for GetPredictionsRequest {
 #[test]
 fn test_request() {
     use helix::*;
+
     let req = GetPredictionsRequest::broadcaster_id("55696719")
-        .id("d6676d5c-c86e-44d2-bfc4-100fb48f0656");
+        .ids(vec!["d6676d5c-c86e-44d2-bfc4-100fb48f0656".into()]);
 
     // From twitch docs
     let data = br#"

--- a/src/helix/endpoints/predictions/get_predictions.rs
+++ b/src/helix/endpoints/predictions/get_predictions.rs
@@ -39,7 +39,6 @@
 
 use super::*;
 use helix::RequestGet;
-use std::borrow::Cow;
 pub use types::{PredictionOutcome, PredictionOutcomeId, PredictionStatus};
 
 /// Query Parameters for [Get predictions](super::get_predictions)
@@ -52,7 +51,7 @@ pub struct GetPredictionsRequest<'a> {
     /// The broadcaster running Predictions. Provided broadcaster_id must match the user_id in the user OAuth token.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: &'a types::UserIdRef,
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
     /// ID of a Prediction. Filters results to one or more specific Predictions.
     /// Not providing one or more IDs will return the full list of Predictions for the authenticated channel.
     ///
@@ -70,9 +69,9 @@ pub struct GetPredictionsRequest<'a> {
 
 impl<'a> GetPredictionsRequest<'a> {
     /// Get information about predictions for this broadcasters channel.
-    pub fn broadcaster_id(broadcaster_id: impl Into<&'a types::UserIdRef>) -> Self {
+    pub fn broadcaster_id(broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a) -> Self {
         Self {
-            broadcaster_id: broadcaster_id.into(),
+            broadcaster_id: broadcaster_id.to_cow(),
             id: Cow::Borrowed(&[]),
             after: Default::default(),
             first: Default::default(),

--- a/src/helix/endpoints/predictions/get_predictions.rs
+++ b/src/helix/endpoints/predictions/get_predictions.rs
@@ -3,14 +3,12 @@
 //!
 //! ## Request: [GetPredictionsRequest]
 //!
-//! To use this endpoint, construct a [`GetPredictionsRequest`] with the [`GetPredictionsRequest::builder()`] method.
+//! To use this endpoint, construct a [`GetPredictionsRequest`] with the [`GetPredictionsRequest::broadcaster_id()`] method.
 //!
 //! ```rust
 //! use twitch_api::helix::predictions::get_predictions;
-//! let request = get_predictions::GetPredictionsRequest::builder()
-//!     .id(vec!["ed961efd-8a3f-4cf5-a9d0-e616c590cd2a".into()])
-//!     .broadcaster_id("1234")
-//!     .build();
+//! let request = get_predictions::GetPredictionsRequest::broadcaster_id("1234")
+//!     .ids(vec!["ed961efd-8a3f-4cf5-a9d0-e616c590cd2a".into()]);
 //! ```
 //!
 //! ## Response: [Prediction]
@@ -25,10 +23,8 @@
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = get_predictions::GetPredictionsRequest::builder()
-//!     .id(vec!["ed961efd-8a3f-4cf5-a9d0-e616c590cd2a".into()])
-//!     .broadcaster_id("1234")
-//!     .build();
+//! let request = get_predictions::GetPredictionsRequest::broadcaster_id("1234")
+//!     .ids(vec!["ed961efd-8a3f-4cf5-a9d0-e616c590cd2a".into()]);
 //! let response: Vec<get_predictions::Prediction> = client.req_get(request, &token).await?.data;
 //! # Ok(())
 //! # }

--- a/src/helix/endpoints/predictions/get_predictions.rs
+++ b/src/helix/endpoints/predictions/get_predictions.rs
@@ -57,7 +57,7 @@ pub struct GetPredictionsRequest<'a> {
     pub id: Cow<'a, [&'a types::PredictionIdRef]>,
     /// Cursor for forward pagination
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
-    pub after: Option<helix::Cursor>,
+    pub after: Option<Cow<'a, helix::CursorRef>>,
     /// Maximum number of objects to return. Maximum: 20. Default: 20.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     pub first: Option<usize>,
@@ -125,7 +125,9 @@ impl Request for GetPredictionsRequest<'_> {
 impl RequestGet for GetPredictionsRequest<'_> {}
 
 impl helix::Paginated for GetPredictionsRequest<'_> {
-    fn set_pagination(&mut self, cursor: Option<helix::Cursor>) { self.after = cursor; }
+    fn set_pagination(&mut self, cursor: Option<helix::Cursor>) {
+        self.after = cursor.map(|c| c.into_cow())
+    }
 }
 
 #[cfg(test)]

--- a/src/helix/endpoints/predictions/mod.rs
+++ b/src/helix/endpoints/predictions/mod.rs
@@ -5,6 +5,7 @@ use crate::{
     types,
 };
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 
 pub mod create_prediction;
 pub mod end_prediction;

--- a/src/helix/endpoints/raids/cancel_a_raid.rs
+++ b/src/helix/endpoints/raids/cancel_a_raid.rs
@@ -45,15 +45,16 @@ use helix::RequestDelete;
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct CancelARaidRequest {
+pub struct CancelARaidRequest<'a> {
     /// The ID of the broadcaster that sent the raiding party.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub broadcaster_id: types::UserId,
+    #[serde(borrow)]
+    pub broadcaster_id: &'a types::UserIdRef,
 }
 
-impl CancelARaidRequest {
+impl<'a> CancelARaidRequest<'a> {
     /// Cancel a pending raid on this broadcasters channel
-    pub fn broadcaster_id(broadcaster_id: impl Into<types::UserId>) -> Self {
+    pub fn broadcaster_id(broadcaster_id: impl Into<&'a types::UserIdRef>) -> Self {
         Self {
             broadcaster_id: broadcaster_id.into(),
         }
@@ -70,7 +71,7 @@ pub enum CancelARaidResponse {
     Success,
 }
 
-impl Request for CancelARaidRequest {
+impl Request for CancelARaidRequest<'_> {
     type Response = CancelARaidResponse;
 
     #[cfg(feature = "twitch_oauth2")]
@@ -80,7 +81,7 @@ impl Request for CancelARaidRequest {
     const SCOPE: &'static [twitch_oauth2::Scope] = &[twitch_oauth2::Scope::ChannelManageRaids];
 }
 
-impl RequestDelete for CancelARaidRequest {
+impl RequestDelete for CancelARaidRequest<'_> {
     fn parse_inner_response(
         request: Option<Self>,
         uri: &http::Uri,

--- a/src/helix/endpoints/raids/cancel_a_raid.rs
+++ b/src/helix/endpoints/raids/cancel_a_raid.rs
@@ -5,13 +5,11 @@
 //!
 //! ## Request: [CancelARaidRequest]
 //!
-//! To use this endpoint, construct a [`CancelARaidRequest`] with the [`CancelARaidRequest::builder()`] method.
+//! To use this endpoint, construct a [`CancelARaidRequest`] with the [`CancelARaidRequest::broadcaster_id()`] method.
 //!
 //! ```rust
 //! use twitch_api::helix::raids::cancel_a_raid;
-//! let request = cancel_a_raid::CancelARaidRequest::builder()
-//!     .broadcaster_id("1234")
-//!     .build();
+//! let request = cancel_a_raid::CancelARaidRequest::broadcaster_id("1234");
 //! ```
 //!
 //! ## Response: [CancelARaidResponse]
@@ -26,9 +24,7 @@
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = cancel_a_raid::CancelARaidRequest::builder()
-//!     .broadcaster_id("1234")
-//!     .build();
+//! let request = cancel_a_raid::CancelARaidRequest::broadcaster_id("1234");
 //! let response: cancel_a_raid::CancelARaidResponse = client.req_delete(request, &token).await?.data;
 //! # Ok(())
 //! # }

--- a/src/helix/endpoints/raids/cancel_a_raid.rs
+++ b/src/helix/endpoints/raids/cancel_a_raid.rs
@@ -49,14 +49,14 @@ pub struct CancelARaidRequest<'a> {
     /// The ID of the broadcaster that sent the raiding party.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: &'a types::UserIdRef,
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
 }
 
 impl<'a> CancelARaidRequest<'a> {
     /// Cancel a pending raid on this broadcasters channel
-    pub fn broadcaster_id(broadcaster_id: impl Into<&'a types::UserIdRef>) -> Self {
+    pub fn broadcaster_id(broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a) -> Self {
         Self {
-            broadcaster_id: broadcaster_id.into(),
+            broadcaster_id: broadcaster_id.to_cow(),
         }
     }
 }

--- a/src/helix/endpoints/raids/mod.rs
+++ b/src/helix/endpoints/raids/mod.rs
@@ -5,6 +5,7 @@ use crate::{
     types,
 };
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 
 pub mod cancel_a_raid;
 pub mod start_a_raid;

--- a/src/helix/endpoints/raids/start_a_raid.rs
+++ b/src/helix/endpoints/raids/start_a_raid.rs
@@ -43,20 +43,22 @@ use helix::RequestPost;
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct StartARaidRequest {
+pub struct StartARaidRequest<'a> {
     /// The ID of the broadcaster that’s sending the raiding party.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    from_broadcaster_id: types::UserId,
+    #[serde(borrow)]
+    from_broadcaster_id: &'a types::UserIdRef,
     /// The ID of the broadcaster to raid.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    to_broadcaster_id: types::UserId,
+    #[serde(borrow)]
+    to_broadcaster_id: &'a types::UserIdRef,
 }
 
-impl StartARaidRequest {
+impl<'a> StartARaidRequest<'a> {
     /// Create a new [`StartARaidRequest`]
     pub fn new(
-        from_broadcaster_id: impl Into<types::UserId>,
-        to_broadcaster_id: impl Into<types::UserId>,
+        from_broadcaster_id: impl Into<&'a types::UserIdRef>,
+        to_broadcaster_id: impl Into<&'a types::UserIdRef>,
     ) -> Self {
         Self {
             from_broadcaster_id: from_broadcaster_id.into(),
@@ -77,7 +79,7 @@ pub struct StartARaidResponse {
     /// A Boolean value that indicates whether the channel being raided contains mature content.
     is_mature: bool,
 }
-impl Request for StartARaidRequest {
+impl Request for StartARaidRequest<'_> {
     type Response = StartARaidResponse;
 
     const PATH: &'static str = "raids";
@@ -85,7 +87,7 @@ impl Request for StartARaidRequest {
     const SCOPE: &'static [twitch_oauth2::Scope] = &[twitch_oauth2::Scope::ChannelManageRaids];
 }
 
-impl RequestPost for StartARaidRequest {
+impl RequestPost for StartARaidRequest<'_> {
     type Body = helix::EmptyBody;
 
     fn parse_inner_response(

--- a/src/helix/endpoints/raids/start_a_raid.rs
+++ b/src/helix/endpoints/raids/start_a_raid.rs
@@ -47,22 +47,22 @@ pub struct StartARaidRequest<'a> {
     /// The ID of the broadcaster that’s sending the raiding party.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    from_broadcaster_id: &'a types::UserIdRef,
+    from_broadcaster_id: Cow<'a, types::UserIdRef>,
     /// The ID of the broadcaster to raid.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    to_broadcaster_id: &'a types::UserIdRef,
+    to_broadcaster_id: Cow<'a, types::UserIdRef>,
 }
 
 impl<'a> StartARaidRequest<'a> {
     /// Create a new [`StartARaidRequest`]
     pub fn new(
-        from_broadcaster_id: impl Into<&'a types::UserIdRef>,
-        to_broadcaster_id: impl Into<&'a types::UserIdRef>,
+        from_broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
+        to_broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
     ) -> Self {
         Self {
-            from_broadcaster_id: from_broadcaster_id.into(),
-            to_broadcaster_id: to_broadcaster_id.into(),
+            from_broadcaster_id: from_broadcaster_id.to_cow(),
+            to_broadcaster_id: to_broadcaster_id.to_cow(),
         }
     }
 }

--- a/src/helix/endpoints/schedule/create_channel_stream_schedule_segment.rs
+++ b/src/helix/endpoints/schedule/create_channel_stream_schedule_segment.rs
@@ -26,7 +26,7 @@
 //!         "America/New_York",
 //!         false,
 //!     );
-//! body.duration = Some("60");
+//! body.duration = Some("60".into());
 //! body.category_id = Some(twitch_types::CategoryIdRef::from_static("509670").as_cow());
 //! body.title = Some("TwitchDev Monthly Update // July 1, 2021".into());
 //! ```
@@ -55,7 +55,7 @@
 //!         "America/New_York",
 //!         false,
 //!     );
-//! body.duration = Some("60");
+//! body.duration = Some("60".into());
 //! body.category_id = Some(twitch_types::CategoryIdRef::from_static("509670").as_cow());
 //! body.title = Some("TwitchDev Monthly Update // July 1, 2021".into());
 //! let response: create_channel_stream_schedule_segment::CreateChannelStreamScheduleSegmentResponse = client.req_post(request, body, &token).await?.data;
@@ -105,13 +105,13 @@ pub struct CreateChannelStreamScheduleSegmentBody<'a> {
     /// The timezone of the application creating the scheduled broadcast using the IANA time zone database format.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub timezone: &'a str,
+    pub timezone: Cow<'a, str>,
     /// Indicates if the scheduled broadcast is recurring weekly.
     pub is_recurring: bool,
     /// Duration of the scheduled broadcast in minutes from the start_time. Default: 240.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(skip_serializing_if = "Option::is_none", borrow)]
-    pub duration: Option<&'a str>,
+    pub duration: Option<Cow<'a, str>>,
     /// Game/Category ID for the scheduled broadcast.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(skip_serializing_if = "Option::is_none", borrow)]
@@ -119,14 +119,14 @@ pub struct CreateChannelStreamScheduleSegmentBody<'a> {
     /// Title for the scheduled broadcast. Maximum: 140 characters.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(skip_serializing_if = "Option::is_none", borrow)]
-    pub title: Option<&'a str>,
+    pub title: Option<Cow<'a, str>>,
 }
 
 impl<'a> CreateChannelStreamScheduleSegmentBody<'a> {
     /// Create a single scheduled broadcast or a recurring scheduled broadcast for a channel’s [stream schedule](https://help.twitch.tv/s/article/channel-page-setup#Schedule).
     pub fn new(
         start_time: impl types::IntoCow<'a, types::TimestampRef> + 'a,
-        timezone: impl Into<&'a str>,
+        timezone: impl Into<Cow<'a, str>>,
         is_recurring: bool,
     ) -> Self {
         Self {
@@ -169,9 +169,9 @@ fn test_request() {
 
     let ts = types::Timestamp::try_from("2021-07-01T18:00:00Z").unwrap();
     let body = CreateChannelStreamScheduleSegmentBody {
-        duration: Some("60"),
+        duration: Some("60".into()),
         category_id: Some(types::IntoCow::to_cow("509670")),
-        title: Some("TwitchDev Monthly Update // July 1, 2021"),
+        title: Some("TwitchDev Monthly Update // July 1, 2021".into()),
         ..CreateChannelStreamScheduleSegmentBody::new(&*ts, "America/New_York", false)
     };
 

--- a/src/helix/endpoints/schedule/create_channel_stream_schedule_segment.rs
+++ b/src/helix/endpoints/schedule/create_channel_stream_schedule_segment.rs
@@ -5,15 +5,12 @@
 //!
 //! ## Request: [CreateChannelStreamScheduleSegmentRequest]
 //!
-//! To use this endpoint, construct a [`CreateChannelStreamScheduleSegmentRequest`] with the [`CreateChannelStreamScheduleSegmentRequest::builder()`] method.
+//! To use this endpoint, construct a [`CreateChannelStreamScheduleSegmentRequest`] with the [`CreateChannelStreamScheduleSegmentRequest::broadcaster_id()`] method.
 //!
 //! ```rust
 //! use twitch_api::helix::schedule::create_channel_stream_schedule_segment;
 //! let request =
-//!     create_channel_stream_schedule_segment::CreateChannelStreamScheduleSegmentRequest::builder(
-//!     )
-//!     .broadcaster_id("141981764")
-//!     .build();
+//!     create_channel_stream_schedule_segment::CreateChannelStreamScheduleSegmentRequest::broadcaster_id("141981764");
 //! ```
 //!
 //! ## Body: [CreateChannelStreamScheduleSegmentBody]
@@ -23,15 +20,15 @@
 //! ```
 //! # use std::convert::TryFrom;
 //! # use twitch_api::helix::schedule::create_channel_stream_schedule_segment;
-//! let body =
-//!     create_channel_stream_schedule_segment::CreateChannelStreamScheduleSegmentBody::builder()
-//!         .start_time(&twitch_api::types::Timestamp::try_from("2021-07-01T18:00:00Z").unwrap())
-//!         .timezone("America/New_York")
-//!         .is_recurring(false)
-//!         .duration("60")
-//!         .category_id(Some("509670".into()))
-//!         .title("TwitchDev Monthly Update // July 1, 2021")
-//!         .build();
+//! let mut body =
+//!     create_channel_stream_schedule_segment::CreateChannelStreamScheduleSegmentBody::new(
+//!         twitch_api::types::Timestamp::try_from("2021-07-01T18:00:00Z").unwrap(),
+//!         "America/New_York",
+//!         false,
+//!     );
+//! body.duration = Some("60");
+//! body.category_id = Some(twitch_types::CategoryIdRef::from_static("509670").as_cow());
+//! body.title = Some("TwitchDev Monthly Update // July 1, 2021".into());
 //! ```
 //!
 //! ## Response: [ScheduledBroadcasts]
@@ -49,18 +46,18 @@
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = create_channel_stream_schedule_segment::CreateChannelStreamScheduleSegmentRequest::builder()
-//!     .broadcaster_id("141981764")
-//!     .build();
+//! let request =
+//!     create_channel_stream_schedule_segment::CreateChannelStreamScheduleSegmentRequest::broadcaster_id("141981764");
 //! let timestamp = twitch_api::types::Timestamp::try_from("2021-07-01T18:00:00Z")?;
-//! let body = create_channel_stream_schedule_segment::CreateChannelStreamScheduleSegmentBody::builder()
-//!     .start_time(&timestamp)
-//!     .timezone("America/New_York")
-//!     .is_recurring(false)
-//!     .duration("60")
-//!     .category_id(Some("509670".into()))
-//!     .title("TwitchDev Monthly Update // July 1, 2021")
-//!     .build();
+//! let mut body =
+//!     create_channel_stream_schedule_segment::CreateChannelStreamScheduleSegmentBody::new(
+//!         twitch_api::types::Timestamp::try_from("2021-07-01T18:00:00Z").unwrap(),
+//!         "America/New_York",
+//!         false,
+//!     );
+//! body.duration = Some("60");
+//! body.category_id = Some(twitch_types::CategoryIdRef::from_static("509670").as_cow());
+//! body.title = Some("TwitchDev Monthly Update // July 1, 2021".into());
 //! let response: create_channel_stream_schedule_segment::CreateChannelStreamScheduleSegmentResponse = client.req_post(request, body, &token).await?.data;
 //! # Ok(())
 //! # }

--- a/src/helix/endpoints/schedule/create_channel_stream_schedule_segment.rs
+++ b/src/helix/endpoints/schedule/create_channel_stream_schedule_segment.rs
@@ -25,7 +25,7 @@
 //! # use twitch_api::helix::schedule::create_channel_stream_schedule_segment;
 //! let body =
 //!     create_channel_stream_schedule_segment::CreateChannelStreamScheduleSegmentBody::builder()
-//!         .start_time(&*twitch_api::types::Timestamp::try_from("2021-07-01T18:00:00Z").unwrap())
+//!         .start_time(&twitch_api::types::Timestamp::try_from("2021-07-01T18:00:00Z").unwrap())
 //!         .timezone("America/New_York")
 //!         .is_recurring(false)
 //!         .duration("60")
@@ -54,7 +54,7 @@
 //!     .build();
 //! let timestamp = twitch_api::types::Timestamp::try_from("2021-07-01T18:00:00Z")?;
 //! let body = create_channel_stream_schedule_segment::CreateChannelStreamScheduleSegmentBody::builder()
-//!     .start_time(&*timestamp)
+//!     .start_time(&timestamp)
 //!     .timezone("America/New_York")
 //!     .is_recurring(false)
 //!     .duration("60")
@@ -81,14 +81,14 @@ pub struct CreateChannelStreamScheduleSegmentRequest<'a> {
     /// User ID of the broadcaster who owns the channel streaming schedule. Provided broadcaster_id must match the user_id in the user OAuth token.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: &'a types::UserIdRef,
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
 }
 
 impl<'a> CreateChannelStreamScheduleSegmentRequest<'a> {
     /// Create a single scheduled broadcast or a recurring scheduled broadcast for a channel’s [stream schedule](https://help.twitch.tv/s/article/channel-page-setup#Schedule).
-    pub fn broadcaster_id(broadcaster_id: impl Into<&'a types::UserIdRef>) -> Self {
+    pub fn broadcaster_id(broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a) -> Self {
         Self {
-            broadcaster_id: broadcaster_id.into(),
+            broadcaster_id: broadcaster_id.to_cow(),
         }
     }
 }
@@ -103,7 +103,7 @@ pub struct CreateChannelStreamScheduleSegmentBody<'a> {
     /// Start time for the scheduled broadcast specified in RFC3339 format.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub start_time: &'a types::TimestampRef,
+    pub start_time: Cow<'a, types::TimestampRef>,
     // FIXME: specific braid?
     /// The timezone of the application creating the scheduled broadcast using the IANA time zone database format.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
@@ -118,7 +118,7 @@ pub struct CreateChannelStreamScheduleSegmentBody<'a> {
     /// Game/Category ID for the scheduled broadcast.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(skip_serializing_if = "Option::is_none", borrow)]
-    pub category_id: Option<&'a types::CategoryIdRef>,
+    pub category_id: Option<Cow<'a, types::CategoryIdRef>>,
     /// Title for the scheduled broadcast. Maximum: 140 characters.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(skip_serializing_if = "Option::is_none", borrow)]
@@ -128,12 +128,12 @@ pub struct CreateChannelStreamScheduleSegmentBody<'a> {
 impl<'a> CreateChannelStreamScheduleSegmentBody<'a> {
     /// Create a single scheduled broadcast or a recurring scheduled broadcast for a channel’s [stream schedule](https://help.twitch.tv/s/article/channel-page-setup#Schedule).
     pub fn new(
-        start_time: impl Into<&'a types::TimestampRef>,
+        start_time: impl types::IntoCow<'a, types::TimestampRef> + 'a,
         timezone: impl Into<&'a str>,
         is_recurring: bool,
     ) -> Self {
         Self {
-            start_time: start_time.into(),
+            start_time: start_time.to_cow(),
             timezone: timezone.into(),
             is_recurring,
             duration: Default::default(),
@@ -173,7 +173,7 @@ fn test_request() {
     let ts = types::Timestamp::try_from("2021-07-01T18:00:00Z").unwrap();
     let body = CreateChannelStreamScheduleSegmentBody {
         duration: Some("60"),
-        category_id: Some("509670".into()),
+        category_id: Some(types::IntoCow::to_cow("509670")),
         title: Some("TwitchDev Monthly Update // July 1, 2021"),
         ..CreateChannelStreamScheduleSegmentBody::new(&*ts, "America/New_York", false)
     };

--- a/src/helix/endpoints/schedule/create_channel_stream_schedule_segment.rs
+++ b/src/helix/endpoints/schedule/create_channel_stream_schedule_segment.rs
@@ -25,12 +25,12 @@
 //! # use twitch_api::helix::schedule::create_channel_stream_schedule_segment;
 //! let body =
 //!     create_channel_stream_schedule_segment::CreateChannelStreamScheduleSegmentBody::builder()
-//!         .start_time(twitch_api::types::Timestamp::try_from("2021-07-01T18:00:00Z").unwrap())
+//!         .start_time(&*twitch_api::types::Timestamp::try_from("2021-07-01T18:00:00Z").unwrap())
 //!         .timezone("America/New_York")
 //!         .is_recurring(false)
-//!         .duration("60".to_string())
+//!         .duration("60")
 //!         .category_id(Some("509670".into()))
-//!         .title("TwitchDev Monthly Update // July 1, 2021".to_string())
+//!         .title("TwitchDev Monthly Update // July 1, 2021")
 //!         .build();
 //! ```
 //!
@@ -52,13 +52,14 @@
 //! let request = create_channel_stream_schedule_segment::CreateChannelStreamScheduleSegmentRequest::builder()
 //!     .broadcaster_id("141981764")
 //!     .build();
+//! let timestamp = twitch_api::types::Timestamp::try_from("2021-07-01T18:00:00Z")?;
 //! let body = create_channel_stream_schedule_segment::CreateChannelStreamScheduleSegmentBody::builder()
-//!     .start_time(twitch_api::types::Timestamp::try_from("2021-07-01T18:00:00Z")?)
+//!     .start_time(&*timestamp)
 //!     .timezone("America/New_York")
 //!     .is_recurring(false)
-//!     .duration("60".to_string())
+//!     .duration("60")
 //!     .category_id(Some("509670".into()))
-//!     .title("TwitchDev Monthly Update // July 1, 2021".to_string())
+//!     .title("TwitchDev Monthly Update // July 1, 2021")
 //!     .build();
 //! let response: create_channel_stream_schedule_segment::CreateChannelStreamScheduleSegmentResponse = client.req_post(request, body, &token).await?.data;
 //! # Ok(())

--- a/src/helix/endpoints/schedule/delete_channel_stream_schedule_segment.rs
+++ b/src/helix/endpoints/schedule/delete_channel_stream_schedule_segment.rs
@@ -54,22 +54,22 @@ pub struct DeleteChannelStreamScheduleSegmentRequest<'a> {
     /// User ID of the broadcaster who owns the channel streaming schedule. Provided broadcaster_id must match the user_id in the user OAuth token.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: &'a types::UserIdRef,
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
     /// The ID of the streaming segment to delete.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub id: &'a types::StreamSegmentIdRef,
+    pub id: Cow<'a, types::StreamSegmentIdRef>,
 }
 
 impl<'a> DeleteChannelStreamScheduleSegmentRequest<'a> {
     /// Delete a single scheduled broadcast or a recurring scheduled broadcast for a channel’s [stream schedule](https://help.twitch.tv/s/article/channel-page-setup#Schedule).
     pub fn new(
-        broadcaster_id: impl Into<&'a types::UserIdRef>,
-        id: impl Into<&'a types::StreamSegmentIdRef>,
+        broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
+        id: impl types::IntoCow<'a, types::StreamSegmentIdRef> + 'a,
     ) -> Self {
         Self {
-            broadcaster_id: broadcaster_id.into(),
-            id: id.into(),
+            broadcaster_id: broadcaster_id.to_cow(),
+            id: id.to_cow(),
         }
     }
 }

--- a/src/helix/endpoints/schedule/delete_channel_stream_schedule_segment.rs
+++ b/src/helix/endpoints/schedule/delete_channel_stream_schedule_segment.rs
@@ -50,20 +50,22 @@ use helix::RequestDelete;
 #[derive(PartialEq, Deserialize, Serialize, Clone, Debug)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct DeleteChannelStreamScheduleSegmentRequest {
+pub struct DeleteChannelStreamScheduleSegmentRequest<'a> {
     /// User ID of the broadcaster who owns the channel streaming schedule. Provided broadcaster_id must match the user_id in the user OAuth token.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub broadcaster_id: types::UserId,
+    #[serde(borrow)]
+    pub broadcaster_id: &'a types::UserIdRef,
     /// The ID of the streaming segment to delete.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub id: types::StreamSegmentId,
+    #[serde(borrow)]
+    pub id: &'a types::StreamSegmentIdRef,
 }
 
-impl DeleteChannelStreamScheduleSegmentRequest {
+impl<'a> DeleteChannelStreamScheduleSegmentRequest<'a> {
     /// Delete a single scheduled broadcast or a recurring scheduled broadcast for a channel’s [stream schedule](https://help.twitch.tv/s/article/channel-page-setup#Schedule).
     pub fn new(
-        broadcaster_id: impl Into<types::UserId>,
-        id: impl Into<types::StreamSegmentId>,
+        broadcaster_id: impl Into<&'a types::UserIdRef>,
+        id: impl Into<&'a types::StreamSegmentIdRef>,
     ) -> Self {
         Self {
             broadcaster_id: broadcaster_id.into(),
@@ -82,7 +84,7 @@ pub enum DeleteChannelStreamScheduleSegment {
     Success,
 }
 
-impl Request for DeleteChannelStreamScheduleSegmentRequest {
+impl Request for DeleteChannelStreamScheduleSegmentRequest<'_> {
     type Response = DeleteChannelStreamScheduleSegment;
 
     const PATH: &'static str = "schedule/segment";
@@ -90,7 +92,7 @@ impl Request for DeleteChannelStreamScheduleSegmentRequest {
     const SCOPE: &'static [twitch_oauth2::Scope] = &[twitch_oauth2::Scope::ChannelManageSchedule];
 }
 
-impl RequestDelete for DeleteChannelStreamScheduleSegmentRequest {
+impl RequestDelete for DeleteChannelStreamScheduleSegmentRequest<'_> {
     fn parse_inner_response(
         request: Option<Self>,
         uri: &http::Uri,

--- a/src/helix/endpoints/schedule/get_channel_stream_schedule.rs
+++ b/src/helix/endpoints/schedule/get_channel_stream_schedule.rs
@@ -60,7 +60,7 @@ pub struct GetChannelStreamScheduleRequest<'a> {
     /// A timezone offset for the requester specified in minutes. This is recommended to ensure stream segments are returned for the correct week. For example, a timezone that is +4 hours from GMT would be “240.” If not specified, “0” is used for GMT.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(borrow)]
-    pub utc_offset: Option<&'a str>,
+    pub utc_offset: Option<Cow<'a, str>>,
     /// Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
     #[cfg_attr(feature = "typed-builder", builder(default))]
     pub after: Option<helix::Cursor>,
@@ -98,7 +98,7 @@ impl<'a> GetChannelStreamScheduleRequest<'a> {
     }
 
     /// Set the utc_offset for the request.
-    pub fn utc_offset(mut self, utc_offset: impl Into<&'a str>) -> Self {
+    pub fn utc_offset(mut self, utc_offset: impl Into<Cow<'a, str>>) -> Self {
         self.utc_offset = Some(utc_offset.into());
         self
     }

--- a/src/helix/endpoints/schedule/get_channel_stream_schedule.rs
+++ b/src/helix/endpoints/schedule/get_channel_stream_schedule.rs
@@ -63,7 +63,7 @@ pub struct GetChannelStreamScheduleRequest<'a> {
     pub utc_offset: Option<Cow<'a, str>>,
     /// Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
     #[cfg_attr(feature = "typed-builder", builder(default))]
-    pub after: Option<helix::Cursor>,
+    pub after: Option<Cow<'a, helix::CursorRef>>,
     /// Maximum number of stream segments to return. Maximum: 25. Default: 20.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     pub first: Option<usize>,
@@ -126,7 +126,9 @@ impl Request for GetChannelStreamScheduleRequest<'_> {
 impl RequestGet for GetChannelStreamScheduleRequest<'_> {}
 
 impl helix::Paginated for GetChannelStreamScheduleRequest<'_> {
-    fn set_pagination(&mut self, cursor: Option<helix::Cursor>) { self.after = cursor; }
+    fn set_pagination(&mut self, cursor: Option<helix::Cursor>) {
+        self.after = cursor.map(|c| c.into_cow())
+    }
 }
 
 #[cfg(test)]

--- a/src/helix/endpoints/schedule/get_channel_stream_schedule.rs
+++ b/src/helix/endpoints/schedule/get_channel_stream_schedule.rs
@@ -51,15 +51,15 @@ pub struct GetChannelStreamScheduleRequest<'a> {
     /// User ID of the broadcaster who owns the channel streaming schedule. Provided broadcaster_id must match the user_id in the user OAuth token.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: &'a types::UserIdRef,
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
     /// The ID of the stream segment to return. Maximum: 100.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(borrow)]
-    pub id: Option<&'a types::StreamSegmentIdRef>,
+    pub id: Option<Cow<'a, types::StreamSegmentIdRef>>,
     /// A timestamp in RFC3339 format to start returning stream segments from. If not specified, the current date and time is used.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(borrow)]
-    pub start_time: Option<&'a types::TimestampRef>,
+    pub start_time: Option<Cow<'a, types::TimestampRef>>,
     /// A timezone offset for the requester specified in minutes. This is recommended to ensure stream segments are returned for the correct week. For example, a timezone that is +4 hours from GMT would be “240.” If not specified, “0” is used for GMT.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(borrow)]
@@ -74,9 +74,9 @@ pub struct GetChannelStreamScheduleRequest<'a> {
 
 impl<'a> GetChannelStreamScheduleRequest<'a> {
     /// Get a broadcasters schedule
-    pub fn broadcaster_id(broadcaster_id: impl Into<&'a types::UserIdRef>) -> Self {
+    pub fn broadcaster_id(broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a) -> Self {
         Self {
-            broadcaster_id: broadcaster_id.into(),
+            broadcaster_id: broadcaster_id.to_cow(),
             id: Default::default(),
             start_time: Default::default(),
             utc_offset: Default::default(),
@@ -86,14 +86,17 @@ impl<'a> GetChannelStreamScheduleRequest<'a> {
     }
 
     /// Set the id for the request.
-    pub fn id(mut self, id: impl Into<&'a types::StreamSegmentIdRef>) -> Self {
-        self.id = Some(id.into());
+    pub fn id(mut self, id: impl types::IntoCow<'a, types::StreamSegmentIdRef> + 'a) -> Self {
+        self.id = Some(id.to_cow());
         self
     }
 
     /// Set the start_time for the request.
-    pub fn start_time(mut self, start_time: impl Into<&'a types::TimestampRef>) -> Self {
-        self.start_time = Some(start_time.into());
+    pub fn start_time(
+        mut self,
+        start_time: impl types::IntoCow<'a, types::TimestampRef> + 'a,
+    ) -> Self {
+        self.start_time = Some(start_time.to_cow());
         self
     }
 

--- a/src/helix/endpoints/schedule/get_channel_stream_schedule.rs
+++ b/src/helix/endpoints/schedule/get_channel_stream_schedule.rs
@@ -47,19 +47,23 @@ use helix::RequestGet;
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct GetChannelStreamScheduleRequest {
+pub struct GetChannelStreamScheduleRequest<'a> {
     /// User ID of the broadcaster who owns the channel streaming schedule. Provided broadcaster_id must match the user_id in the user OAuth token.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub broadcaster_id: types::UserId,
+    #[serde(borrow)]
+    pub broadcaster_id: &'a types::UserIdRef,
     /// The ID of the stream segment to return. Maximum: 100.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
-    pub id: Option<types::StreamSegmentId>,
+    #[serde(borrow)]
+    pub id: Option<&'a types::StreamSegmentIdRef>,
     /// A timestamp in RFC3339 format to start returning stream segments from. If not specified, the current date and time is used.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
-    pub start_time: Option<types::Timestamp>,
+    #[serde(borrow)]
+    pub start_time: Option<&'a types::TimestampRef>,
     /// A timezone offset for the requester specified in minutes. This is recommended to ensure stream segments are returned for the correct week. For example, a timezone that is +4 hours from GMT would be “240.” If not specified, “0” is used for GMT.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
-    pub utc_offset: Option<String>,
+    #[serde(borrow)]
+    pub utc_offset: Option<&'a str>,
     /// Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
     #[cfg_attr(feature = "typed-builder", builder(default))]
     pub after: Option<helix::Cursor>,
@@ -68,9 +72,9 @@ pub struct GetChannelStreamScheduleRequest {
     pub first: Option<usize>,
 }
 
-impl GetChannelStreamScheduleRequest {
+impl<'a> GetChannelStreamScheduleRequest<'a> {
     /// Get a broadcasters schedule
-    pub fn broadcaster_id(broadcaster_id: impl Into<types::UserId>) -> Self {
+    pub fn broadcaster_id(broadcaster_id: impl Into<&'a types::UserIdRef>) -> Self {
         Self {
             broadcaster_id: broadcaster_id.into(),
             id: Default::default(),
@@ -82,19 +86,19 @@ impl GetChannelStreamScheduleRequest {
     }
 
     /// Set the id for the request.
-    pub fn id(mut self, id: impl Into<types::StreamSegmentId>) -> Self {
+    pub fn id(mut self, id: impl Into<&'a types::StreamSegmentIdRef>) -> Self {
         self.id = Some(id.into());
         self
     }
 
     /// Set the start_time for the request.
-    pub fn start_time(mut self, start_time: impl Into<types::Timestamp>) -> Self {
+    pub fn start_time(mut self, start_time: impl Into<&'a types::TimestampRef>) -> Self {
         self.start_time = Some(start_time.into());
         self
     }
 
     /// Set the utc_offset for the request.
-    pub fn utc_offset(mut self, utc_offset: impl Into<String>) -> Self {
+    pub fn utc_offset(mut self, utc_offset: impl Into<&'a str>) -> Self {
         self.utc_offset = Some(utc_offset.into());
         self
     }
@@ -111,7 +115,7 @@ impl GetChannelStreamScheduleRequest {
 /// [`get-channel-stream-schedule`](https://dev.twitch.tv/docs/api/reference#get-channel-stream-schedule)
 pub type GetChannelStreamScheduleResponse = ScheduledBroadcasts;
 
-impl Request for GetChannelStreamScheduleRequest {
+impl Request for GetChannelStreamScheduleRequest<'_> {
     type Response = ScheduledBroadcasts;
 
     const PATH: &'static str = "schedule";
@@ -119,9 +123,9 @@ impl Request for GetChannelStreamScheduleRequest {
     const SCOPE: &'static [twitch_oauth2::Scope] = &[];
 }
 
-impl RequestGet for GetChannelStreamScheduleRequest {}
+impl RequestGet for GetChannelStreamScheduleRequest<'_> {}
 
-impl helix::Paginated for GetChannelStreamScheduleRequest {
+impl helix::Paginated for GetChannelStreamScheduleRequest<'_> {
     fn set_pagination(&mut self, cursor: Option<helix::Cursor>) { self.after = cursor; }
 }
 

--- a/src/helix/endpoints/schedule/get_channel_stream_schedule.rs
+++ b/src/helix/endpoints/schedule/get_channel_stream_schedule.rs
@@ -6,13 +6,12 @@
 //! See also [`get_channel_schedule`](helix::HelixClient::get_channel_schedule)
 //! ## Request: [GetChannelStreamScheduleRequest]
 //!
-//! To use this endpoint, construct a [`GetChannelStreamScheduleRequest`] with the [`GetChannelStreamScheduleRequest::builder()`] method.
+//! To use this endpoint, construct a [`GetChannelStreamScheduleRequest`] with the [`GetChannelStreamScheduleRequest::broadcaster_id()`] method.
 //!
 //! ```rust
 //! use twitch_api::helix::schedule::get_channel_stream_schedule;
-//! let request = get_channel_stream_schedule::GetChannelStreamScheduleRequest::builder()
-//!     .broadcaster_id("1234")
-//!     .build();
+//! let request =
+//!     get_channel_stream_schedule::GetChannelStreamScheduleRequest::broadcaster_id("1234");
 //! ```
 //!
 //! ## Response: [ScheduledBroadcasts]
@@ -27,9 +26,7 @@
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = get_channel_stream_schedule::GetChannelStreamScheduleRequest::builder()
-//!     .broadcaster_id("1234")
-//!     .build();
+//! let request = get_channel_stream_schedule::GetChannelStreamScheduleRequest::broadcaster_id("1234");
 //! let response: helix::schedule::ScheduledBroadcasts = client.req_get(request, &token).await?.data;
 //! # Ok(())
 //! # }

--- a/src/helix/endpoints/schedule/mod.rs
+++ b/src/helix/endpoints/schedule/mod.rs
@@ -4,6 +4,7 @@ use crate::{
     types,
 };
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 
 pub mod create_channel_stream_schedule_segment;
 pub mod delete_channel_stream_schedule_segment;

--- a/src/helix/endpoints/schedule/update_channel_stream_schedule.rs
+++ b/src/helix/endpoints/schedule/update_channel_stream_schedule.rs
@@ -49,27 +49,31 @@ use helix::RequestPatch;
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct UpdateChannelStreamScheduleRequest {
+pub struct UpdateChannelStreamScheduleRequest<'a> {
     /// User ID of the broadcaster who owns the channel streaming schedule. Provided broadcaster_id must match the user_id in the user OAuth token.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub broadcaster_id: types::UserId,
+    #[serde(borrow)]
+    pub broadcaster_id: &'a types::UserIdRef,
     /// Indicates if Vacation Mode is enabled. Set to true to add a vacation or false to remove vacation from the channel streaming schedule.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     pub is_vacation_enabled: Option<bool>,
     /// Start time for vacation specified in RFC3339 format. Required if is_vacation_enabled is set to true.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
-    pub vacation_start_time: Option<types::Timestamp>,
+    #[serde(borrow)]
+    pub vacation_start_time: Option<&'a types::TimestampRef>,
     /// End time for vacation specified in RFC3339 format. Required if is_vacation_enabled is set to true.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
-    pub vacation_end_time: Option<types::Timestamp>,
+    #[serde(borrow)]
+    pub vacation_end_time: Option<&'a types::TimestampRef>,
     /// The timezone for when the vacation is being scheduled using the IANA time zone database format. Required if is_vacation_enabled is set to true.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
-    pub timezone: Option<String>,
+    #[serde(borrow)]
+    pub timezone: Option<&'a str>,
 }
 
-impl UpdateChannelStreamScheduleRequest {
+impl<'a> UpdateChannelStreamScheduleRequest<'a> {
     /// Update the settings for a channel’s stream schedule.
-    pub fn broadcaster_id(broadcaster_id: impl Into<types::UserId>) -> Self {
+    pub fn broadcaster_id(broadcaster_id: impl Into<&'a types::UserIdRef>) -> Self {
         Self {
             broadcaster_id: broadcaster_id.into(),
             is_vacation_enabled: Default::default(),
@@ -91,7 +95,7 @@ pub enum UpdateChannelStreamSchedule {
     Success,
 }
 
-impl Request for UpdateChannelStreamScheduleRequest {
+impl Request for UpdateChannelStreamScheduleRequest<'_> {
     type Response = UpdateChannelStreamSchedule;
 
     const PATH: &'static str = "schedule/settings";
@@ -99,7 +103,7 @@ impl Request for UpdateChannelStreamScheduleRequest {
     const SCOPE: &'static [twitch_oauth2::Scope] = &[twitch_oauth2::Scope::ChannelManageSchedule];
 }
 
-impl RequestPatch for UpdateChannelStreamScheduleRequest {
+impl RequestPatch for UpdateChannelStreamScheduleRequest<'_> {
     type Body = helix::EmptyBody;
 
     fn parse_inner_response(
@@ -137,13 +141,17 @@ impl RequestPatch for UpdateChannelStreamScheduleRequest {
 #[cfg(test)]
 #[test]
 fn test_request() {
+    use std::convert::TryFrom;
+
     use helix::*;
-    use std::convert::TryInto;
+
+    let start = types::Timestamp::try_from("2021-05-16T00:00:00Z").unwrap();
+    let end = types::Timestamp::try_from("2021-05-23T00:00:00Z").unwrap();
     let req = UpdateChannelStreamScheduleRequest {
         is_vacation_enabled: Some(true),
-        vacation_start_time: Some("2021-05-16T00:00:00Z".try_into().unwrap()),
-        vacation_end_time: Some("2021-05-23T00:00:00Z".try_into().unwrap()),
-        timezone: Some("America/New_York".to_string()),
+        vacation_start_time: Some(&start),
+        vacation_end_time: Some(&end),
+        timezone: Some("America/New_York"),
         ..UpdateChannelStreamScheduleRequest::broadcaster_id("141981764")
     };
 

--- a/src/helix/endpoints/schedule/update_channel_stream_schedule.rs
+++ b/src/helix/endpoints/schedule/update_channel_stream_schedule.rs
@@ -68,7 +68,7 @@ pub struct UpdateChannelStreamScheduleRequest<'a> {
     /// The timezone for when the vacation is being scheduled using the IANA time zone database format. Required if is_vacation_enabled is set to true.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(borrow)]
-    pub timezone: Option<&'a str>,
+    pub timezone: Option<Cow<'a, str>>,
 }
 
 impl<'a> UpdateChannelStreamScheduleRequest<'a> {
@@ -151,7 +151,7 @@ fn test_request() {
         is_vacation_enabled: Some(true),
         vacation_start_time: Some(types::IntoCow::to_cow(&start)),
         vacation_end_time: Some(types::IntoCow::to_cow(&end)),
-        timezone: Some("America/New_York"),
+        timezone: Some("America/New_York".into()),
         ..UpdateChannelStreamScheduleRequest::broadcaster_id("141981764")
     };
 

--- a/src/helix/endpoints/schedule/update_channel_stream_schedule.rs
+++ b/src/helix/endpoints/schedule/update_channel_stream_schedule.rs
@@ -10,9 +10,11 @@
 //!
 //! ```rust
 //! use twitch_api::helix::schedule::update_channel_stream_schedule;
-//! let request = update_channel_stream_schedule::UpdateChannelStreamScheduleRequest::builder()
-//!     .broadcaster_id("274637212")
-//!     .build();
+//! let mut request =
+//!     update_channel_stream_schedule::UpdateChannelStreamScheduleRequest::broadcaster_id(
+//!         "274637212",
+//!     );
+//! request.is_vacation_enabled = Some(true);
 //! ```
 //!
 //! ## Response: [UpdateChannelStreamSchedule]
@@ -29,10 +31,8 @@
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = update_channel_stream_schedule::UpdateChannelStreamScheduleRequest::builder()
-//!     .broadcaster_id("274637212")
-//!     .is_vacation_enabled(false)
-//!     .build();
+//! let mut request = update_channel_stream_schedule::UpdateChannelStreamScheduleRequest::broadcaster_id("274637212");
+//! request.is_vacation_enabled = Some(true);
 //! let body = helix::EmptyBody;
 //! let response: update_channel_stream_schedule::UpdateChannelStreamSchedule = client.req_patch(request, body, &token).await?.data;
 //! # Ok(())

--- a/src/helix/endpoints/schedule/update_channel_stream_schedule.rs
+++ b/src/helix/endpoints/schedule/update_channel_stream_schedule.rs
@@ -53,18 +53,18 @@ pub struct UpdateChannelStreamScheduleRequest<'a> {
     /// User ID of the broadcaster who owns the channel streaming schedule. Provided broadcaster_id must match the user_id in the user OAuth token.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: &'a types::UserIdRef,
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
     /// Indicates if Vacation Mode is enabled. Set to true to add a vacation or false to remove vacation from the channel streaming schedule.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     pub is_vacation_enabled: Option<bool>,
     /// Start time for vacation specified in RFC3339 format. Required if is_vacation_enabled is set to true.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(borrow)]
-    pub vacation_start_time: Option<&'a types::TimestampRef>,
+    pub vacation_start_time: Option<Cow<'a, types::TimestampRef>>,
     /// End time for vacation specified in RFC3339 format. Required if is_vacation_enabled is set to true.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(borrow)]
-    pub vacation_end_time: Option<&'a types::TimestampRef>,
+    pub vacation_end_time: Option<Cow<'a, types::TimestampRef>>,
     /// The timezone for when the vacation is being scheduled using the IANA time zone database format. Required if is_vacation_enabled is set to true.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(borrow)]
@@ -73,9 +73,9 @@ pub struct UpdateChannelStreamScheduleRequest<'a> {
 
 impl<'a> UpdateChannelStreamScheduleRequest<'a> {
     /// Update the settings for a channel’s stream schedule.
-    pub fn broadcaster_id(broadcaster_id: impl Into<&'a types::UserIdRef>) -> Self {
+    pub fn broadcaster_id(broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a) -> Self {
         Self {
-            broadcaster_id: broadcaster_id.into(),
+            broadcaster_id: broadcaster_id.to_cow(),
             is_vacation_enabled: Default::default(),
             vacation_start_time: Default::default(),
             vacation_end_time: Default::default(),
@@ -149,8 +149,8 @@ fn test_request() {
     let end = types::Timestamp::try_from("2021-05-23T00:00:00Z").unwrap();
     let req = UpdateChannelStreamScheduleRequest {
         is_vacation_enabled: Some(true),
-        vacation_start_time: Some(&start),
-        vacation_end_time: Some(&end),
+        vacation_start_time: Some(types::IntoCow::to_cow(&start)),
+        vacation_end_time: Some(types::IntoCow::to_cow(&end)),
         timezone: Some("America/New_York"),
         ..UpdateChannelStreamScheduleRequest::broadcaster_id("141981764")
     };

--- a/src/helix/endpoints/schedule/update_channel_stream_schedule_segment.rs
+++ b/src/helix/endpoints/schedule/update_channel_stream_schedule_segment.rs
@@ -23,7 +23,7 @@
 //! # use twitch_api::helix::schedule::update_channel_stream_schedule_segment;
 //! let body =
 //!     update_channel_stream_schedule_segment::UpdateChannelStreamScheduleSegmentBody::builder()
-//!         .duration("120".to_string())
+//!         .duration("120")
 //!         .build();
 //! ```
 //!
@@ -46,7 +46,7 @@
 //!     .id("eyJzZWdtZW50SUQiOiJlNGFjYzcyNC0zNzFmLTQwMmMtODFjYS0yM2FkYTc5NzU5ZDQiLCJpc29ZZWFyIjoyMDIxLCJpc29XZWVrIjoyNn0=")
 //!     .build();
 //! let body = update_channel_stream_schedule_segment::UpdateChannelStreamScheduleSegmentBody::builder()
-//!     .duration("120".to_string())
+//!     .duration("120")
 //!     .build();
 //! let response: update_channel_stream_schedule_segment::UpdateChannelStreamScheduleSegmentResponse = client.req_patch(request, body, &token).await?.data;
 //! # Ok(())

--- a/src/helix/endpoints/schedule/update_channel_stream_schedule_segment.rs
+++ b/src/helix/endpoints/schedule/update_channel_stream_schedule_segment.rs
@@ -23,7 +23,7 @@
 //! # use twitch_api::helix::schedule::update_channel_stream_schedule_segment;
 //! let body =
 //!     update_channel_stream_schedule_segment::UpdateChannelStreamScheduleSegmentBody::builder()
-//!         .duration("120")
+//!         .duration(Some("120".into()))
 //!         .build();
 //! ```
 //!
@@ -46,7 +46,7 @@
 //!     "eyJzZWdtZW50SUQiOiJlNGFjYzcyNC0zNzFmLTQwMmMtODFjYS0yM2FkYTc5NzU5ZDQiLCJpc29ZZWFyIjoyMDIxLCJpc29XZWVrIjoyNn0=",
 //! );
 //! let body = update_channel_stream_schedule_segment::UpdateChannelStreamScheduleSegmentBody::builder()
-//!     .duration("120")
+//!     .duration(Some("120".into()))
 //!     .build();
 //! let response: update_channel_stream_schedule_segment::UpdateChannelStreamScheduleSegmentResponse = client.req_patch(request, body, &token).await?.data;
 //! # Ok(())
@@ -98,11 +98,11 @@ pub struct UpdateChannelStreamScheduleSegmentBody<'a> {
     /// Start time for the scheduled broadcast specified in RFC3339 format.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(skip_serializing_if = "Option::is_none", borrow)]
-    pub start_time: Option<&'a str>,
+    pub start_time: Option<Cow<'a, str>>,
     /// Duration of the scheduled broadcast in minutes from the start_time. Default: 240.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(skip_serializing_if = "Option::is_none", borrow)]
-    pub duration: Option<&'a str>,
+    pub duration: Option<Cow<'a, str>>,
     /// Game/Category ID for the scheduled broadcast.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(skip_serializing_if = "Option::is_none", borrow)]
@@ -110,7 +110,7 @@ pub struct UpdateChannelStreamScheduleSegmentBody<'a> {
     /// Title for the scheduled broadcast. Maximum: 140 characters.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(skip_serializing_if = "Option::is_none", borrow)]
-    pub title: Option<&'a str>,
+    pub title: Option<Cow<'a, str>>,
     /// Indicated if the scheduled broadcast is canceled.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -119,7 +119,7 @@ pub struct UpdateChannelStreamScheduleSegmentBody<'a> {
     /// The timezone of the application creating the scheduled broadcast using the IANA time zone database format.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(skip_serializing_if = "Option::is_none", borrow)]
-    pub timezone: Option<&'a str>,
+    pub timezone: Option<Cow<'a, str>>,
 }
 
 impl helix::private::SealedSerialize for UpdateChannelStreamScheduleSegmentBody<'_> {}
@@ -177,7 +177,7 @@ fn test_request() {
         "eyJzZWdtZW50SUQiOiJlNGFjYzcyNC0zNzFmLTQwMmMtODFjYS0yM2FkYTc5NzU5ZDQiLCJpc29ZZWFyIjoyMDIxLCJpc29XZWVrIjoyNn0=");
 
     let body = UpdateChannelStreamScheduleSegmentBody {
-        duration: Some("120"),
+        duration: Some("120".into()),
         ..<_>::default()
     };
 

--- a/src/helix/endpoints/schedule/update_channel_stream_schedule_segment.rs
+++ b/src/helix/endpoints/schedule/update_channel_stream_schedule_segment.rs
@@ -68,22 +68,22 @@ pub struct UpdateChannelStreamScheduleSegmentRequest<'a> {
     /// User ID of the broadcaster who owns the channel streaming schedule. Provided broadcaster_id must match the user_id in the user OAuth token.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: &'a types::UserIdRef,
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
     /// The ID of the streaming segment to update.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub id: &'a types::StreamSegmentIdRef,
+    pub id: Cow<'a, types::StreamSegmentIdRef>,
 }
 
 impl<'a> UpdateChannelStreamScheduleSegmentRequest<'a> {
     /// Update a single scheduled broadcast or a recurring scheduled broadcast for a channel’s [stream schedule](https://help.twitch.tv/s/article/channel-page-setup#Schedule).
     pub fn new(
-        broadcaster_id: impl Into<&'a types::UserIdRef>,
-        id: impl Into<&'a types::StreamSegmentIdRef>,
+        broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
+        id: impl types::IntoCow<'a, types::StreamSegmentIdRef> + 'a,
     ) -> Self {
         Self {
-            broadcaster_id: broadcaster_id.into(),
-            id: id.into(),
+            broadcaster_id: broadcaster_id.to_cow(),
+            id: id.to_cow(),
         }
     }
 }
@@ -106,7 +106,7 @@ pub struct UpdateChannelStreamScheduleSegmentBody<'a> {
     /// Game/Category ID for the scheduled broadcast.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(skip_serializing_if = "Option::is_none", borrow)]
-    pub category_id: Option<&'a types::CategoryIdRef>,
+    pub category_id: Option<Cow<'a, types::CategoryIdRef>>,
     /// Title for the scheduled broadcast. Maximum: 140 characters.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(skip_serializing_if = "Option::is_none", borrow)]

--- a/src/helix/endpoints/schedule/update_channel_stream_schedule_segment.rs
+++ b/src/helix/endpoints/schedule/update_channel_stream_schedule_segment.rs
@@ -64,20 +64,22 @@ use helix::RequestPatch;
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct UpdateChannelStreamScheduleSegmentRequest {
+pub struct UpdateChannelStreamScheduleSegmentRequest<'a> {
     /// User ID of the broadcaster who owns the channel streaming schedule. Provided broadcaster_id must match the user_id in the user OAuth token.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub broadcaster_id: types::UserId,
+    #[serde(borrow)]
+    pub broadcaster_id: &'a types::UserIdRef,
     /// The ID of the streaming segment to update.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub id: types::StreamSegmentId,
+    #[serde(borrow)]
+    pub id: &'a types::StreamSegmentIdRef,
 }
 
-impl UpdateChannelStreamScheduleSegmentRequest {
+impl<'a> UpdateChannelStreamScheduleSegmentRequest<'a> {
     /// Update a single scheduled broadcast or a recurring scheduled broadcast for a channel’s [stream schedule](https://help.twitch.tv/s/article/channel-page-setup#Schedule).
     pub fn new(
-        broadcaster_id: impl Into<types::UserId>,
-        id: impl Into<types::StreamSegmentId>,
+        broadcaster_id: impl Into<&'a types::UserIdRef>,
+        id: impl Into<&'a types::StreamSegmentIdRef>,
     ) -> Self {
         Self {
             broadcaster_id: broadcaster_id.into(),
@@ -92,23 +94,23 @@ impl UpdateChannelStreamScheduleSegmentRequest {
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug, Default)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct UpdateChannelStreamScheduleSegmentBody {
+pub struct UpdateChannelStreamScheduleSegmentBody<'a> {
     /// Start time for the scheduled broadcast specified in RFC3339 format.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub start_time: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", borrow)]
+    pub start_time: Option<&'a str>,
     /// Duration of the scheduled broadcast in minutes from the start_time. Default: 240.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub duration: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", borrow)]
+    pub duration: Option<&'a str>,
     /// Game/Category ID for the scheduled broadcast.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub category_id: Option<types::CategoryId>,
+    #[serde(skip_serializing_if = "Option::is_none", borrow)]
+    pub category_id: Option<&'a types::CategoryIdRef>,
     /// Title for the scheduled broadcast. Maximum: 140 characters.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub title: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", borrow)]
+    pub title: Option<&'a str>,
     /// Indicated if the scheduled broadcast is canceled.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -116,18 +118,18 @@ pub struct UpdateChannelStreamScheduleSegmentBody {
     // FIXME: Enum?
     /// The timezone of the application creating the scheduled broadcast using the IANA time zone database format.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub timezone: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none", borrow)]
+    pub timezone: Option<&'a str>,
 }
 
-impl helix::private::SealedSerialize for UpdateChannelStreamScheduleSegmentBody {}
+impl helix::private::SealedSerialize for UpdateChannelStreamScheduleSegmentBody<'_> {}
 
 /// Return Values for [Update Channel Stream Schedule Segment](super::update_channel_stream_schedule_segment)
 ///
 /// [`update-channel-stream-schedule-segment`](https://dev.twitch.tv/docs/api/reference#update-channel-stream-schedule-segment)
 pub type UpdateChannelStreamScheduleSegmentResponse = ScheduledBroadcasts;
 
-impl Request for UpdateChannelStreamScheduleSegmentRequest {
+impl Request for UpdateChannelStreamScheduleSegmentRequest<'_> {
     type Response = UpdateChannelStreamScheduleSegmentResponse;
 
     const PATH: &'static str = "schedule/segment";
@@ -135,8 +137,8 @@ impl Request for UpdateChannelStreamScheduleSegmentRequest {
     const SCOPE: &'static [twitch_oauth2::Scope] = &[twitch_oauth2::Scope::ChannelManageSchedule];
 }
 
-impl RequestPatch for UpdateChannelStreamScheduleSegmentRequest {
-    type Body = UpdateChannelStreamScheduleSegmentBody;
+impl<'a> RequestPatch for UpdateChannelStreamScheduleSegmentRequest<'a> {
+    type Body = UpdateChannelStreamScheduleSegmentBody<'a>;
 
     fn parse_inner_response(
         request: Option<Self>,
@@ -175,7 +177,7 @@ fn test_request() {
         "eyJzZWdtZW50SUQiOiJlNGFjYzcyNC0zNzFmLTQwMmMtODFjYS0yM2FkYTc5NzU5ZDQiLCJpc29ZZWFyIjoyMDIxLCJpc29XZWVrIjoyNn0=");
 
     let body = UpdateChannelStreamScheduleSegmentBody {
-        duration: Some("120".to_string()),
+        duration: Some("120"),
         ..<_>::default()
     };
 

--- a/src/helix/endpoints/schedule/update_channel_stream_schedule_segment.rs
+++ b/src/helix/endpoints/schedule/update_channel_stream_schedule_segment.rs
@@ -5,14 +5,14 @@
 //!
 //! ## Request: [UpdateChannelStreamScheduleSegmentRequest]
 //!
-//! To use this endpoint, construct a [`UpdateChannelStreamScheduleSegmentRequest`] with the [`UpdateChannelStreamScheduleSegmentRequest::builder()`] method.
+//! To use this endpoint, construct a [`UpdateChannelStreamScheduleSegmentRequest`] with the [`UpdateChannelStreamScheduleSegmentRequest::new()`] method.
 //!
 //! ```rust
 //! use twitch_api::helix::schedule::update_channel_stream_schedule_segment;
-//! let request = update_channel_stream_schedule_segment::UpdateChannelStreamScheduleSegmentRequest::builder()
-//!     .broadcaster_id("141981764")
-//!     .id("eyJzZWdtZW50SUQiOiJlNGFjYzcyNC0zNzFmLTQwMmMtODFjYS0yM2FkYTc5NzU5ZDQiLCJpc29ZZWFyIjoyMDIxLCJpc29XZWVrIjoyNn0=")
-//!     .build();
+//! let request = update_channel_stream_schedule_segment::UpdateChannelStreamScheduleSegmentRequest::new(
+//!     "141981764",
+//!     "eyJzZWdtZW50SUQiOiJlNGFjYzcyNC0zNzFmLTQwMmMtODFjYS0yM2FkYTc5NzU5ZDQiLCJpc29ZZWFyIjoyMDIxLCJpc29XZWVrIjoyNn0=",
+//! );
 //! ```
 //!
 //! ## Body: [UpdateChannelStreamScheduleSegmentBody]
@@ -41,10 +41,10 @@
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = update_channel_stream_schedule_segment::UpdateChannelStreamScheduleSegmentRequest::builder()
-//!     .broadcaster_id("141981764")
-//!     .id("eyJzZWdtZW50SUQiOiJlNGFjYzcyNC0zNzFmLTQwMmMtODFjYS0yM2FkYTc5NzU5ZDQiLCJpc29ZZWFyIjoyMDIxLCJpc29XZWVrIjoyNn0=")
-//!     .build();
+//! let request = update_channel_stream_schedule_segment::UpdateChannelStreamScheduleSegmentRequest::new(
+//!     "141981764",
+//!     "eyJzZWdtZW50SUQiOiJlNGFjYzcyNC0zNzFmLTQwMmMtODFjYS0yM2FkYTc5NzU5ZDQiLCJpc29ZZWFyIjoyMDIxLCJpc29XZWVrIjoyNn0=",
+//! );
 //! let body = update_channel_stream_schedule_segment::UpdateChannelStreamScheduleSegmentBody::builder()
 //!     .duration("120")
 //!     .build();

--- a/src/helix/endpoints/search/mod.rs
+++ b/src/helix/endpoints/search/mod.rs
@@ -22,6 +22,7 @@ use crate::{
     types,
 };
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 
 pub mod search_categories;
 pub mod search_channels;

--- a/src/helix/endpoints/search/search_categories.rs
+++ b/src/helix/endpoints/search/search_categories.rs
@@ -50,7 +50,7 @@ pub struct SearchCategoriesRequest<'a> {
     /// URI encoded search query
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub query: &'a str,
+    pub query: Cow<'a, str>,
     /// Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
     #[cfg_attr(feature = "typed-builder", builder(default))]
     pub after: Option<helix::Cursor>,
@@ -67,7 +67,7 @@ impl<'a> SearchCategoriesRequest<'a> {
     /// Search categories with the following query.
     pub fn query(query: impl Into<&'a str>) -> Self {
         Self {
-            query: query.into(),
+            query: query.into().into(),
             after: None,
             before: None,
             first: None,

--- a/src/helix/endpoints/search/search_categories.rs
+++ b/src/helix/endpoints/search/search_categories.rs
@@ -46,24 +46,26 @@ use helix::RequestGet;
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct SearchCategoriesRequest {
+pub struct SearchCategoriesRequest<'a> {
     /// URI encoded search query
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub query: String,
+    #[serde(borrow)]
+    pub query: &'a str,
     /// Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
     #[cfg_attr(feature = "typed-builder", builder(default))]
     pub after: Option<helix::Cursor>,
     /// Cursor for backward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
     #[cfg_attr(feature = "typed-builder", builder(default))]
-    pub before: Option<helix::Cursor>,
+    #[serde(borrow)]
+    pub before: Option<&'a helix::CursorRef>,
     /// Number of values to be returned per page. Limit: 100. Default: 20.
     #[cfg_attr(feature = "typed-builder", builder(setter(into), default))]
     pub first: Option<usize>,
 }
 
-impl SearchCategoriesRequest {
+impl<'a> SearchCategoriesRequest<'a> {
     /// Search categories with the following query.
-    pub fn query(query: impl Into<String>) -> Self {
+    pub fn query(query: impl Into<&'a str>) -> Self {
         Self {
             query: query.into(),
             after: None,
@@ -84,7 +86,7 @@ impl SearchCategoriesRequest {
 /// [`search-categories`](https://dev.twitch.tv/docs/api/reference#search-categories)
 pub type Category = types::TwitchCategory;
 
-impl Request for SearchCategoriesRequest {
+impl Request for SearchCategoriesRequest<'_> {
     type Response = Vec<Category>;
 
     const PATH: &'static str = "search/categories";
@@ -92,7 +94,7 @@ impl Request for SearchCategoriesRequest {
     const SCOPE: &'static [twitch_oauth2::Scope] = &[];
 }
 
-impl RequestGet for SearchCategoriesRequest {
+impl RequestGet for SearchCategoriesRequest<'_> {
     fn parse_inner_response(
         request: Option<Self>,
         uri: &http::Uri,
@@ -121,7 +123,7 @@ impl RequestGet for SearchCategoriesRequest {
     }
 }
 
-impl helix::Paginated for SearchCategoriesRequest {
+impl helix::Paginated for SearchCategoriesRequest<'_> {
     fn set_pagination(&mut self, cursor: Option<helix::Cursor>) { self.after = cursor }
 }
 

--- a/src/helix/endpoints/search/search_categories.rs
+++ b/src/helix/endpoints/search/search_categories.rs
@@ -53,11 +53,11 @@ pub struct SearchCategoriesRequest<'a> {
     pub query: Cow<'a, str>,
     /// Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
     #[cfg_attr(feature = "typed-builder", builder(default))]
-    pub after: Option<helix::Cursor>,
+    pub after: Option<Cow<'a, helix::CursorRef>>,
     /// Cursor for backward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
     #[cfg_attr(feature = "typed-builder", builder(default))]
     #[serde(borrow)]
-    pub before: Option<&'a helix::CursorRef>,
+    pub before: Option<Cow<'a, helix::CursorRef>>,
     /// Number of values to be returned per page. Limit: 100. Default: 20.
     #[cfg_attr(feature = "typed-builder", builder(setter(into), default))]
     pub first: Option<usize>,
@@ -124,7 +124,9 @@ impl RequestGet for SearchCategoriesRequest<'_> {
 }
 
 impl helix::Paginated for SearchCategoriesRequest<'_> {
-    fn set_pagination(&mut self, cursor: Option<helix::Cursor>) { self.after = cursor }
+    fn set_pagination(&mut self, cursor: Option<helix::Cursor>) {
+        self.after = cursor.map(|c| c.into_cow())
+    }
 }
 
 #[cfg(test)]

--- a/src/helix/endpoints/search/search_categories.rs
+++ b/src/helix/endpoints/search/search_categories.rs
@@ -65,9 +65,9 @@ pub struct SearchCategoriesRequest<'a> {
 
 impl<'a> SearchCategoriesRequest<'a> {
     /// Search categories with the following query.
-    pub fn query(query: impl Into<&'a str>) -> Self {
+    pub fn query(query: impl Into<Cow<'a, str>>) -> Self {
         Self {
-            query: query.into().into(),
+            query: query.into(),
             after: None,
             before: None,
             first: None,

--- a/src/helix/endpoints/search/search_channels.rs
+++ b/src/helix/endpoints/search/search_channels.rs
@@ -53,7 +53,7 @@ pub struct SearchChannelsRequest<'a> {
     pub query: Cow<'a, str>,
     /// Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
     #[cfg_attr(feature = "typed-builder", builder(default))]
-    pub after: Option<helix::Cursor>,
+    pub after: Option<Cow<'a, helix::CursorRef>>,
     /// Maximum number of objects to return. Maximum: 100 Default: 20
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     // FIXME: No setter because int
@@ -134,7 +134,9 @@ impl Request for SearchChannelsRequest<'_> {
 impl RequestGet for SearchChannelsRequest<'_> {}
 
 impl helix::Paginated for SearchChannelsRequest<'_> {
-    fn set_pagination(&mut self, cursor: Option<helix::Cursor>) { self.after = cursor }
+    fn set_pagination(&mut self, cursor: Option<helix::Cursor>) {
+        self.after = cursor.map(|c| c.into_cow())
+    }
 }
 
 #[cfg(test)]

--- a/src/helix/endpoints/search/search_channels.rs
+++ b/src/helix/endpoints/search/search_channels.rs
@@ -46,10 +46,11 @@ use helix::RequestGet;
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct SearchChannelsRequest {
+pub struct SearchChannelsRequest<'a> {
     /// URL encoded search query
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub query: String,
+    #[serde(borrow)]
+    pub query: &'a str,
     /// Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
     #[cfg_attr(feature = "typed-builder", builder(default))]
     pub after: Option<helix::Cursor>,
@@ -62,9 +63,9 @@ pub struct SearchChannelsRequest {
     pub live_only: Option<bool>,
 }
 
-impl SearchChannelsRequest {
+impl<'a> SearchChannelsRequest<'a> {
     /// Search channels with the following query.
-    pub fn query(query: impl Into<String>) -> Self {
+    pub fn query(query: impl Into<&'a str>) -> Self {
         Self {
             query: query.into(),
             after: None,
@@ -122,7 +123,7 @@ pub struct Channel {
     pub tag_ids: Vec<types::TagId>,
 }
 
-impl Request for SearchChannelsRequest {
+impl Request for SearchChannelsRequest<'_> {
     type Response = Vec<Channel>;
 
     const PATH: &'static str = "search/channels";
@@ -130,9 +131,9 @@ impl Request for SearchChannelsRequest {
     const SCOPE: &'static [twitch_oauth2::Scope] = &[];
 }
 
-impl RequestGet for SearchChannelsRequest {}
+impl RequestGet for SearchChannelsRequest<'_> {}
 
-impl helix::Paginated for SearchChannelsRequest {
+impl helix::Paginated for SearchChannelsRequest<'_> {
     fn set_pagination(&mut self, cursor: Option<helix::Cursor>) { self.after = cursor }
 }
 

--- a/src/helix/endpoints/search/search_channels.rs
+++ b/src/helix/endpoints/search/search_channels.rs
@@ -50,7 +50,7 @@ pub struct SearchChannelsRequest<'a> {
     /// URL encoded search query
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub query: &'a str,
+    pub query: Cow<'a, str>,
     /// Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
     #[cfg_attr(feature = "typed-builder", builder(default))]
     pub after: Option<helix::Cursor>,
@@ -65,7 +65,7 @@ pub struct SearchChannelsRequest<'a> {
 
 impl<'a> SearchChannelsRequest<'a> {
     /// Search channels with the following query.
-    pub fn query(query: impl Into<&'a str>) -> Self {
+    pub fn query(query: impl Into<Cow<'a, str>>) -> Self {
         Self {
             query: query.into(),
             after: None,

--- a/src/helix/endpoints/streams/get_followed_streams.rs
+++ b/src/helix/endpoints/streams/get_followed_streams.rs
@@ -5,13 +5,11 @@
 //!
 //! ## Request: [GetFollowedStreamsRequest]
 //!
-//! To use this endpoint, construct a [`GetFollowedStreamsRequest`] with the [`GetFollowedStreamsRequest::builder()`] method.
+//! To use this endpoint, construct a [`GetFollowedStreamsRequest`] with the [`GetFollowedStreamsRequest::user_id()`] method.
 //!
 //! ```rust
 //! use twitch_api::helix::streams::get_followed_streams;
-//! let request = get_followed_streams::GetFollowedStreamsRequest::builder()
-//!     .user_id("1234")
-//!     .build();
+//! let request = get_followed_streams::GetFollowedStreamsRequest::user_id("1234");
 //! ```
 //!
 //! ## Response: [Stream]
@@ -26,9 +24,7 @@
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = get_followed_streams::GetFollowedStreamsRequest::builder()
-//!     .user_id("1234")
-//!     .build();
+//! let request = get_followed_streams::GetFollowedStreamsRequest::user_id("1234");
 //! let response: Vec<get_followed_streams::GetFollowedStreamsResponse> = client.req_get(request, &token).await?.data;
 //! # Ok(())
 //! # }

--- a/src/helix/endpoints/streams/get_followed_streams.rs
+++ b/src/helix/endpoints/streams/get_followed_streams.rs
@@ -46,28 +46,30 @@ use helix::RequestGet;
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct GetFollowedStreamsRequest {
+pub struct GetFollowedStreamsRequest<'a> {
     /// Returns streams broadcast by one or more specified user IDs. You can specify up to 100 IDs.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub user_id: types::UserId,
+    #[serde(borrow)]
+    pub user_id: &'a types::UserIdRef,
     /// Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
     #[cfg_attr(feature = "typed-builder", builder(default))]
     pub after: Option<helix::Cursor>,
     /// Cursor for backward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
     #[cfg_attr(feature = "typed-builder", builder(default))]
-    pub before: Option<helix::Cursor>,
+    #[serde(borrow)]
+    pub before: Option<&'a helix::CursorRef>,
     /// Maximum number of objects to return. Maximum: 100. Default: 20.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     pub first: Option<usize>,
 }
 
-impl GetFollowedStreamsRequest {
+impl<'a> GetFollowedStreamsRequest<'a> {
     /// Get a users followed streams.
     ///
     /// Requires token with scope [`user:read:follows`](twitch_oauth2::Scope::UserReadFollows).
     ///
     /// See also [`HelixClient::get_followed_streams`](crate::helix::HelixClient::get_followed_streams).
-    pub fn user_id(user_id: impl Into<types::UserId>) -> Self {
+    pub fn user_id(user_id: impl Into<&'a types::UserIdRef>) -> Self {
         Self {
             user_id: user_id.into(),
             after: Default::default(),
@@ -88,7 +90,7 @@ impl GetFollowedStreamsRequest {
 /// [`get-followed-streams`](https://dev.twitch.tv/docs/api/reference#get-followed-streams)
 pub type GetFollowedStreamsResponse = Stream;
 
-impl Request for GetFollowedStreamsRequest {
+impl Request for GetFollowedStreamsRequest<'_> {
     type Response = Vec<GetFollowedStreamsResponse>;
 
     const PATH: &'static str = "streams/followed";
@@ -96,9 +98,9 @@ impl Request for GetFollowedStreamsRequest {
     const SCOPE: &'static [twitch_oauth2::Scope] = &[twitch_oauth2::Scope::UserReadFollows];
 }
 
-impl RequestGet for GetFollowedStreamsRequest {}
+impl RequestGet for GetFollowedStreamsRequest<'_> {}
 
-impl helix::Paginated for GetFollowedStreamsRequest {
+impl helix::Paginated for GetFollowedStreamsRequest<'_> {
     fn set_pagination(&mut self, cursor: Option<helix::Cursor>) { self.after = cursor }
 }
 

--- a/src/helix/endpoints/streams/get_followed_streams.rs
+++ b/src/helix/endpoints/streams/get_followed_streams.rs
@@ -50,7 +50,7 @@ pub struct GetFollowedStreamsRequest<'a> {
     /// Returns streams broadcast by one or more specified user IDs. You can specify up to 100 IDs.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub user_id: &'a types::UserIdRef,
+    pub user_id: Cow<'a, types::UserIdRef>,
     /// Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
     #[cfg_attr(feature = "typed-builder", builder(default))]
     pub after: Option<helix::Cursor>,
@@ -69,9 +69,9 @@ impl<'a> GetFollowedStreamsRequest<'a> {
     /// Requires token with scope [`user:read:follows`](twitch_oauth2::Scope::UserReadFollows).
     ///
     /// See also [`HelixClient::get_followed_streams`](crate::helix::HelixClient::get_followed_streams).
-    pub fn user_id(user_id: impl Into<&'a types::UserIdRef>) -> Self {
+    pub fn user_id(user_id: impl types::IntoCow<'a, types::UserIdRef> + 'a) -> Self {
         Self {
-            user_id: user_id.into(),
+            user_id: user_id.to_cow(),
             after: Default::default(),
             before: Default::default(),
             first: Default::default(),

--- a/src/helix/endpoints/streams/get_followed_streams.rs
+++ b/src/helix/endpoints/streams/get_followed_streams.rs
@@ -49,11 +49,11 @@ pub struct GetFollowedStreamsRequest<'a> {
     pub user_id: Cow<'a, types::UserIdRef>,
     /// Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
     #[cfg_attr(feature = "typed-builder", builder(default))]
-    pub after: Option<helix::Cursor>,
+    pub after: Option<Cow<'a, helix::CursorRef>>,
     /// Cursor for backward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
     #[cfg_attr(feature = "typed-builder", builder(default))]
     #[serde(borrow)]
-    pub before: Option<&'a helix::CursorRef>,
+    pub before: Option<Cow<'a, helix::CursorRef>>,
     /// Maximum number of objects to return. Maximum: 100. Default: 20.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     pub first: Option<usize>,
@@ -97,7 +97,9 @@ impl Request for GetFollowedStreamsRequest<'_> {
 impl RequestGet for GetFollowedStreamsRequest<'_> {}
 
 impl helix::Paginated for GetFollowedStreamsRequest<'_> {
-    fn set_pagination(&mut self, cursor: Option<helix::Cursor>) { self.after = cursor }
+    fn set_pagination(&mut self, cursor: Option<helix::Cursor>) {
+        self.after = cursor.map(|c| c.into_cow())
+    }
 }
 
 #[cfg(test)]

--- a/src/helix/endpoints/streams/get_stream_tags.rs
+++ b/src/helix/endpoints/streams/get_stream_tags.rs
@@ -46,16 +46,17 @@ use helix::RequestGet;
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct GetStreamTagsRequest {
+pub struct GetStreamTagsRequest<'a> {
     // FIXME: twitch docs sucks
     /// ID of the stream whose tags are going to be fetched
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub broadcaster_id: types::UserId,
+    #[serde(borrow)]
+    pub broadcaster_id: &'a types::UserIdRef,
 }
 
-impl GetStreamTagsRequest {
+impl<'a> GetStreamTagsRequest<'a> {
     /// ID of the stream whose tags are going to be fetched
-    pub fn broadcaster_id(broadcaster_id: impl Into<types::UserId>) -> Self {
+    pub fn broadcaster_id(broadcaster_id: impl Into<&'a types::UserIdRef>) -> Self {
         Self {
             broadcaster_id: broadcaster_id.into(),
         }
@@ -67,7 +68,7 @@ impl GetStreamTagsRequest {
 /// [`get-stream-tags`](https://dev.twitch.tv/docs/api/reference#get-stream-tags)
 pub type Tag = helix::tags::TwitchTag;
 
-impl Request for GetStreamTagsRequest {
+impl Request for GetStreamTagsRequest<'_> {
     type Response = Vec<Tag>;
 
     const PATH: &'static str = "streams/tags";
@@ -75,7 +76,7 @@ impl Request for GetStreamTagsRequest {
     const SCOPE: &'static [twitch_oauth2::Scope] = &[];
 }
 
-impl RequestGet for GetStreamTagsRequest {}
+impl RequestGet for GetStreamTagsRequest<'_> {}
 
 #[cfg(test)]
 #[test]

--- a/src/helix/endpoints/streams/get_stream_tags.rs
+++ b/src/helix/endpoints/streams/get_stream_tags.rs
@@ -5,13 +5,11 @@
 //!
 //! ## Request: [GetStreamTagsRequest]
 //!
-//! To use this endpoint, construct a [`GetStreamTagsRequest`] with the [`GetStreamTagsRequest::builder()`] method.
+//! To use this endpoint, construct a [`GetStreamTagsRequest`] with the [`GetStreamTagsRequest::broadcaster_id()`] method.
 //!
 //! ```rust
 //! use twitch_api::helix::streams::get_stream_tags;
-//! let request = get_stream_tags::GetStreamTagsRequest::builder()
-//!     .broadcaster_id("1234")
-//!     .build();
+//! let request = get_stream_tags::GetStreamTagsRequest::broadcaster_id("1234");
 //! ```
 //!
 //! ## Response: [Tag](helix::tags::TwitchTag)
@@ -26,9 +24,7 @@
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = get_stream_tags::GetStreamTagsRequest::builder()
-//!     .broadcaster_id("1234")
-//!     .build();
+//! let request = get_stream_tags::GetStreamTagsRequest::broadcaster_id("1234");
 //! let response: Vec<get_stream_tags::Tag> = client.req_get(request, &token).await?.data;
 //! # Ok(())
 //! # }

--- a/src/helix/endpoints/streams/get_stream_tags.rs
+++ b/src/helix/endpoints/streams/get_stream_tags.rs
@@ -51,14 +51,14 @@ pub struct GetStreamTagsRequest<'a> {
     /// ID of the stream whose tags are going to be fetched
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: &'a types::UserIdRef,
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
 }
 
 impl<'a> GetStreamTagsRequest<'a> {
     /// ID of the stream whose tags are going to be fetched
-    pub fn broadcaster_id(broadcaster_id: impl Into<&'a types::UserIdRef>) -> Self {
+    pub fn broadcaster_id(broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a) -> Self {
         Self {
-            broadcaster_id: broadcaster_id.into(),
+            broadcaster_id: broadcaster_id.to_cow(),
         }
     }
 }

--- a/src/helix/endpoints/streams/get_streams.rs
+++ b/src/helix/endpoints/streams/get_streams.rs
@@ -10,7 +10,7 @@
 //! ```rust
 //! use twitch_api::helix::streams::get_streams;
 //! let request = get_streams::GetStreamsRequest::builder()
-//!     .user_login(vec!["justintvfan".into()])
+//!     .user_login(&["justintvfan".into()][..])
 //!     .build();
 //! ```
 //!
@@ -20,14 +20,16 @@
 //!
 //! ```rust, no_run
 //! use twitch_api::helix::{self, streams::get_streams};
-//! # use twitch_api::client;
+//! # use twitch_api::{client, types};
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
-//! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
+//! let client: helix::HelixClient<'static, client::DummyHttpClient> =
+//!     helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
+//! let logins: &[&types::UserNameRef] = &["justintvfan".into()];
 //! let request = get_streams::GetStreamsRequest::builder()
-//!     .user_login(vec!["justintvfan".into()])
+//!     .user_login(logins)
 //!     .build();
 //! let response: Vec<get_streams::Stream> = client.req_get(request, &token).await?.data;
 //! # Ok(())
@@ -59,7 +61,10 @@ pub struct GetStreamsRequest<'a> {
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     pub first: Option<usize>,
     /// Returns streams broadcasting a specified game ID. You can specify up to 10 IDs.
-    #[cfg_attr(feature = "typed-builder", builder(default))]
+    #[cfg_attr(
+        feature = "typed-builder",
+        builder(default_code = "Cow::Borrowed(&[])", setter(into))
+    )]
     #[serde(borrow)]
     pub game_id: Cow<'a, [&'a types::CategoryIdRef]>,
     /// Stream language. You can specify up to 100 languages.
@@ -67,11 +72,17 @@ pub struct GetStreamsRequest<'a> {
     #[serde(borrow)]
     pub language: Option<&'a str>,
     /// Returns streams broadcast by one or more specified user IDs. You can specify up to 100 IDs.
-    #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
+    #[cfg_attr(
+        feature = "typed-builder",
+        builder(default_code = "Cow::Borrowed(&[])", setter(into))
+    )]
     #[serde(borrow)]
     pub user_id: Cow<'a, [&'a types::UserIdRef]>,
     /// Returns streams broadcast by one or more specified user login names. You can specify up to 100 names.
-    #[cfg_attr(feature = "typed-builder", builder(default))]
+    #[cfg_attr(
+        feature = "typed-builder",
+        builder(default_code = "Cow::Borrowed(&[])", setter(into))
+    )]
     #[serde(borrow)]
     pub user_login: Cow<'a, [&'a types::UserNameRef]>,
 }

--- a/src/helix/endpoints/streams/get_streams.rs
+++ b/src/helix/endpoints/streams/get_streams.rs
@@ -51,11 +51,11 @@ use helix::RequestGet;
 pub struct GetStreamsRequest<'a> {
     /// Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
     #[cfg_attr(feature = "typed-builder", builder(default))]
-    pub after: Option<helix::Cursor>,
+    pub after: Option<Cow<'a, helix::CursorRef>>,
     /// Cursor for backward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
     #[cfg_attr(feature = "typed-builder", builder(default))]
     #[serde(borrow)]
-    pub before: Option<&'a helix::CursorRef>,
+    pub before: Option<Cow<'a, helix::CursorRef>>,
     /// Maximum number of objects to return. Maximum: 100. Default: 20.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     pub first: Option<usize>,
@@ -174,7 +174,9 @@ impl Request for GetStreamsRequest<'_> {
 impl RequestGet for GetStreamsRequest<'_> {}
 
 impl helix::Paginated for GetStreamsRequest<'_> {
-    fn set_pagination(&mut self, cursor: Option<helix::Cursor>) { self.after = cursor }
+    fn set_pagination(&mut self, cursor: Option<helix::Cursor>) {
+        self.after = cursor.map(|c| c.into_cow())
+    }
 }
 
 #[cfg(test)]

--- a/src/helix/endpoints/streams/get_streams.rs
+++ b/src/helix/endpoints/streams/get_streams.rs
@@ -69,7 +69,7 @@ pub struct GetStreamsRequest<'a> {
     /// Stream language. You can specify up to 100 languages.
     #[cfg_attr(feature = "typed-builder", builder(default))]
     #[serde(borrow)]
-    pub language: Option<&'a str>,
+    pub language: Option<Cow<'a, str>>,
     /// Returns streams broadcast by one or more specified user IDs. You can specify up to 100 IDs.
     #[cfg_attr(
         feature = "typed-builder",

--- a/src/helix/endpoints/streams/get_streams.rs
+++ b/src/helix/endpoints/streams/get_streams.rs
@@ -41,7 +41,6 @@
 
 use super::*;
 use helix::RequestGet;
-use std::borrow::Cow;
 
 /// Query Parameters for [Get Streams](super::get_streams)
 ///

--- a/src/helix/endpoints/streams/mod.rs
+++ b/src/helix/endpoints/streams/mod.rs
@@ -4,16 +4,15 @@
 //! # Examples
 //!
 //! ```rust,no_run
-//! # use twitch_api::helix::{HelixClient, streams::GetStreamsRequest};
+//! # use twitch_api::{helix::{HelixClient, streams::GetStreamsRequest}, types};
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 //! let client = HelixClient::new();
 //! # let _: &HelixClient<twitch_api::DummyHttpClient> = &client;
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let req = GetStreamsRequest::builder()
-//!     .user_login(vec!["justinfan1337".into()])
-//!     .build();
+//! let logins: &[&types::UserNameRef] = &["justinfan1337".into()];
+//! let req = GetStreamsRequest::builder().user_login(logins).build();
 //!
 //! // If this doesn't return a result, that would mean the stream is not live.
 //! println!("{:?}", &client.req_get(req, &token).await?.data.get(0));

--- a/src/helix/endpoints/streams/mod.rs
+++ b/src/helix/endpoints/streams/mod.rs
@@ -24,6 +24,7 @@ use crate::{
     types,
 };
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 
 #[doc(inline)]
 pub use get_followed_streams::GetFollowedStreamsRequest;

--- a/src/helix/endpoints/streams/replace_stream_tags.rs
+++ b/src/helix/endpoints/streams/replace_stream_tags.rs
@@ -9,9 +9,7 @@
 //!
 //! ```rust
 //! use twitch_api::helix::streams::replace_stream_tags;
-//! let request = replace_stream_tags::ReplaceStreamTagsRequest::builder()
-//!     .broadcaster_id("1234")
-//!     .build();
+//! let request = replace_stream_tags::ReplaceStreamTagsRequest::broadcaster_id("1234");
 //! ```
 //!
 //! ## Body: [ReplaceStreamTagsBody]
@@ -20,12 +18,10 @@
 //!
 //! ```
 //! # use twitch_api::helix::streams::replace_stream_tags;
-//! let body = replace_stream_tags::ReplaceStreamTagsBody::builder()
-//!     .tag_ids(vec![
-//!         "621fb5bf-5498-4d8f-b4ac-db4d40d401bf".into(),
-//!         "79977fb9-f106-4a87-a386-f1b0f99783dd".into(),
-//!     ])
-//!     .build();
+//! let body = replace_stream_tags::ReplaceStreamTagsBody::tag_ids(vec![
+//!     "621fb5bf-5498-4d8f-b4ac-db4d40d401bf".into(),
+//!     "79977fb9-f106-4a87-a386-f1b0f99783dd".into(),
+//! ]);
 //! ```
 //!
 //! ## Response: [ReplaceStreamTags]
@@ -42,15 +38,11 @@
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = replace_stream_tags::ReplaceStreamTagsRequest::builder()
-//!     .broadcaster_id("1234")
-//!     .build();
-//! let body = replace_stream_tags::ReplaceStreamTagsBody::builder()
-//!     .tag_ids(vec![
-//!         "621fb5bf-5498-4d8f-b4ac-db4d40d401bf".into(),
-//!         "79977fb9-f106-4a87-a386-f1b0f99783dd".into(),
-//!     ])
-//!     .build();
+//! let request = replace_stream_tags::ReplaceStreamTagsRequest::broadcaster_id("1234");
+//! let body = replace_stream_tags::ReplaceStreamTagsBody::tag_ids(vec![
+//!     "621fb5bf-5498-4d8f-b4ac-db4d40d401bf".into(),
+//!     "79977fb9-f106-4a87-a386-f1b0f99783dd".into(),
+//! ]);
 //! let response: replace_stream_tags::ReplaceStreamTags = client.req_put(request, body, &token).await?.data;
 //! # Ok(())
 //! # }

--- a/src/helix/endpoints/streams/replace_stream_tags.rs
+++ b/src/helix/endpoints/streams/replace_stream_tags.rs
@@ -60,7 +60,6 @@
 //! and parse the [`http::Response`] with [`ReplaceStreamTagsRequest::parse_response(None, &request.get_uri(), response)`](ReplaceStreamTagsRequest::parse_response)
 use super::*;
 use helix::RequestPut;
-use std::borrow::Cow;
 
 /// Query Parameters for [Replace Stream Tags](super::replace_stream_tags)
 ///
@@ -72,14 +71,14 @@ pub struct ReplaceStreamTagsRequest<'a> {
     /// ID of the stream for which tags are to be replaced.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: &'a types::UserIdRef,
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
 }
 
 impl<'a> ReplaceStreamTagsRequest<'a> {
     /// ID of the stream for which tags are to be replaced.
-    pub fn broadcaster_id(broadcaster_id: impl Into<&'a types::UserIdRef>) -> Self {
+    pub fn broadcaster_id(broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a) -> Self {
         Self {
-            broadcaster_id: broadcaster_id.into(),
+            broadcaster_id: broadcaster_id.to_cow(),
         }
     }
 }

--- a/src/helix/endpoints/subscriptions/check_user_subscription.rs
+++ b/src/helix/endpoints/subscriptions/check_user_subscription.rs
@@ -38,7 +38,6 @@
 //! and parse the [`http::Response`] with [`CheckUserSubscriptionRequest::parse_response(None, &request.get_uri(), response)`](CheckUserSubscriptionRequest::parse_response)
 use super::*;
 use helix::RequestGet;
-use std::borrow::Cow;
 
 /// Query Parameters for [Check User Subscription](super::check_user_subscription)
 ///
@@ -50,7 +49,7 @@ pub struct CheckUserSubscriptionRequest<'a> {
     /// User ID of the broadcaster. Must match the User ID in the Bearer token.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: &'a types::UserIdRef,
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
     /// Unique identifier of account to get subscription status of. Accepts up to 100 values.
     #[cfg_attr(feature = "typed-builder", builder(default))]
     #[serde(borrow)]
@@ -59,9 +58,9 @@ pub struct CheckUserSubscriptionRequest<'a> {
 
 impl<'a> CheckUserSubscriptionRequest<'a> {
     /// Checks subscribed users to this specific channel.
-    pub fn broadcaster_id(broadcaster_id: impl Into<&'a types::UserIdRef>) -> Self {
+    pub fn broadcaster_id(broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a) -> Self {
         Self {
-            broadcaster_id: broadcaster_id.into(),
+            broadcaster_id: broadcaster_id.to_cow(),
             user_id: Cow::Borrowed(&[]),
         }
     }

--- a/src/helix/endpoints/subscriptions/check_user_subscription.rs
+++ b/src/helix/endpoints/subscriptions/check_user_subscription.rs
@@ -5,13 +5,11 @@
 //!
 //! ## Request: [CheckUserSubscriptionRequest]
 //!
-//! To use this endpoint, construct a [`CheckUserSubscriptionRequest`] with the [`CheckUserSubscriptionRequest::builder()`] method.
+//! To use this endpoint, construct a [`CheckUserSubscriptionRequest`] with the [`CheckUserSubscriptionRequest::broadcaster_id()`] method.
 //!
 //! ```rust
 //! use twitch_api::helix::subscriptions::check_user_subscription;
-//! let request = check_user_subscription::CheckUserSubscriptionRequest::builder()
-//!     .broadcaster_id("1234")
-//!     .build();
+//! let request = check_user_subscription::CheckUserSubscriptionRequest::broadcaster_id("1234");
 //! ```
 //!
 //! ## Response: [UserSubscription]
@@ -26,9 +24,7 @@
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = check_user_subscription::CheckUserSubscriptionRequest::builder()
-//!     .broadcaster_id("1234")
-//!     .build();
+//! let request = check_user_subscription::CheckUserSubscriptionRequest::broadcaster_id("1234");
 //! let response: check_user_subscription::UserSubscription = client.req_get(request, &token).await?.data;
 //! # Ok(())
 //! # }

--- a/src/helix/endpoints/subscriptions/get_broadcaster_subscriptions.rs
+++ b/src/helix/endpoints/subscriptions/get_broadcaster_subscriptions.rs
@@ -55,7 +55,7 @@ pub struct GetBroadcasterSubscriptionsRequest<'a> {
     pub user_id: Cow<'a, [&'a types::UserIdRef]>,
     /// Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
     #[cfg_attr(feature = "typed-builder", builder(default))]
-    pub after: Option<helix::Cursor>,
+    pub after: Option<Cow<'a, helix::CursorRef>>,
     /// Number of values to be returned per page. Limit: 100. Default: 20.
     #[cfg_attr(feature = "typed-builder", builder(setter(into), default))]
     pub first: Option<usize>,
@@ -142,7 +142,9 @@ impl Request for GetBroadcasterSubscriptionsRequest<'_> {
 impl RequestGet for GetBroadcasterSubscriptionsRequest<'_> {}
 
 impl helix::Paginated for GetBroadcasterSubscriptionsRequest<'_> {
-    fn set_pagination(&mut self, cursor: Option<helix::Cursor>) { self.after = cursor }
+    fn set_pagination(&mut self, cursor: Option<helix::Cursor>) {
+        self.after = cursor.map(|c| c.into_cow())
+    }
 }
 
 impl helix::Response<GetBroadcasterSubscriptionsRequest<'_>, Vec<BroadcasterSubscription>> {

--- a/src/helix/endpoints/subscriptions/get_broadcaster_subscriptions.rs
+++ b/src/helix/endpoints/subscriptions/get_broadcaster_subscriptions.rs
@@ -39,7 +39,7 @@
 
 use super::*;
 use helix::RequestGet;
-use std::borrow::Cow;
+
 /// Query Parameters for [Get Broadcaster Subscriptions](super::get_broadcaster_subscriptions)
 ///
 /// [`get-broadcaster-subscriptions`](https://dev.twitch.tv/docs/api/reference#get-broadcaster-subscriptions)
@@ -50,7 +50,7 @@ pub struct GetBroadcasterSubscriptionsRequest<'a> {
     /// User ID of the broadcaster. Must match the User ID in the Bearer token.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: &'a types::UserIdRef,
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
     /// Unique identifier of account to get subscription status of. Accepts up to 100 values.
     #[cfg_attr(feature = "typed-builder", builder(default))]
     #[serde(borrow)]
@@ -65,9 +65,9 @@ pub struct GetBroadcasterSubscriptionsRequest<'a> {
 
 impl<'a> GetBroadcasterSubscriptionsRequest<'a> {
     /// Get a broadcasters subscribers
-    pub fn broadcaster_id(broadcaster_id: impl Into<&'a types::UserIdRef>) -> Self {
+    pub fn broadcaster_id(broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a) -> Self {
         Self {
-            broadcaster_id: broadcaster_id.into(),
+            broadcaster_id: broadcaster_id.to_cow(),
             user_id: Cow::Borrowed(&[]),
             after: Default::default(),
             first: Default::default(),

--- a/src/helix/endpoints/subscriptions/get_broadcaster_subscriptions.rs
+++ b/src/helix/endpoints/subscriptions/get_broadcaster_subscriptions.rs
@@ -5,13 +5,12 @@
 //!
 //! ## Request: [GetBroadcasterSubscriptionsRequest]
 //!
-//! To use this endpoint, construct a [`GetBroadcasterSubscriptionsRequest`] with the [`GetBroadcasterSubscriptionsRequest::builder()`] method.
+//! To use this endpoint, construct a [`GetBroadcasterSubscriptionsRequest`] with the [`GetBroadcasterSubscriptionsRequest::broadcaster_id()`] method.
 //!
 //! ```rust
 //! use twitch_api::helix::subscriptions::get_broadcaster_subscriptions;
-//! let request = get_broadcaster_subscriptions::GetBroadcasterSubscriptionsRequest::builder()
-//!     .broadcaster_id("1234")
-//!     .build();
+//! let request =
+//!     get_broadcaster_subscriptions::GetBroadcasterSubscriptionsRequest::broadcaster_id("1234");
 //! ```
 //!
 //! ## Response: [BroadcasterSubscription]
@@ -26,9 +25,8 @@
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = get_broadcaster_subscriptions::GetBroadcasterSubscriptionsRequest::builder()
-//!     .broadcaster_id("1234")
-//!     .build();
+//! let request =
+//!     get_broadcaster_subscriptions::GetBroadcasterSubscriptionsRequest::broadcaster_id("1234");
 //! let response: Vec<get_broadcaster_subscriptions::BroadcasterSubscription> = client.req_get(request, &token).await?.data;
 //! # Ok(())
 //! # }

--- a/src/helix/endpoints/subscriptions/get_broadcaster_subscriptions_events.rs
+++ b/src/helix/endpoints/subscriptions/get_broadcaster_subscriptions_events.rs
@@ -10,14 +10,12 @@
 //!
 //! ## Request: [GetBroadcasterSubscriptionsEventsRequest]
 //!
-//! To use this endpoint, construct a [`GetBroadcasterSubscriptionsEventsRequest`] with the [`GetBroadcasterSubscriptionsEventsRequest::builder()`] method.
+//! To use this endpoint, construct a [`GetBroadcasterSubscriptionsEventsRequest`] with the [`GetBroadcasterSubscriptionsEventsRequest::broadcaster_id()`] method.
 //!
 //! ```rust
 //! use twitch_api::helix::subscriptions::get_broadcaster_subscriptions_events;
 //! let request =
-//!     get_broadcaster_subscriptions_events::GetBroadcasterSubscriptionsEventsRequest::builder()
-//!         .broadcaster_id("1234")
-//!         .build();
+//!     get_broadcaster_subscriptions_events::GetBroadcasterSubscriptionsEventsRequest::broadcaster_id("1234");
 //! ```
 //!
 //! ## Response: [BroadcasterSubscriptionEvent]
@@ -32,9 +30,8 @@
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = get_broadcaster_subscriptions_events::GetBroadcasterSubscriptionsEventsRequest::builder()
-//!     .broadcaster_id("1234")
-//!     .build();
+//! let request =
+//!     get_broadcaster_subscriptions_events::GetBroadcasterSubscriptionsEventsRequest::broadcaster_id("1234");
 //! let response: Vec<get_broadcaster_subscriptions_events::BroadcasterSubscriptionEvent> = client.req_get(request, &token).await?.data;
 //! # Ok(())
 //! # }

--- a/src/helix/endpoints/subscriptions/get_broadcaster_subscriptions_events.rs
+++ b/src/helix/endpoints/subscriptions/get_broadcaster_subscriptions_events.rs
@@ -69,7 +69,7 @@ pub struct GetBroadcasterSubscriptionsEventsRequest<'a> {
     /// Retreive a single event by event ID
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(borrow)]
-    pub id: Option<&'a str>,
+    pub id: Option<Cow<'a, str>>,
 }
 
 impl<'a> GetBroadcasterSubscriptionsEventsRequest<'a> {

--- a/src/helix/endpoints/subscriptions/get_broadcaster_subscriptions_events.rs
+++ b/src/helix/endpoints/subscriptions/get_broadcaster_subscriptions_events.rs
@@ -46,7 +46,6 @@
 
 use super::*;
 use helix::RequestGet;
-use std::borrow::Cow;
 
 /// Query Parameters for [Get Broadcaster Subscriptions Events](super::get_broadcaster_subscriptions_events)
 ///
@@ -58,7 +57,7 @@ pub struct GetBroadcasterSubscriptionsEventsRequest<'a> {
     /// Must match the User ID in the Bearer token.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: &'a types::UserIdRef,
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
     /// Filters the results and only returns a status object for users who have a subscribe event in this channel and have a matching user_id.
     /// Maximum: 100
     #[cfg_attr(feature = "typed-builder", builder(default))]
@@ -78,9 +77,9 @@ pub struct GetBroadcasterSubscriptionsEventsRequest<'a> {
 
 impl<'a> GetBroadcasterSubscriptionsEventsRequest<'a> {
     /// Get events for this broadcaster
-    pub fn broadcaster_id(broadcaster_id: impl Into<&'a types::UserIdRef>) -> Self {
+    pub fn broadcaster_id(broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a) -> Self {
         Self {
-            broadcaster_id: broadcaster_id.into(),
+            broadcaster_id: broadcaster_id.to_cow(),
             user_id: Cow::Borrowed(&[]),
             after: Default::default(),
             first: Default::default(),

--- a/src/helix/endpoints/subscriptions/get_broadcaster_subscriptions_events.rs
+++ b/src/helix/endpoints/subscriptions/get_broadcaster_subscriptions_events.rs
@@ -62,7 +62,7 @@ pub struct GetBroadcasterSubscriptionsEventsRequest<'a> {
     pub user_id: Cow<'a, [&'a types::UserIdRef]>,
     /// Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
     #[cfg_attr(feature = "typed-builder", builder(default))]
-    pub after: Option<helix::Cursor>,
+    pub after: Option<Cow<'a, helix::CursorRef>>,
     /// Maximum number of objects to return. Maximum: 100. Default: 20.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     pub first: Option<usize>,
@@ -184,7 +184,9 @@ impl Request for GetBroadcasterSubscriptionsEventsRequest<'_> {
 impl RequestGet for GetBroadcasterSubscriptionsEventsRequest<'_> {}
 
 impl helix::Paginated for GetBroadcasterSubscriptionsEventsRequest<'_> {
-    fn set_pagination(&mut self, cursor: Option<helix::Cursor>) { self.after = cursor }
+    fn set_pagination(&mut self, cursor: Option<helix::Cursor>) {
+        self.after = cursor.map(|c| c.into_cow())
+    }
 }
 
 #[cfg(test)]

--- a/src/helix/endpoints/subscriptions/mod.rs
+++ b/src/helix/endpoints/subscriptions/mod.rs
@@ -26,6 +26,7 @@ use crate::{
     types,
 };
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 
 pub mod check_user_subscription;
 pub mod get_broadcaster_subscriptions;

--- a/src/helix/endpoints/subscriptions/mod.rs
+++ b/src/helix/endpoints/subscriptions/mod.rs
@@ -11,10 +11,7 @@
 //! # let _: &HelixClient<twitch_api::DummyHttpClient> = &client;
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let req = GetBroadcasterSubscriptionsRequest::builder()
-//!     .broadcaster_id("1234")
-//!     .build();
-//!
+//! let req = GetBroadcasterSubscriptionsRequest::broadcaster_id("1234");
 //!
 //! println!("{:?}", &client.req_get(req, &token).await?.data);
 //! # Ok(())

--- a/src/helix/endpoints/tags/get_all_stream_tags.rs
+++ b/src/helix/endpoints/tags/get_all_stream_tags.rs
@@ -38,7 +38,6 @@
 
 use super::*;
 use helix::RequestGet;
-use std::borrow::Cow;
 
 /// Query Parameters for [Get All Stream Tags](super::get_all_stream_tags)
 ///

--- a/src/helix/endpoints/tags/get_all_stream_tags.rs
+++ b/src/helix/endpoints/tags/get_all_stream_tags.rs
@@ -48,7 +48,7 @@ use helix::RequestGet;
 pub struct GetAllStreamTagsRequest<'a> {
     /// Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
     #[cfg_attr(feature = "typed-builder", builder(default))]
-    pub after: Option<helix::Cursor>,
+    pub after: Option<Cow<'a, helix::CursorRef>>,
     /// Maximum number of objects to return. Maximum: 100. Default: 20.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     pub first: Option<usize>,
@@ -92,7 +92,9 @@ impl Request for GetAllStreamTagsRequest<'_> {
 impl RequestGet for GetAllStreamTagsRequest<'_> {}
 
 impl helix::Paginated for GetAllStreamTagsRequest<'_> {
-    fn set_pagination(&mut self, cursor: Option<helix::Cursor>) { self.after = cursor }
+    fn set_pagination(&mut self, cursor: Option<helix::Cursor>) {
+        self.after = cursor.map(|c| c.into_cow())
+    }
 }
 
 #[cfg(test)]

--- a/src/helix/endpoints/tags/get_all_stream_tags.rs
+++ b/src/helix/endpoints/tags/get_all_stream_tags.rs
@@ -38,14 +38,15 @@
 
 use super::*;
 use helix::RequestGet;
+use std::borrow::Cow;
 
 /// Query Parameters for [Get All Stream Tags](super::get_all_stream_tags)
 ///
 /// [`get-all-stream-tags`](https://dev.twitch.tv/docs/api/reference#get-all-stream-tags)
-#[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug, Default)]
+#[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct GetAllStreamTagsRequest {
+pub struct GetAllStreamTagsRequest<'a> {
     /// Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
     #[cfg_attr(feature = "typed-builder", builder(default))]
     pub after: Option<helix::Cursor>,
@@ -54,20 +55,25 @@ pub struct GetAllStreamTagsRequest {
     pub first: Option<usize>,
     /// ID of a tag. Multiple IDs can be specified. If provided, only the specified tag(s) is(are) returned. Maximum of 100.
     #[cfg_attr(feature = "typed-builder", builder(default))]
-    pub tag_id: Vec<types::TagId>,
+    #[serde(borrow)]
+    pub tag_id: Cow<'a, [&'a types::TagIdRef]>,
 }
 
-impl GetAllStreamTagsRequest {
+impl<'a> GetAllStreamTagsRequest<'a> {
     /// Filter the results for specific tag.
-    pub fn tag_ids(mut self, tag_ids: impl IntoIterator<Item = impl Into<types::TagId>>) -> Self {
-        self.tag_id = tag_ids.into_iter().map(Into::into).collect();
+    pub fn tag_ids(mut self, tag_ids: impl Into<Cow<'a, [&'a types::TagIdRef]>>) -> Self {
+        self.tag_id = tag_ids.into();
         self
     }
+}
 
-    /// Filter the results for specific tag.
-    pub fn tag_id(mut self, tag_id: impl Into<types::TagId>) -> Self {
-        self.tag_id = vec![tag_id.into()];
-        self
+impl Default for GetAllStreamTagsRequest<'_> {
+    fn default() -> Self {
+        Self {
+            after: None,
+            first: None,
+            tag_id: Cow::Borrowed(&[]),
+        }
     }
 }
 
@@ -76,7 +82,7 @@ impl GetAllStreamTagsRequest {
 /// [`get-all-stream-tags`](https://dev.twitch.tv/docs/api/reference#get-all-stream-tags)
 pub type Tag = helix::tags::TwitchTag;
 
-impl Request for GetAllStreamTagsRequest {
+impl Request for GetAllStreamTagsRequest<'_> {
     type Response = Vec<Tag>;
 
     const PATH: &'static str = "tags/streams";
@@ -84,9 +90,9 @@ impl Request for GetAllStreamTagsRequest {
     const SCOPE: &'static [twitch_oauth2::Scope] = &[];
 }
 
-impl RequestGet for GetAllStreamTagsRequest {}
+impl RequestGet for GetAllStreamTagsRequest<'_> {}
 
-impl helix::Paginated for GetAllStreamTagsRequest {
+impl helix::Paginated for GetAllStreamTagsRequest<'_> {
     fn set_pagination(&mut self, cursor: Option<helix::Cursor>) { self.after = cursor }
 }
 

--- a/src/helix/endpoints/tags/mod.rs
+++ b/src/helix/endpoints/tags/mod.rs
@@ -22,6 +22,7 @@ use crate::{
     types,
 };
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 use std::collections::HashMap;
 
 pub mod get_all_stream_tags;

--- a/src/helix/endpoints/teams/get_channel_teams.rs
+++ b/src/helix/endpoints/teams/get_channel_teams.rs
@@ -3,13 +3,11 @@
 //!
 //! ## Request: [GetChannelTeamsRequest]
 //!
-//! To use this endpoint, construct a [`GetChannelTeamsRequest`] with the [`GetChannelTeamsRequest::builder()`] method.
+//! To use this endpoint, construct a [`GetChannelTeamsRequest`] with the [`GetChannelTeamsRequest::broadcaster_id()`] method.
 //!
 //! ```rust
 //! use twitch_api::helix::teams::get_channel_teams;
-//! let request = get_channel_teams::GetChannelTeamsRequest::builder()
-//!     .broadcaster_id("1337")
-//!     .build();
+//! let request = get_channel_teams::GetChannelTeamsRequest::broadcaster_id("1337");
 //! ```
 //!
 //! ## Response: [BroadcasterTeam]
@@ -24,9 +22,7 @@
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = get_channel_teams::GetChannelTeamsRequest::builder()
-//!     .broadcaster_id("1337")
-//!     .build();
+//! let request = get_channel_teams::GetChannelTeamsRequest::broadcaster_id("1337");
 //! let response: Vec<get_channel_teams::BroadcasterTeam> = client.req_get(request, &token).await?.data;
 //! # Ok(())
 //! # }

--- a/src/helix/endpoints/teams/get_channel_teams.rs
+++ b/src/helix/endpoints/teams/get_channel_teams.rs
@@ -48,14 +48,14 @@ pub struct GetChannelTeamsRequest<'a> {
     /// Team ID.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: &'a types::UserIdRef,
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
 }
 
 impl<'a> GetChannelTeamsRequest<'a> {
     /// Get the team of this specific broadcaster
-    pub fn broadcaster_id(broadcaster_id: impl Into<&'a types::UserIdRef>) -> Self {
+    pub fn broadcaster_id(broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a) -> Self {
         Self {
-            broadcaster_id: broadcaster_id.into(),
+            broadcaster_id: broadcaster_id.to_cow(),
         }
     }
 }

--- a/src/helix/endpoints/teams/get_channel_teams.rs
+++ b/src/helix/endpoints/teams/get_channel_teams.rs
@@ -44,15 +44,16 @@ use helix::RequestGet;
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct GetChannelTeamsRequest {
+pub struct GetChannelTeamsRequest<'a> {
     /// Team ID.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub broadcaster_id: types::UserId,
+    #[serde(borrow)]
+    pub broadcaster_id: &'a types::UserIdRef,
 }
 
-impl GetChannelTeamsRequest {
+impl<'a> GetChannelTeamsRequest<'a> {
     /// Get the team of this specific broadcaster
-    pub fn broadcaster_id(broadcaster_id: impl Into<types::UserId>) -> Self {
+    pub fn broadcaster_id(broadcaster_id: impl Into<&'a types::UserIdRef>) -> Self {
         Self {
             broadcaster_id: broadcaster_id.into(),
         }
@@ -77,7 +78,7 @@ pub struct BroadcasterTeam {
     pub team: TeamInformation,
 }
 
-impl Request for GetChannelTeamsRequest {
+impl Request for GetChannelTeamsRequest<'_> {
     type Response = Vec<BroadcasterTeam>;
 
     #[cfg(feature = "twitch_oauth2")]
@@ -87,7 +88,7 @@ impl Request for GetChannelTeamsRequest {
     const SCOPE: &'static [twitch_oauth2::Scope] = &[];
 }
 
-impl RequestGet for GetChannelTeamsRequest {}
+impl RequestGet for GetChannelTeamsRequest<'_> {}
 
 #[cfg(test)]
 #[test]

--- a/src/helix/endpoints/teams/get_teams.rs
+++ b/src/helix/endpoints/teams/get_teams.rs
@@ -3,13 +3,11 @@
 //!
 //! ## Request: [GetTeamsRequest]
 //!
-//! To use this endpoint, construct a [`GetTeamsRequest`] with the [`GetTeamsRequest::builder()`] method.
+//! To use this endpoint, construct a [`GetTeamsRequest`]
 //!
 //! ```rust
 //! use twitch_api::helix::teams::get_teams;
-//! let request = get_teams::GetTeamsRequest::builder()
-//!     .name("coolteam")
-//!     .build();
+//! let request = get_teams::GetTeamsRequest::name("coolteam");
 //! ```
 //!
 //! ## Response: [Team]
@@ -24,9 +22,7 @@
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = get_teams::GetTeamsRequest::builder()
-//!     .name("coolteam")
-//!     .build();
+//! let request = get_teams::GetTeamsRequest::name("coolteam");
 //! let response: Vec<get_teams::Team> = client.req_get(request, &token).await?.data;
 //! # Ok(())
 //! # }
@@ -52,7 +48,7 @@ pub struct GetTeamsRequest<'a> {
     /// Team name.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(borrow)]
-    pub name: Option<&'a str>,
+    pub name: Option<Cow<'a, str>>,
 }
 
 impl<'a> GetTeamsRequest<'a> {
@@ -65,10 +61,10 @@ impl<'a> GetTeamsRequest<'a> {
     }
 
     /// Get team with this name
-    pub fn name(name: &'a str) -> Self {
+    pub fn name(name: impl Into<Cow<'a, str>>) -> Self {
         Self {
             id: None,
-            name: Some(name),
+            name: Some(name.into()),
         }
     }
 }

--- a/src/helix/endpoints/teams/get_teams.rs
+++ b/src/helix/endpoints/teams/get_teams.rs
@@ -44,18 +44,20 @@ use helix::RequestGet;
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct GetTeamsRequest {
+pub struct GetTeamsRequest<'a> {
     /// Team ID.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
-    pub id: Option<types::TeamId>,
+    #[serde(borrow)]
+    pub id: Option<&'a types::TeamIdRef>,
     /// Team name.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
-    pub name: Option<String>,
+    #[serde(borrow)]
+    pub name: Option<&'a str>,
 }
 
-impl GetTeamsRequest {
+impl<'a> GetTeamsRequest<'a> {
     /// Get team with this [`TeamId`](types::TeamId)
-    pub fn id(id: impl Into<types::TeamId>) -> Self {
+    pub fn id(id: impl Into<&'a types::TeamIdRef>) -> Self {
         Self {
             id: Some(id.into()),
             name: None,
@@ -63,7 +65,7 @@ impl GetTeamsRequest {
     }
 
     /// Get team with this name
-    pub fn name(name: String) -> Self {
+    pub fn name(name: &'a str) -> Self {
         Self {
             id: None,
             name: Some(name),
@@ -85,7 +87,7 @@ pub struct Team {
     pub team: TeamInformation,
 }
 
-impl Request for GetTeamsRequest {
+impl Request for GetTeamsRequest<'_> {
     type Response = Vec<Team>;
 
     #[cfg(feature = "twitch_oauth2")]
@@ -95,7 +97,7 @@ impl Request for GetTeamsRequest {
     const SCOPE: &'static [twitch_oauth2::Scope] = &[];
 }
 
-impl RequestGet for GetTeamsRequest {}
+impl RequestGet for GetTeamsRequest<'_> {}
 
 #[cfg(test)]
 #[test]

--- a/src/helix/endpoints/teams/get_teams.rs
+++ b/src/helix/endpoints/teams/get_teams.rs
@@ -48,7 +48,7 @@ pub struct GetTeamsRequest<'a> {
     /// Team ID.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(borrow)]
-    pub id: Option<&'a types::TeamIdRef>,
+    pub id: Option<Cow<'a, types::TeamIdRef>>,
     /// Team name.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(borrow)]
@@ -57,9 +57,9 @@ pub struct GetTeamsRequest<'a> {
 
 impl<'a> GetTeamsRequest<'a> {
     /// Get team with this [`TeamId`](types::TeamId)
-    pub fn id(id: impl Into<&'a types::TeamIdRef>) -> Self {
+    pub fn id(id: impl types::IntoCow<'a, types::TeamIdRef> + 'a) -> Self {
         Self {
-            id: Some(id.into()),
+            id: Some(id.to_cow()),
             name: None,
         }
     }

--- a/src/helix/endpoints/teams/get_teams.rs
+++ b/src/helix/endpoints/teams/get_teams.rs
@@ -8,7 +8,7 @@
 //! ```rust
 //! use twitch_api::helix::teams::get_teams;
 //! let request = get_teams::GetTeamsRequest::builder()
-//!     .name("coolteam".to_string())
+//!     .name("coolteam")
 //!     .build();
 //! ```
 //!
@@ -25,7 +25,7 @@
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
 //! let request = get_teams::GetTeamsRequest::builder()
-//!     .name("coolteam".to_string())
+//!     .name("coolteam")
 //!     .build();
 //! let response: Vec<get_teams::Team> = client.req_get(request, &token).await?.data;
 //! # Ok(())

--- a/src/helix/endpoints/teams/mod.rs
+++ b/src/helix/endpoints/teams/mod.rs
@@ -5,6 +5,7 @@ use crate::{
     types,
 };
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 
 pub mod get_channel_teams;
 pub mod get_teams;

--- a/src/helix/endpoints/users/block_user.rs
+++ b/src/helix/endpoints/users/block_user.rs
@@ -5,19 +5,15 @@
 //!
 //! ## Request: [BlockUserRequest]
 //!
-//! To use this endpoint, construct a [`BlockUserRequest`] with the [`BlockUserRequest::builder()`] method.
+//! To use this endpoint, construct a [`BlockUserRequest`] with the [`BlockUserRequest::block_user()`] method.
 //!
 //! ```rust
 //! use twitch_api::helix::users::block_user::{self, Reason, SourceContext};
-//! let request = block_user::BlockUserRequest::builder()
-//!     .target_user_id("1234")
-//!     .build();
+//! let request = block_user::BlockUserRequest::block_user("1234");
 //! // Or, specifying a reason for the block
-//! let request = block_user::BlockUserRequest::builder()
-//!     .target_user_id("1234")
+//! let request = block_user::BlockUserRequest::block_user("1234")
 //!     .source_context(SourceContext::Chat)
-//!     .reason(Reason::Spam)
-//!     .build();
+//!     .reason(Reason::Spam);
 //! ```
 //!
 //! ## Response: [BlockUser]
@@ -32,9 +28,7 @@
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = block_user::BlockUserRequest::builder()
-//!     .target_user_id("1234")
-//!     .build();
+//! let request = block_user::BlockUserRequest::block_user("1234");
 //! let response: block_user::BlockUser = client.req_put(request, helix::EmptyBody, &token).await?.data;
 //! # Ok(())
 //! # }

--- a/src/helix/endpoints/users/block_user.rs
+++ b/src/helix/endpoints/users/block_user.rs
@@ -56,7 +56,7 @@ pub struct BlockUserRequest<'a> {
     /// User ID of the follower
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub target_user_id: &'a types::UserIdRef,
+    pub target_user_id: Cow<'a, types::UserIdRef>,
     /// Source context for blocking the user. Valid values: "chat", "whisper".
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     pub source_context: Option<SourceContext>,
@@ -67,9 +67,9 @@ pub struct BlockUserRequest<'a> {
 
 impl<'a> BlockUserRequest<'a> {
     /// Block a user
-    pub fn block_user(target_user_id: impl Into<&'a types::UserIdRef>) -> Self {
+    pub fn block_user(target_user_id: impl types::IntoCow<'a, types::UserIdRef> + 'a) -> Self {
         Self {
-            target_user_id: target_user_id.into(),
+            target_user_id: target_user_id.to_cow(),
             source_context: None,
             reason: None,
         }

--- a/src/helix/endpoints/users/block_user.rs
+++ b/src/helix/endpoints/users/block_user.rs
@@ -52,10 +52,11 @@ use helix::RequestPut;
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct BlockUserRequest {
+pub struct BlockUserRequest<'a> {
     /// User ID of the follower
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub target_user_id: types::UserId,
+    #[serde(borrow)]
+    pub target_user_id: &'a types::UserIdRef,
     /// Source context for blocking the user. Valid values: "chat", "whisper".
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     pub source_context: Option<SourceContext>,
@@ -64,9 +65,9 @@ pub struct BlockUserRequest {
     pub reason: Option<Reason>,
 }
 
-impl BlockUserRequest {
+impl<'a> BlockUserRequest<'a> {
     /// Block a user
-    pub fn block_user(target_user_id: impl Into<types::UserId>) -> Self {
+    pub fn block_user(target_user_id: impl Into<&'a types::UserIdRef>) -> Self {
         Self {
             target_user_id: target_user_id.into(),
             source_context: None,
@@ -88,7 +89,7 @@ impl BlockUserRequest {
 }
 
 /// Source context for blocking the user.
-#[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
+#[derive(PartialEq, Eq, Deserialize, Serialize, Copy, Clone, Debug)]
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
 pub enum SourceContext {
@@ -99,7 +100,7 @@ pub enum SourceContext {
 }
 
 /// Reason for blocking the user.
-#[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
+#[derive(PartialEq, Eq, Deserialize, Serialize, Copy, Clone, Debug)]
 #[serde(rename_all = "lowercase")]
 #[non_exhaustive]
 pub enum Reason {
@@ -121,7 +122,7 @@ pub enum BlockUser {
     Success,
 }
 
-impl Request for BlockUserRequest {
+impl Request for BlockUserRequest<'_> {
     type Response = BlockUser;
 
     #[cfg(feature = "twitch_oauth2")]
@@ -131,7 +132,7 @@ impl Request for BlockUserRequest {
     const SCOPE: &'static [twitch_oauth2::Scope] = &[twitch_oauth2::Scope::UserManageBlockedUsers];
 }
 
-impl RequestPut for BlockUserRequest {
+impl RequestPut for BlockUserRequest<'_> {
     type Body = helix::EmptyBody;
 
     fn parse_inner_response(

--- a/src/helix/endpoints/users/get_user_block_list.rs
+++ b/src/helix/endpoints/users/get_user_block_list.rs
@@ -3,13 +3,11 @@
 //!
 //! ## Request: [GetUserBlockListRequest]
 //!
-//! To use this endpoint, construct a [`GetUserBlockListRequest`] with the [`GetUserBlockListRequest::builder()`] method.
+//! To use this endpoint, construct a [`GetUserBlockListRequest`] with the [`GetUserBlockListRequest::broadcaster_id()`] method.
 //!
 //! ```rust
 //! use twitch_api::helix::users::get_user_block_list;
-//! let request = get_user_block_list::GetUserBlockListRequest::builder()
-//!     .broadcaster_id("1234")
-//!     .build();
+//! let request = get_user_block_list::GetUserBlockListRequest::broadcaster_id("1234");
 //! ```
 //!
 //! ## Response: [UserBlock]
@@ -24,9 +22,7 @@
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = get_user_block_list::GetUserBlockListRequest::builder()
-//!     .broadcaster_id("1234")
-//!     .build();
+//! let request = get_user_block_list::GetUserBlockListRequest::broadcaster_id("1234");
 //! let response: Vec<get_user_block_list::UserBlock> = client.req_get(request, &token).await?.data;
 //! # Ok(())
 //! # }

--- a/src/helix/endpoints/users/get_user_block_list.rs
+++ b/src/helix/endpoints/users/get_user_block_list.rs
@@ -47,7 +47,7 @@ pub struct GetUserBlockListRequest<'a> {
     pub broadcaster_id: Cow<'a, types::UserIdRef>,
     /// Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
     #[cfg_attr(feature = "typed-builder", builder(default))]
-    pub after: Option<helix::Cursor>,
+    pub after: Option<Cow<'a, helix::CursorRef>>,
     /// Maximum number of objects to return. Maximum: 100. Default: 20.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     pub first: Option<usize>,
@@ -93,7 +93,9 @@ impl Request for GetUserBlockListRequest<'_> {
 impl RequestGet for GetUserBlockListRequest<'_> {}
 
 impl helix::Paginated for GetUserBlockListRequest<'_> {
-    fn set_pagination(&mut self, cursor: Option<helix::Cursor>) { self.after = cursor }
+    fn set_pagination(&mut self, cursor: Option<helix::Cursor>) {
+        self.after = cursor.map(|c| c.into_cow())
+    }
 }
 
 #[cfg(test)]

--- a/src/helix/endpoints/users/get_user_block_list.rs
+++ b/src/helix/endpoints/users/get_user_block_list.rs
@@ -8,7 +8,7 @@
 //! ```rust
 //! use twitch_api::helix::users::get_user_block_list;
 //! let request = get_user_block_list::GetUserBlockListRequest::builder()
-//!     .broadcaster_id("1234".to_string())
+//!     .broadcaster_id("1234")
 //!     .build();
 //! ```
 //!
@@ -25,7 +25,7 @@
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
 //! let request = get_user_block_list::GetUserBlockListRequest::builder()
-//!     .broadcaster_id("1234".to_string())
+//!     .broadcaster_id("1234")
 //!     .build();
 //! let response: Vec<get_user_block_list::UserBlock> = client.req_get(request, &token).await?.data;
 //! # Ok(())

--- a/src/helix/endpoints/users/get_user_block_list.rs
+++ b/src/helix/endpoints/users/get_user_block_list.rs
@@ -48,7 +48,7 @@ pub struct GetUserBlockListRequest<'a> {
     /// User ID for a Twitch user.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub broadcaster_id: &'a types::UserIdRef,
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
     /// Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
     #[cfg_attr(feature = "typed-builder", builder(default))]
     pub after: Option<helix::Cursor>,
@@ -59,9 +59,9 @@ pub struct GetUserBlockListRequest<'a> {
 
 impl<'a> GetUserBlockListRequest<'a> {
     /// Get a specified user’s block list
-    pub fn broadcaster_id(broadcaster_id: impl Into<&'a types::UserIdRef>) -> Self {
+    pub fn broadcaster_id(broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a) -> Self {
         Self {
-            broadcaster_id: broadcaster_id.into(),
+            broadcaster_id: broadcaster_id.to_cow(),
             after: Default::default(),
             first: Default::default(),
         }

--- a/src/helix/endpoints/users/get_user_block_list.rs
+++ b/src/helix/endpoints/users/get_user_block_list.rs
@@ -44,10 +44,11 @@ use helix::RequestGet;
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct GetUserBlockListRequest {
+pub struct GetUserBlockListRequest<'a> {
     /// User ID for a Twitch user.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub broadcaster_id: types::UserId,
+    #[serde(borrow)]
+    pub broadcaster_id: &'a types::UserIdRef,
     /// Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
     #[cfg_attr(feature = "typed-builder", builder(default))]
     pub after: Option<helix::Cursor>,
@@ -56,9 +57,9 @@ pub struct GetUserBlockListRequest {
     pub first: Option<usize>,
 }
 
-impl GetUserBlockListRequest {
+impl<'a> GetUserBlockListRequest<'a> {
     /// Get a specified user’s block list
-    pub fn broadcaster_id(broadcaster_id: impl Into<types::UserId>) -> Self {
+    pub fn broadcaster_id(broadcaster_id: impl Into<&'a types::UserIdRef>) -> Self {
         Self {
             broadcaster_id: broadcaster_id.into(),
             after: Default::default(),
@@ -82,7 +83,7 @@ pub struct UserBlock {
     pub display_name: types::DisplayName,
 }
 
-impl Request for GetUserBlockListRequest {
+impl Request for GetUserBlockListRequest<'_> {
     type Response = Vec<UserBlock>;
 
     #[cfg(feature = "twitch_oauth2")]
@@ -93,9 +94,9 @@ impl Request for GetUserBlockListRequest {
     const SCOPE: &'static [twitch_oauth2::Scope] = &[];
 }
 
-impl RequestGet for GetUserBlockListRequest {}
+impl RequestGet for GetUserBlockListRequest<'_> {}
 
-impl helix::Paginated for GetUserBlockListRequest {
+impl helix::Paginated for GetUserBlockListRequest<'_> {
     fn set_pagination(&mut self, cursor: Option<helix::Cursor>) { self.after = cursor }
 }
 

--- a/src/helix/endpoints/users/get_users.rs
+++ b/src/helix/endpoints/users/get_users.rs
@@ -41,7 +41,6 @@
 
 use super::*;
 use helix::RequestGet;
-use std::borrow::Cow;
 
 /// Query Parameters for [Get Users](super::get_users)
 ///

--- a/src/helix/endpoints/users/get_users.rs
+++ b/src/helix/endpoints/users/get_users.rs
@@ -8,8 +8,8 @@
 //! ```rust
 //! use twitch_api::helix::users::get_users;
 //! let request = get_users::GetUsersRequest::builder()
-//!     .id(vec!["1234".into()])
-//!     .login(vec!["justintvfan".into()])
+//!     .id(&["1234".into()][..])
+//!     .login(&["justintvfan".into()][..])
 //!     .build();
 //! ```
 //!
@@ -19,15 +19,17 @@
 //!
 //! ```rust, no_run
 //! use twitch_api::helix::{self, users::get_users};
-//! # use twitch_api::client;
+//! # use twitch_api::{client, types};
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
+//! let ids: &[&types::UserIdRef] = &["1234".into()];
+//! let logins: &[&types::UserNameRef] = &["justintvfan".into()];
 //! let request = get_users::GetUsersRequest::builder()
-//!     .id(vec!["1234".into()])
-//!     .login(vec!["justintvfan".into()])
+//!     .id(ids)
+//!     .login(logins)
 //!     .build();
 //! let response: Vec<get_users::User> = client.req_get(request, &token).await?.data;
 //! # Ok(())
@@ -49,11 +51,17 @@ use std::borrow::Cow;
 #[non_exhaustive]
 pub struct GetUsersRequest<'a> {
     /// User ID. Multiple user IDs can be specified. Limit: 100.
-    #[cfg_attr(feature = "typed-builder", builder(default))]
+    #[cfg_attr(
+        feature = "typed-builder",
+        builder(default_code = "Cow::Borrowed(&[])", setter(into))
+    )]
     #[serde(borrow)]
     pub id: Cow<'a, [&'a types::UserIdRef]>,
     /// User login name. Multiple login names can be specified. Limit: 100.
-    #[cfg_attr(feature = "typed-builder", builder(default))]
+    #[cfg_attr(
+        feature = "typed-builder",
+        builder(default_code = "Cow::Borrowed(&[])", setter(into))
+    )]
     #[serde(borrow)]
     pub login: Cow<'a, [&'a types::UserNameRef]>,
 }
@@ -63,7 +71,7 @@ impl<'a> GetUsersRequest<'a> {
     ///
     /// ```rust
     /// use twitch_api::helix::users::get_users::GetUsersRequest;
-    /// GetUsersRequest::logins(["twitch", "justintv"]);
+    /// GetUsersRequest::logins(&["twitch".into(), "justintv".into()][..]);
     /// ```
     pub fn logins(login: impl Into<Cow<'a, [&'a types::UserNameRef]>>) -> Self {
         Self {

--- a/src/helix/endpoints/users/get_users_follows.rs
+++ b/src/helix/endpoints/users/get_users_follows.rs
@@ -53,38 +53,38 @@ pub struct GetUsersFollowsRequest<'a> {
     /// User ID. The request returns information about users who are being followed by the from_id user.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(borrow)]
-    pub from_id: Option<&'a types::UserIdRef>,
+    pub from_id: Option<Cow<'a, types::UserIdRef>>,
     /// User ID. The request returns information about users who are following the to_id user.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(borrow)]
-    pub to_id: Option<&'a types::UserIdRef>,
+    pub to_id: Option<Cow<'a, types::UserIdRef>>,
 }
 
 impl<'a> GetUsersFollowsRequest<'a> {
     /// Get the broadcasters that `from_id` is following
-    pub fn following(from_id: impl Into<&'a types::UserIdRef>) -> Self {
+    pub fn following(from_id: impl types::IntoCow<'a, types::UserIdRef> + 'a) -> Self {
         Self {
-            from_id: Some(from_id.into()),
+            from_id: Some(from_id.to_cow()),
             ..Self::empty()
         }
     }
 
     /// Get the followers of `to_id`
-    pub fn followers(to_id: impl Into<&'a types::UserIdRef>) -> Self {
+    pub fn followers(to_id: impl types::IntoCow<'a, types::UserIdRef> + 'a) -> Self {
         Self {
-            to_id: Some(to_id.into()),
+            to_id: Some(to_id.to_cow()),
             ..Self::empty()
         }
     }
 
     /// Check if user follows a specific broadcaster
     pub fn follows(
-        user_id: impl Into<&'a types::UserIdRef>,
-        broadcaster_id: impl Into<&'a types::UserIdRef>,
+        user_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
+        broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
     ) -> Self {
         Self {
-            from_id: Some(user_id.into()),
-            to_id: Some(broadcaster_id.into()),
+            from_id: Some(user_id.to_cow()),
+            to_id: Some(broadcaster_id.to_cow()),
             ..Self::empty()
         }
     }

--- a/src/helix/endpoints/users/get_users_follows.rs
+++ b/src/helix/endpoints/users/get_users_follows.rs
@@ -42,7 +42,7 @@ use helix::RequestGet;
 pub struct GetUsersFollowsRequest<'a> {
     /// Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
     #[cfg_attr(feature = "typed-builder", builder(default))]
-    pub after: Option<helix::Cursor>,
+    pub after: Option<Cow<'a, helix::CursorRef>>,
     /// Maximum number of objects to return. Maximum: 100. Default: 20.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     pub first: Option<usize>,
@@ -189,7 +189,9 @@ impl RequestGet for GetUsersFollowsRequest<'_> {
 }
 
 impl helix::Paginated for GetUsersFollowsRequest<'_> {
-    fn set_pagination(&mut self, cursor: Option<helix::Cursor>) { self.after = cursor }
+    fn set_pagination(&mut self, cursor: Option<helix::Cursor>) {
+        self.after = cursor.map(|c| c.into_cow())
+    }
 }
 
 #[cfg(test)]

--- a/src/helix/endpoints/users/get_users_follows.rs
+++ b/src/helix/endpoints/users/get_users_follows.rs
@@ -3,13 +3,11 @@
 //!
 //! ## Request: [GetUsersFollowsRequest]
 //!
-//! To use this endpoint, construct a [`GetUsersFollowsRequest`] with the [`GetUsersFollowsRequest::builder()`] method.
+//! To use this endpoint, construct a [`GetUsersFollowsRequest`]
 //!
 //! ```rust
 //! use twitch_api::helix::users::get_users_follows;
-//! let request = get_users_follows::GetUsersFollowsRequest::builder()
-//!     .to_id(Some("1234".into()))
-//!     .build();
+//! let request = get_users_follows::GetUsersFollowsRequest::following("1234");
 //! ```
 //!
 //! ## Response: [UsersFollows]
@@ -24,9 +22,7 @@
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = get_users_follows::GetUsersFollowsRequest::builder()
-//!     .to_id(Some("1234".into()))
-//!     .build();
+//! let request = get_users_follows::GetUsersFollowsRequest::following("1234");
 //! let response: Vec<get_users_follows::FollowRelationship> = client.req_get(request, &token).await?.data.follow_relationships;
 //! # Ok(())
 //! # }

--- a/src/helix/endpoints/users/mod.rs
+++ b/src/helix/endpoints/users/mod.rs
@@ -24,6 +24,7 @@ use crate::{
     types,
 };
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 
 pub mod block_user;
 pub mod get_user_block_list;

--- a/src/helix/endpoints/users/mod.rs
+++ b/src/helix/endpoints/users/mod.rs
@@ -5,16 +5,15 @@
 //! # Examples
 //!
 //! ```rust,no_run
-//! # use twitch_api::helix::{HelixClient, users::GetUsersRequest};
+//! # use twitch_api::{helix::{HelixClient, users::GetUsersRequest}, types};
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 //! let client = HelixClient::new();
 //! # let _: &HelixClient<twitch_api::DummyHttpClient> = &client;
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let req = GetUsersRequest::builder()
-//!     .login(vec!["justinfan1337".into()])
-//!     .build();
+//! let logins: &[&types::UserNameRef] = &["justintvfan".into()];
+//! let req = GetUsersRequest::builder().login(logins).build();
 //!
 //! println!("{:?}", &client.req_get(req, &token).await?.data);
 //! # Ok(())

--- a/src/helix/endpoints/users/unblock_user.rs
+++ b/src/helix/endpoints/users/unblock_user.rs
@@ -45,15 +45,16 @@ use helix::RequestDelete;
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct UnblockUserRequest {
+pub struct UnblockUserRequest<'a> {
     /// User ID of the follower
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub target_user_id: types::UserId,
+    #[serde(borrow)]
+    pub target_user_id: &'a types::UserIdRef,
 }
 
-impl UnblockUserRequest {
+impl<'a> UnblockUserRequest<'a> {
     /// Create a new unblock request
-    pub fn unblock_user(target_user_id: impl Into<types::UserId>) -> Self {
+    pub fn unblock_user(target_user_id: impl Into<&'a types::UserIdRef>) -> Self {
         Self {
             target_user_id: target_user_id.into(),
         }
@@ -70,7 +71,7 @@ pub enum UnblockUser {
     Success,
 }
 
-impl Request for UnblockUserRequest {
+impl Request for UnblockUserRequest<'_> {
     type Response = UnblockUser;
 
     #[cfg(feature = "twitch_oauth2")]
@@ -80,7 +81,7 @@ impl Request for UnblockUserRequest {
     const SCOPE: &'static [twitch_oauth2::Scope] = &[twitch_oauth2::Scope::UserManageBlockedUsers];
 }
 
-impl RequestDelete for UnblockUserRequest {
+impl RequestDelete for UnblockUserRequest<'_> {
     fn parse_inner_response(
         request: Option<Self>,
         uri: &http::Uri,

--- a/src/helix/endpoints/users/unblock_user.rs
+++ b/src/helix/endpoints/users/unblock_user.rs
@@ -49,14 +49,14 @@ pub struct UnblockUserRequest<'a> {
     /// User ID of the follower
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub target_user_id: &'a types::UserIdRef,
+    pub target_user_id: Cow<'a, types::UserIdRef>,
 }
 
 impl<'a> UnblockUserRequest<'a> {
     /// Create a new unblock request
-    pub fn unblock_user(target_user_id: impl Into<&'a types::UserIdRef>) -> Self {
+    pub fn unblock_user(target_user_id: impl types::IntoCow<'a, types::UserIdRef> + 'a) -> Self {
         Self {
-            target_user_id: target_user_id.into(),
+            target_user_id: target_user_id.to_cow(),
         }
     }
 }

--- a/src/helix/endpoints/users/unblock_user.rs
+++ b/src/helix/endpoints/users/unblock_user.rs
@@ -5,13 +5,11 @@
 //!
 //! ## Request: [UnblockUserRequest]
 //!
-//! To use this endpoint, construct a [`UnblockUserRequest`] with the [`UnblockUserRequest::builder()`] method.
+//! To use this endpoint, construct a [`UnblockUserRequest`] with the [`UnblockUserRequest::unblock_user()`] method.
 //!
 //! ```rust
 //! use twitch_api::helix::users::unblock_user;
-//! let request = unblock_user::UnblockUserRequest::builder()
-//!     .target_user_id("1234")
-//!     .build();
+//! let request = unblock_user::UnblockUserRequest::unblock_user("1234");
 //! ```
 //!
 //! ## Response: [UnblockUser]
@@ -26,9 +24,7 @@
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = unblock_user::UnblockUserRequest::builder()
-//!     .target_user_id("1234")
-//!     .build();
+//! let request = unblock_user::UnblockUserRequest::unblock_user("1234");
 //! let response: unblock_user::UnblockUser = client.req_delete(request, &token).await?.data;
 //! # Ok(())
 //! # }

--- a/src/helix/endpoints/videos/delete_videos.rs
+++ b/src/helix/endpoints/videos/delete_videos.rs
@@ -10,7 +10,7 @@
 //! ```rust
 //! use twitch_api::helix::videos::delete_videos;
 //! let request = delete_videos::DeleteVideosRequest::builder()
-//!     .id(vec!["1234".into()])
+//!     .id(&["1234".into()][..])
 //!     .build();
 //! ```
 //!
@@ -20,14 +20,15 @@
 //!
 //! ```rust, no_run
 //! use twitch_api::helix::{self, videos::delete_videos};
-//! # use twitch_api::client;
+//! # use twitch_api::{client, types};
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
+//! let ids: &[&types::VideoIdRef] = &["1234".into()];
 //! let request = delete_videos::DeleteVideosRequest::builder()
-//!     .id(vec!["1234".into()])
+//!     .id(ids)
 //!     .build();
 //! let response: delete_videos::DeleteVideo = client.req_delete(request, &token).await?.data;
 //! # Ok(())
@@ -50,7 +51,10 @@ use std::borrow::Cow;
 #[non_exhaustive]
 pub struct DeleteVideosRequest<'a> {
     /// ID of the video(s) to be deleted. Limit: 5.
-    #[cfg_attr(feature = "typed-builder", builder(default))]
+    #[cfg_attr(
+        feature = "typed-builder",
+        builder(default_code = "Cow::Borrowed(&[])", setter(into))
+    )]
     #[serde(borrow)]
     pub id: Cow<'a, [&'a types::VideoIdRef]>,
 }

--- a/src/helix/endpoints/videos/delete_videos.rs
+++ b/src/helix/endpoints/videos/delete_videos.rs
@@ -40,7 +40,6 @@
 
 use super::*;
 use helix::RequestDelete;
-use std::borrow::Cow;
 
 // FIXME: One of id, user_id or game_id needs to be specified. typed_builder should have enums. id can not be used with other params
 /// Query Parameters for [Delete Videos](super::delete_videos)

--- a/src/helix/endpoints/videos/get_videos.rs
+++ b/src/helix/endpoints/videos/get_videos.rs
@@ -61,11 +61,11 @@ pub struct GetVideosRequest<'a> {
     pub game_id: Option<Cow<'a, types::CategoryIdRef>>,
     /// Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
     #[cfg_attr(feature = "typed-builder", builder(default))]
-    pub after: Option<helix::Cursor>,
+    pub after: Option<Cow<'a, helix::CursorRef>>,
     /// Cursor for backward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
     #[cfg_attr(feature = "typed-builder", builder(default))]
     #[serde(borrow)]
-    pub before: Option<&'a helix::CursorRef>,
+    pub before: Option<Cow<'a, helix::CursorRef>>,
     /// Number of values to be returned when getting videos by user or game ID. Limit: 100. Default: 20.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     pub first: Option<usize>,
@@ -178,7 +178,9 @@ impl Request for GetVideosRequest<'_> {
 impl RequestGet for GetVideosRequest<'_> {}
 
 impl helix::Paginated for GetVideosRequest<'_> {
-    fn set_pagination(&mut self, cursor: Option<helix::Cursor>) { self.after = cursor }
+    fn set_pagination(&mut self, cursor: Option<helix::Cursor>) {
+        self.after = cursor.map(|c| c.into_cow())
+    }
 }
 
 #[cfg(test)]

--- a/src/helix/endpoints/videos/get_videos.rs
+++ b/src/helix/endpoints/videos/get_videos.rs
@@ -39,7 +39,6 @@
 
 use super::*;
 use helix::RequestGet;
-use std::borrow::Cow;
 
 // FIXME: One of id, user_id or game_id needs to be specified. typed_builder should have enums. id can not be used with other params
 /// Query Parameters for [Get Videos](super::get_videos)
@@ -59,11 +58,11 @@ pub struct GetVideosRequest<'a> {
     /// ID of the user who owns the video.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(borrow)]
-    pub user_id: Option<&'a types::UserIdRef>,
+    pub user_id: Option<Cow<'a, types::UserIdRef>>,
     /// ID of the game the video is of.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(borrow)]
-    pub game_id: Option<&'a types::CategoryIdRef>,
+    pub game_id: Option<Cow<'a, types::CategoryIdRef>>,
     /// Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
     #[cfg_attr(feature = "typed-builder", builder(default))]
     pub after: Option<helix::Cursor>,
@@ -100,17 +99,17 @@ impl<'a> GetVideosRequest<'a> {
     }
 
     /// ID of the user who owns the video.
-    pub fn user_id(user_id: impl Into<&'a types::UserIdRef>) -> Self {
+    pub fn user_id(user_id: impl types::IntoCow<'a, types::UserIdRef> + 'a) -> Self {
         Self {
-            user_id: Some(user_id.into()),
+            user_id: Some(user_id.to_cow()),
             ..Self::default()
         }
     }
 
     /// ID of the game the video is of.
-    pub fn game_id(game_id: impl Into<&'a types::CategoryIdRef>) -> Self {
+    pub fn game_id(game_id: impl types::IntoCow<'a, types::CategoryIdRef> + 'a) -> Self {
         Self {
-            game_id: Some(game_id.into()),
+            game_id: Some(game_id.to_cow()),
             ..Self::default()
         }
     }

--- a/src/helix/endpoints/videos/get_videos.rs
+++ b/src/helix/endpoints/videos/get_videos.rs
@@ -72,7 +72,7 @@ pub struct GetVideosRequest<'a> {
     /// Language of the video being queried. Limit: 1.
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[serde(borrow)]
-    pub language: Option<&'a str>,
+    pub language: Option<Cow<'a, str>>,
     /// Period during which the video was created. Valid values: "all", "day", "week", "month". Default: "all".
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     pub period: Option<VideoPeriod>,

--- a/src/helix/endpoints/videos/get_videos.rs
+++ b/src/helix/endpoints/videos/get_videos.rs
@@ -5,13 +5,11 @@
 //!
 //! ## Request: [GetVideosRequest]
 //!
-//! To use this endpoint, construct a [`GetVideosRequest`] with the [`GetVideosRequest::builder()`] method.
+//! To use this endpoint, construct a [`GetVideosRequest`]
 //!
 //! ```rust
 //! use twitch_api::helix::videos::get_videos;
-//! let request = get_videos::GetVideosRequest::builder()
-//!     .user_id(Some("1234".into()))
-//!     .build();
+//! let request = get_videos::GetVideosRequest::user_id("1234");
 //! ```
 //!
 //! ## Response: [Video]
@@ -26,9 +24,7 @@
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = get_videos::GetVideosRequest::builder()
-//!     .user_id(Some("1234".into()))
-//!     .build();
+//! let request = get_videos::GetVideosRequest::user_id("1234");
 //! let response: Vec<get_videos::Video> = client.req_get(request, &token).await?.data;
 //! # Ok(())
 //! # }

--- a/src/helix/endpoints/videos/get_videos.rs
+++ b/src/helix/endpoints/videos/get_videos.rs
@@ -50,7 +50,10 @@ use std::borrow::Cow;
 #[non_exhaustive]
 pub struct GetVideosRequest<'a> {
     /// ID of the video being queried. Limit: 100. If this is specified, you cannot use any of the optional query parameters below.
-    #[cfg_attr(feature = "typed-builder", builder(default))]
+    #[cfg_attr(
+        feature = "typed-builder",
+        builder(default_code = "Cow::Borrowed(&[])", setter(into))
+    )]
     #[serde(borrow)]
     pub id: Cow<'a, [&'a types::VideoIdRef]>,
     /// ID of the user who owns the video.

--- a/src/helix/endpoints/videos/mod.rs
+++ b/src/helix/endpoints/videos/mod.rs
@@ -4,14 +4,15 @@
 //! # Examples
 //!
 //! ```rust,no_run
-//! # use twitch_api::helix::{HelixClient, videos::GetVideosRequest};
+//! # use twitch_api::{helix::{HelixClient, videos::GetVideosRequest}, types};
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 //! let client = HelixClient::new();
 //! # let _: &HelixClient<twitch_api::DummyHttpClient> = &client;
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let req = GetVideosRequest::builder().id(vec!["1337".into()]).build();
+//! let ids: &[&types::VideoIdRef] = &["1234".into()];
+//! let req = GetVideosRequest::builder().id(ids).build();
 //!
 //! println!("{:?}", &client.req_get(req, &token).await?.data);
 //! # Ok(())

--- a/src/helix/endpoints/videos/mod.rs
+++ b/src/helix/endpoints/videos/mod.rs
@@ -23,6 +23,7 @@ use crate::{
     types,
 };
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 
 pub mod delete_videos;
 pub mod get_videos;

--- a/src/helix/endpoints/whispers/mod.rs
+++ b/src/helix/endpoints/whispers/mod.rs
@@ -6,6 +6,7 @@ use crate::{
     types,
 };
 use serde::{Deserialize, Serialize};
+use std::borrow::Cow;
 
 pub mod send_whisper;
 

--- a/src/helix/endpoints/whispers/send_whisper.rs
+++ b/src/helix/endpoints/whispers/send_whisper.rs
@@ -9,10 +9,7 @@
 //!
 //! ```rust
 //! use twitch_api::helix::whispers::send_whisper;
-//! let request = send_whisper::SendWhisperRequest::builder()
-//!     .to_user_id("456")
-//!     .from_user_id("123")
-//!     .build();
+//! let request = send_whisper::SendWhisperRequest::new("456", "123");
 //! ```
 //!
 //! ## Body: [SendWhisperBody]
@@ -38,10 +35,7 @@
 //! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
 //! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
 //! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
-//! let request = send_whisper::SendWhisperRequest::builder()
-//!     .to_user_id("456")
-//!     .from_user_id("123")
-//!     .build();
+//! let request = send_whisper::SendWhisperRequest::new("456", "123");
 //! let body = send_whisper::SendWhisperBody::new("Hello!");
 //! let response: send_whisper::SendWhisperResponse = client.req_post(request, body, &token).await?.data;
 //! # Ok(())

--- a/src/helix/endpoints/whispers/send_whisper.rs
+++ b/src/helix/endpoints/whispers/send_whisper.rs
@@ -63,19 +63,22 @@ pub struct SendWhisperRequest<'a> {
     /// The ID of the user sending the whisper. This user must have a verified phone number.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub from_user_id: &'a types::UserIdRef,
+    pub from_user_id: Cow<'a, types::UserIdRef>,
     /// The ID of the user to receive the whisper.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[serde(borrow)]
-    pub to_user_id: &'a types::UserIdRef,
+    pub to_user_id: Cow<'a, types::UserIdRef>,
 }
 
 impl<'a> SendWhisperRequest<'a> {
     /// Create a new [`SendWhisperRequest`]
-    pub fn new(from: impl Into<&'a types::UserIdRef>, to: impl Into<&'a types::UserIdRef>) -> Self {
+    pub fn new(
+        from: impl types::IntoCow<'a, types::UserIdRef> + 'a,
+        to: impl types::IntoCow<'a, types::UserIdRef> + 'a,
+    ) -> Self {
         Self {
-            from_user_id: from.into(),
-            to_user_id: to.into(),
+            from_user_id: from.to_cow(),
+            to_user_id: to.to_cow(),
         }
     }
 }

--- a/src/helix/endpoints/whispers/send_whisper.rs
+++ b/src/helix/endpoints/whispers/send_whisper.rs
@@ -91,7 +91,7 @@ pub struct SendWhisperBody<'a> {
     /// 10,000 characters if the user you're sending the message to has whispered you before.
     ///
     /// Messages that exceed the maximum length are truncated.
-    pub message: &'a str,
+    pub message: Cow<'a, str>,
 }
 
 impl<'a> From<&'a str> for SendWhisperBody<'a> {
@@ -100,7 +100,11 @@ impl<'a> From<&'a str> for SendWhisperBody<'a> {
 
 impl<'a> SendWhisperBody<'a> {
     /// Create a new message
-    pub fn new(message: &'a str) -> Self { Self { message } }
+    pub fn new(message: impl Into<Cow<'a, str>>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
 }
 
 impl helix::private::SealedSerialize for SendWhisperBody<'_> {}

--- a/src/helix/endpoints/whispers/send_whisper.rs
+++ b/src/helix/endpoints/whispers/send_whisper.rs
@@ -59,18 +59,20 @@ use helix::RequestPost;
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[non_exhaustive]
-pub struct SendWhisperRequest {
+pub struct SendWhisperRequest<'a> {
     /// The ID of the user sending the whisper. This user must have a verified phone number.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub from_user_id: types::UserId,
+    #[serde(borrow)]
+    pub from_user_id: &'a types::UserIdRef,
     /// The ID of the user to receive the whisper.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub to_user_id: types::UserId,
+    #[serde(borrow)]
+    pub to_user_id: &'a types::UserIdRef,
 }
 
-impl SendWhisperRequest {
+impl<'a> SendWhisperRequest<'a> {
     /// Create a new [`SendWhisperRequest`]
-    pub fn new(from: impl Into<types::UserId>, to: impl Into<types::UserId>) -> Self {
+    pub fn new(from: impl Into<&'a types::UserIdRef>, to: impl Into<&'a types::UserIdRef>) -> Self {
         Self {
             from_user_id: from.into(),
             to_user_id: to.into(),
@@ -83,7 +85,7 @@ impl SendWhisperRequest {
 /// [`send-whisper`](https://dev.twitch.tv/docs/api/reference#send-whisper)
 #[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
 #[non_exhaustive]
-pub struct SendWhisperBody {
+pub struct SendWhisperBody<'a> {
     /// The whisper message to send. The message must not be empty.
     ///
     /// The maximum message lengths are:
@@ -92,23 +94,19 @@ pub struct SendWhisperBody {
     /// 10,000 characters if the user you're sending the message to has whispered you before.
     ///
     /// Messages that exceed the maximum length are truncated.
-    pub message: String,
+    pub message: &'a str,
 }
 
-impl From<String> for SendWhisperBody {
-    fn from(string: String) -> Self { Self::new(string) }
+impl<'a> From<&'a str> for SendWhisperBody<'a> {
+    fn from(string: &'a str) -> Self { Self::new(string) }
 }
 
-impl SendWhisperBody {
+impl<'a> SendWhisperBody<'a> {
     /// Create a new message
-    pub fn new(message: impl std::fmt::Display) -> Self {
-        Self {
-            message: message.to_string(),
-        }
-    }
+    pub fn new(message: &'a str) -> Self { Self { message } }
 }
 
-impl helix::private::SealedSerialize for SendWhisperBody {}
+impl helix::private::SealedSerialize for SendWhisperBody<'_> {}
 
 /// Return Values for [Send Whisper](super::send_whisper)
 ///
@@ -121,7 +119,7 @@ pub enum SendWhisperResponse {
     Success,
 }
 
-impl Request for SendWhisperRequest {
+impl Request for SendWhisperRequest<'_> {
     type Response = SendWhisperResponse;
 
     const PATH: &'static str = "whispers";
@@ -129,8 +127,8 @@ impl Request for SendWhisperRequest {
     const SCOPE: &'static [twitch_oauth2::Scope] = &[twitch_oauth2::Scope::UserManageWhispers];
 }
 
-impl RequestPost for SendWhisperRequest {
-    type Body = SendWhisperBody;
+impl<'a> RequestPost for SendWhisperRequest<'a> {
+    type Body = SendWhisperBody<'a>;
 
     fn parse_inner_response(
         request: Option<Self>,

--- a/src/helix/mod.rs
+++ b/src/helix/mod.rs
@@ -5,12 +5,13 @@
 //! you can decide to use this library without any specific client implementation.
 //!
 //! ```rust
-//! use twitch_api::helix::{self, Request, RequestGet, users::{GetUsersRequest, User}};
+//! use twitch_api::{helix::{self, Request, RequestGet, users::{GetUsersRequest, User}}, types};
 //!
 //! # #[tokio::main]
 //! # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
 //!
-//! let request = GetUsersRequest::login("justintv123");
+//! let logins: &[&types::UserNameRef] = &["justintv123".into()];
+//! let request = GetUsersRequest::logins(logins);
 //!
 //! // Send it however you want
 //! // Create a [`http::Response<hyper::body::Bytes>`] with RequestGet::create_request, which takes an access token and a client_id

--- a/src/helix/mod.rs
+++ b/src/helix/mod.rs
@@ -129,6 +129,16 @@ struct Pagination {
 #[aliri_braid::braid(serde)]
 pub struct Cursor;
 
+impl CursorRef {
+    /// Get a borrowed [`Cow<'_, CursorRef>`](std::borrow::Cow::Borrowed)
+    pub fn as_cow(&self) -> ::std::borrow::Cow<'_, CursorRef> { self.into() }
+}
+
+impl Cursor {
+    /// Get a owned [`Cow<'_, CursorRef>`](std::borrow::Cow::Owned)
+    fn into_cow<'a>(self) -> std::borrow::Cow<'a, CursorRef> { std::borrow::Cow::Owned(self) }
+}
+
 /// Errors that can happen when creating a body
 #[derive(thiserror::Error, Debug, displaydoc::Display)]
 pub enum BodyError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -57,7 +57,7 @@
 //! #       Err(e) => panic!(e),
 //! #   };
 //!
-//! println!("{:?}", &client.helix.get_channel_from_login("twitch".to_string(), &token).await?.unwrap().title);
+//! println!("{:?}", &client.helix.get_channel_from_login("twitch", &token).await?.unwrap().title);
 //! # Ok(())
 //! # }
 //! ```


### PR DESCRIPTION
Since #194 only implemented a few references and a lot of changes happened in the meantime, I went ahead and tried to refactor (most) request fields to use references. "_most_" in this case means that (1) `after`/`cursor`s remain owned (since I couldn't get pagination to work) and (2) eventsub requests remain owned.

I think having (mostly) non-owned requests is already a big step.

* Some fields are `&str` or `&types::TypeRef` but should be `Cow<'_, str>` for the `Deserialize` impl (since they might be encoded as escaped characters in JSON). These are mainly user-inputs. user-ids, user-logins, UUIDs and similar can remain, since they aren't escaped in JSON. I think it's fair to make sure `Deserialize` works for JSON, but it shouldn't need to work for _all_ encodings.
* The use of `Cow<'_, [&types::TypeRef]>` makes passing (static) slices a bit ugly, because `&["foo"]` is `&[&str; 1]` and `&["foo"][..]` is `&[&str]` and `Cow`'s `Into` only accepts the latter.