### PR TITLE
Mark `TeamInformation::thumbnail_url` optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Client ext methods that take a `IntoIterator<Item = T>` now takes a `IntoIterator<Item = impl Into<T>>`
 - `Get Channel Information` can now take multiple ids
 - Simplified lifetimes for `Client`. Fixes an issue where &'1 Thing<'static> where: Thing<'static> would wrongly lower '1 to be specific. See <https://github.com/twitch-rs/twitch_api/issues/236>
+- `TeamInformation::thumbnail_url` is now optional (`Option<String>`).
 
 ### Changes
 

--- a/src/helix/endpoints/teams/get_teams.rs
+++ b/src/helix/endpoints/teams/get_teams.rs
@@ -140,3 +140,52 @@ fn test_request() {
 
     dbg!(GetTeamsRequest::parse_response(Some(req), &uri, http_response).unwrap());
 }
+
+#[cfg(test)]
+#[test]
+fn test_no_thumbnail() {
+    use helix::*;
+    let req = GetTeamsRequest::id("10920");
+
+    // From response, shortened strings
+    let data = br#"
+    {
+      "data": [
+        {
+          "background_image_url": null,
+          "banner": null,
+          "created_at": "2021-02-26T15:15:43Z",
+          "id": "10920",
+          "info": "info",
+          "team_display_name": "display",
+          "team_name": "partyanimals",
+          "thumbnail_url": null,
+          "updated_at": "2021-04-19T18:24:48Z",
+          "users": [
+            {
+              "user_id": "103198412",
+              "user_login": "findtherabbit",
+              "user_name": "FindTheRabbit"
+            },
+            {
+              "user_id": "126291224",
+              "user_login": "chri5py",
+              "user_name": "chri5py"
+            }
+          ]
+        }
+      ]
+    }
+"#
+    .to_vec();
+
+    let http_response = http::Response::builder().body(data).unwrap();
+
+    let uri = req.get_uri().unwrap();
+    assert_eq!(
+        uri.to_string(),
+        "https://api.twitch.tv/helix/teams?id=10920"
+    );
+
+    dbg!(GetTeamsRequest::parse_response(Some(req), &uri, http_response).unwrap());
+}

--- a/src/helix/endpoints/teams/mod.rs
+++ b/src/helix/endpoints/teams/mod.rs
@@ -26,7 +26,7 @@ pub struct TeamInformation {
     /// Team description.
     pub info: String,
     /// Image URL for the Team logo.
-    pub thumbnail_url: String,
+    pub thumbnail_url: Option<String>,
     /// Team name.
     pub team_name: String,
     /// Team display name.


### PR DESCRIPTION
This field seems to be nullable (e.g. for team-id `10920`). This PR marks the field as nullable and adds a test response.

Fixes #318.