### PR TITLE
Predictions improvements

### DIFF
--- a/src/helix/endpoints/predictions/create_prediction.rs
+++ b/src/helix/endpoints/predictions/create_prediction.rs
@@ -79,9 +79,7 @@ pub struct CreatePredictionRequest<'a> {
 
 impl CreatePredictionRequest<'_> {
     /// Create a new [`CreatePredictionRequest`]
-    pub fn new() -> Self {
-        Self::default()
-    }
+    pub fn new() -> Self { Self::default() }
 }
 
 /// Body Parameters for [Create Prediction](super::create_prediction)

--- a/src/helix/endpoints/predictions/create_prediction.rs
+++ b/src/helix/endpoints/predictions/create_prediction.rs
@@ -79,7 +79,9 @@ pub struct CreatePredictionRequest<'a> {
 
 impl CreatePredictionRequest<'_> {
     /// Create a new [`CreatePredictionRequest`]
-    pub fn new() -> Self { Self::default() }
+    pub fn new() -> Self {
+        Self::default()
+    }
 }
 
 /// Body Parameters for [Create Prediction](super::create_prediction)
@@ -138,11 +140,6 @@ impl<'a> NewPredictionOutcome<'a> {
         Self {
             title: title.into(),
         }
-    }
-
-    /// Create a two new [`NewPredictionOutcome`]s
-    pub fn new_tuple(blue: impl Into<Cow<'a, str>>, pink: impl Into<Cow<'a, str>>) -> (Self, Self) {
-        (Self::new(blue), Self::new(pink))
     }
 }
 
@@ -208,7 +205,10 @@ fn test_request() {
     let body = CreatePredictionBody::new(
         "141981764",
         "Any leeks in the stream?",
-        NewPredictionOutcome::new_tuple("Yes, give it time.", "Definitely not."),
+        vec![
+            NewPredictionOutcome::new("Yes, give it time."),
+            NewPredictionOutcome::new("Definitely not."),
+        ],
         120,
     );
 

--- a/src/helix/endpoints/predictions/create_prediction.rs
+++ b/src/helix/endpoints/predictions/create_prediction.rs
@@ -23,10 +23,10 @@
 //! let body = create_prediction::CreatePredictionBody::new(
 //!     "141981764",
 //!     "Any leeks in the stream?",
-//!     create_prediction::NewPredictionOutcome::new_tuple(
-//!         "Yes, give it time.",
-//!         "Definitely not.",
-//!     ),
+//!     vec![
+//!         create_prediction::NewPredictionOutcome::new("Yes, give it time."),
+//!         create_prediction::NewPredictionOutcome::new("Definitely not."),
+//!     ],
 //!     120,
 //! );
 //! ```
@@ -49,7 +49,10 @@
 //! let body = create_prediction::CreatePredictionBody::new(
 //!     "141981764",
 //!     "Any leeks in the stream?",
-//!     create_prediction::NewPredictionOutcome::new_tuple("Yes, give it time.", "Definitely not."),
+//!     vec![
+//!         create_prediction::NewPredictionOutcome::new("Yes, give it time."),
+//!         create_prediction::NewPredictionOutcome::new("Definitely not."),
+//!    ],
 //!     120,
 //! );
 //! let response: create_prediction::CreatePredictionResponse = client.req_post(request, body, &token).await?.data;

--- a/src/helix/endpoints/predictions/create_prediction.rs
+++ b/src/helix/endpoints/predictions/create_prediction.rs
@@ -97,8 +97,8 @@ pub struct CreatePredictionBody<'a> {
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     #[cfg_attr(feature = "deser_borrow", serde(borrow = "'a"))]
     pub title: Cow<'a, str>,
-    /// Array of outcome objects with titles for the Prediction. Array size must be 2.
-    pub outcomes: (NewPredictionOutcome<'a>, NewPredictionOutcome<'a>),
+    /// Array of outcome objects with titles for the Prediction. Minimum: 2. Maximum: 10.
+    pub outcomes: Vec<NewPredictionOutcome<'a>>,
     /// Total duration for the Prediction (in seconds). Minimum: 1. Maximum: 1800.
     pub prediction_window: i64,
 }
@@ -108,7 +108,7 @@ impl<'a> CreatePredictionBody<'a> {
     pub fn new(
         broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
         title: impl Into<Cow<'a, str>>,
-        outcomes: (NewPredictionOutcome<'a>, NewPredictionOutcome<'a>),
+        outcomes: Vec<NewPredictionOutcome<'a>>,
         prediction_window: i64,
     ) -> Self {
         Self {

--- a/src/helix/endpoints/predictions/end_prediction.rs
+++ b/src/helix/endpoints/predictions/end_prediction.rs
@@ -100,7 +100,7 @@ pub struct EndPredictionBody<'a> {
     /// ID of the winning outcome for the Prediction. This parameter is required if status is being set to [`RESOLVED`](types::PredictionStatus).
     #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
     #[cfg_attr(feature = "deser_borrow", serde(borrow = "'a"))]
-    pub winning_outcome_id: Option<Cow<'a, types::PredictionIdRef>>,
+    pub winning_outcome_id: Option<Cow<'a, types::PredictionOutcomeIdRef>>,
 }
 
 impl<'a> EndPredictionBody<'a> {
@@ -123,7 +123,7 @@ impl<'a> EndPredictionBody<'a> {
     /// This parameter is required if status is being set to [`RESOLVED`](types::PredictionStatus).
     pub fn winning_outcome_id(
         mut self,
-        winning_outcome_id: impl types::IntoCow<'a, types::PredictionIdRef> + 'a,
+        winning_outcome_id: impl types::IntoCow<'a, types::PredictionOutcomeIdRef> + 'a,
     ) -> Self {
         self.winning_outcome_id = Some(winning_outcome_id.into_cow());
         self


### PR DESCRIPTION
Creating predictions supports >2 outcomes now: https://dev.twitch.tv/docs/api/reference/#create-prediction

Additionally, cleanup a type error.

(Sorry about the spam, I'm not used to using git on Windows and got something messed up.)