### PR TITLE
Update EventSub WebSocket URL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1536,9 +1536,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.45"
+version = "0.10.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
+checksum = "7e30d8bc91859781f0a943411186324d580f2bbeb71b452fe91ae344806af3f1"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1568,11 +1568,10 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.80"
+version = "0.9.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
+checksum = "0d3d193fb1488ad46ffe3aaabc912cc931d02ee8518fe2959aea8ef52718b0c0"
 dependencies = [
- "autocfg",
  "cc",
  "libc",
  "pkg-config",

--- a/src/eventsub/event/websocket.rs
+++ b/src/eventsub/event/websocket.rs
@@ -363,7 +363,7 @@ mod tests {
                 "id": "AQoQexAWVYKSTIu4ec_2VAxyuhAB",
                 "status": "reconnecting",
                 "keepalive_timeout_seconds": null,
-                "reconnect_url": "wss://eventsub-beta.wss.twitch.tv?...",
+                "reconnect_url": "wss://eventsub.wss.twitch.tv?...",
                 "connected_at": "2019-11-16T10:11:12.123Z"
               }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,7 +183,7 @@ pub static TWITCH_PUBSUB_URL: once_cell::sync::Lazy<url::Url> =
 #[cfg(feature = "eventsub")]
 pub static TWITCH_EVENTSUB_WEBSOCKET_URL: once_cell::sync::Lazy<url::Url> = mock_env_url!(
     "TWITCH_EVENTSUB_WEBSOCKET_URL",
-    "wss://eventsub-beta.wss.twitch.tv/ws"
+    "wss://eventsub.wss.twitch.tv/ws"
 );
 
 /// Client for Twitch APIs.


### PR DESCRIPTION
The `-beta` part was removed from the URL (see [announcement](https://discuss.dev.twitch.tv/t/update-required-for-eventsub-websockets-beta-connection-url/45079) - old URL is valid until 2023-May-15). This updates the constant and one URL in a test-case.