### PR TITLE
Feature-gate references to feature-gated events

### DIFF
--- a/src/eventsub/event.rs
+++ b/src/eventsub/event.rs
@@ -259,8 +259,10 @@ pub enum Event {
     /// Channel Prediction End V1 Event
     ChannelPredictionEndV1(Payload<channel::ChannelPredictionEndV1>),
     /// Channel Shoutout Create V1 Event
+    #[cfg(feature = "unsupported")]
     ChannelShoutoutCreateBeta(Payload<channel::ChannelShoutoutCreateBeta>),
     /// Channel Shoutout Receive V1 Event
+    #[cfg(feature = "unsupported")]
     ChannelShoutoutReceiveBeta(Payload<channel::ChannelShoutoutReceiveBeta>),
     /// Channel Goal Begin V1 Event
     ChannelGoalBeginV1(Payload<channel::ChannelGoalBeginV1>),


### PR DESCRIPTION
This was causing compilation errors without the `unsupported` feature.