### PR TITLE
Prediction improvements

### DIFF
--- a/src/eventsub/event.rs
+++ b/src/eventsub/event.rs
@@ -259,8 +259,10 @@ pub enum Event {
     /// Channel Prediction End V1 Event
     ChannelPredictionEndV1(Payload<channel::ChannelPredictionEndV1>),
     /// Channel Shoutout Create V1 Event
+    #[cfg(feature = "unsupported")]
     ChannelShoutoutCreateBeta(Payload<channel::ChannelShoutoutCreateBeta>),
     /// Channel Shoutout Receive V1 Event
+    #[cfg(feature = "unsupported")]
     ChannelShoutoutReceiveBeta(Payload<channel::ChannelShoutoutReceiveBeta>),
     /// Channel Goal Begin V1 Event
     ChannelGoalBeginV1(Payload<channel::ChannelGoalBeginV1>),

--- a/src/helix/endpoints/predictions/create_prediction.rs
+++ b/src/helix/endpoints/predictions/create_prediction.rs
@@ -97,8 +97,8 @@ pub struct CreatePredictionBody<'a> {
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[cfg_attr(feature = "deser_borrow", serde(borrow = "'a"))]
     pub title: Cow<'a, str>,
-    /// Array of outcome objects with titles for the Prediction. Array size must be 2.
-    pub outcomes: (NewPredictionOutcome<'a>, NewPredictionOutcome<'a>),
+    /// Array of outcome objects with titles for the Prediction. Minimum: 2. Maximum: 10.
+    pub outcomes: Vec<NewPredictionOutcome<'a>>,
     /// Total duration for the Prediction (in seconds). Minimum: 1. Maximum: 1800.
     pub prediction_window: i64,
 }
@@ -108,7 +108,7 @@ impl<'a> CreatePredictionBody<'a> {
     pub fn new(
         broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
         title: impl Into<Cow<'a, str>>,
-        outcomes: (NewPredictionOutcome<'a>, NewPredictionOutcome<'a>),
+        outcomes: Vec<NewPredictionOutcome<'a>>,
         prediction_window: i64,
     ) -> Self {
         Self {

--- a/src/helix/endpoints/predictions/end_prediction.rs
+++ b/src/helix/endpoints/predictions/end_prediction.rs
@@ -100,7 +100,7 @@ pub struct EndPredictionBody<'a> {
     /// ID of the winning outcome for the Prediction. This parameter is required if status is being set to [`RESOLVED`](types::PredictionStatus).
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[cfg_attr(feature = "deser_borrow", serde(borrow = "'a"))]
-    pub winning_outcome_id: Option<Cow<'a, types::PredictionIdRef>>,
+    pub winning_outcome_id: Option<Cow<'a, types::PredictionOutcomeIdRef>>,
 }
 
 impl<'a> EndPredictionBody<'a> {
@@ -123,7 +123,7 @@ impl<'a> EndPredictionBody<'a> {
     /// This parameter is required if status is being set to [`RESOLVED`](types::PredictionStatus).
     pub fn winning_outcome_id(
         mut self,
-        winning_outcome_id: impl types::IntoCow<'a, types::PredictionIdRef> + 'a,
+        winning_outcome_id: impl types::IntoCow<'a, types::PredictionOutcomeIdRef> + 'a,
     ) -> Self {
         self.winning_outcome_id = Some(winning_outcome_id.into_cow());
         self


### PR DESCRIPTION
Creating predictions supports >2 outcomes now: https://dev.twitch.tv/docs/api/reference/#create-prediction

Additionally, cleanup a type error.