### PR TITLE
chatters beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,6 @@
 
 ### Added
 
-- Added `Get Chatters` endpoint
 - Added `Ban User` and `Unban User`
 - Added `Get Chat Settings` endpoint
 - Added `type` and `user_id` query params to `GetEventSubSubscriptionsRequest`

--- a/src/helix/client/client_ext.rs
+++ b/src/helix/client/client_ext.rs
@@ -94,6 +94,7 @@ impl<'a, C: crate::HttpClient<'a> + Sync> HelixClient<'a, C> {
     ///
     /// # Ok(()) }
     /// ```
+    #[cfg(feature = "unsupported")]
     pub fn get_chatters<T>(
         &'a self,
         broadcaster_id: impl Into<&'a types::UserIdRef>,

--- a/src/helix/endpoints/chat/mod.rs
+++ b/src/helix/endpoints/chat/mod.rs
@@ -10,6 +10,7 @@ use std::borrow::Cow;
 pub mod get_channel_chat_badges;
 pub mod get_channel_emotes;
 pub mod get_chat_settings;
+#[cfg(feature = "unsupported")]
 pub mod get_chatters;
 pub mod get_emote_sets;
 pub mod get_global_chat_badges;
@@ -26,6 +27,7 @@ pub use get_channel_emotes::GetChannelEmotesRequest;
 #[doc(inline)]
 pub use get_chat_settings::GetChatSettingsRequest;
 #[doc(inline)]
+#[cfg(feature = "unsupported")]
 pub use get_chatters::{Chatter, GetChattersRequest};
 #[doc(inline)]
 pub use get_emote_sets::GetEmoteSetsRequest;


### PR DESCRIPTION
- release twitch_api 0.7.0-rc.2
- place Get Chatters behind unsupported,
