### PR TITLE
feat(eventsub): add `channel.chat.message`

### DIFF
--- a/src/eventsub/channel/chat/message.rs
+++ b/src/eventsub/channel/chat/message.rs
@@ -1,0 +1,221 @@
+#![doc(alias = "channel.chat.message")]
+//! Any user sends a message to a specific chat room.
+
+use super::*;
+
+/// [`channel.chat.message`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#channelchatmessage): a user sends a message to a specific chat room.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[non_exhaustive]
+pub struct ChannelChatMessageV1 {
+    /// User ID of the channel to receive chat message events for.
+    #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
+    pub broadcaster_user_id: types::UserId,
+    /// The user ID to read chat as.
+    #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
+    pub user_id: types::UserId,
+}
+
+impl ChannelChatMessageV1 {
+    /// Create a new [ChannelChatMessageV1]
+    pub fn new(
+        broadcaster_user_id: impl Into<types::UserId>,
+        user_id: impl Into<types::UserId>,
+    ) -> Self {
+        Self {
+            broadcaster_user_id: broadcaster_user_id.into(),
+            user_id: user_id.into(),
+        }
+    }
+}
+
+impl EventSubscription for ChannelChatMessageV1 {
+    type Payload = ChannelChatMessageV1Payload;
+
+    const EVENT_TYPE: EventType = EventType::ChannelChatMessage;
+    #[cfg(feature = "twitch_oauth2")]
+    /// Additionally, if an app access token is used,
+    /// [user:bot][twitch_oauth2::Scope::UserBot] is requried from the chatting user, i.e. the user specified by [user_id][ChannelChatMessageV1::user_id],
+    /// and either [channel:bot][twitch_oauth2::Scope::ChannelBot] from the broadcaster or moderator status in chat.
+    const SCOPE: twitch_oauth2::Validator =
+        twitch_oauth2::validator![twitch_oauth2::Scope::UserReadChat];
+    const VERSION: &'static str = "1";
+}
+
+/// [`channel.chat.message`](ChannelChatMessageV1Payload) response payload.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[non_exhaustive]
+pub struct ChannelChatMessageV1Payload {
+    /// The broadcaster user ID.
+    pub broadcaster_user_id: types::UserId,
+    /// The broadcaster display name.
+    pub broadcaster_user_name: types::UserName,
+    /// The broadcaster login.
+    pub broadcaster_user_login: types::UserName,
+    /// The user ID of the user that sent the message.
+    pub chatter_user_id: types::UserId,
+    /// The user name of the user that sent the message.
+    pub chatter_user_name: types::UserName,
+    /// The user login of the user that sent the message.
+    pub chatter_user_login: types::UserName,
+    /// A UUID that identifies the message.
+    pub message_id: types::MsgId,
+    /// The structured chat message.
+    pub message: Message,
+    /// The type of message.
+    pub message_type: MessageType,
+    /// List of chat badges.
+    pub badges: Vec<Badge>,
+    /// Metadata if this message is a cheer.
+    pub cheer: Option<Cheer>,
+    /// The color of the user's name in the chat room.
+    /// This is a hexadecimal RGB color code in the form, `#<RGB>`.
+    /// This may be empty if it is never set.
+    pub color: types::HexColor,
+    /// Metadata if this message is a reply.
+    pub reply: Option<Reply>,
+    /// The ID of a channel points custom reward that was redeemed.
+    pub channel_points_custom_reward_id: Option<types::RewardId>,
+}
+
+/// The type a message.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+#[serde(rename_all = "snake_case")]
+pub enum MessageType {
+    /// A regular text message
+    Text,
+    /// A highlighted message with channel points
+    ChannelPointsHighlighted,
+    /// A message sent with channel points during sub-only mode
+    ChannelPointsSubOnly,
+    /// A first message from a user
+    UserIntro,
+}
+
+/// Chat badge
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[non_exhaustive]
+pub struct Badge {
+    /// An ID that identifies this set of chat badges. For example, Bits or Subscriber.
+    pub set_id: types::BadgeSetId,
+    /// An ID that identifies this version of the badge. The ID can be any value.
+    /// For example, for Bits, the ID is the Bits tier level, but for World of Warcraft, it could be Alliance or Horde.
+    pub id: types::ChatBadgeId,
+    /// Contains metadata related to the chat badges in the badges tag.
+    /// Currently, this tag contains metadata only for subscriber badges, to indicate the number of months the user has been a subscriber.
+    pub info: String,
+}
+
+/// Metadata for cheer messages
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[non_exhaustive]
+pub struct Cheer {
+    /// The amount of Bits the user cheered.
+    pub bits: usize,
+}
+
+/// Metadata for reply messages
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[non_exhaustive]
+pub struct Reply {
+    /// An ID that uniquely identifies the parent message that this message is replying to.
+    pub parent_message_id: types::MsgId,
+    /// The message body of the parent message.
+    pub parent_message_body: String,
+    /// User ID of the sender of the parent message.
+    pub parent_user_id: types::UserId,
+    /// User name of the sender of the parent message.
+    pub parent_user_name: types::UserName,
+    /// User login of the sender of the parent message.
+    pub parent_user_login: types::UserName,
+    /// An ID that identifies the parent message of the reply thread.
+    pub thread_message_id: types::MsgId,
+    /// User ID of the sender of the thread's parent message.
+    pub thread_user_id: types::UserId,
+    /// User name of the sender of the thread's parent message.
+    pub thread_user_name: types::UserName,
+    /// User login of the sender of the thread's parent message.
+    pub thread_user_login: types::UserName,
+}
+
+#[cfg(test)]
+#[test]
+fn parse_payload() {
+    let payload = r##"
+    {
+        "subscription": {
+            "id": "47faedb0-b918-4d79-a974-fe799c9b1f6b",
+            "status": "enabled",
+            "type": "channel.chat.message",
+            "version": "1",
+            "condition": {
+                "broadcaster_user_id": "141981764",
+                "user_id": "129546453"
+            },
+            "transport": {
+                "method": "websocket",
+                "session_id": "AgoQL5tbQXjKS4SBPvF0F-Qz0hIGY2VsbC1j"
+            },
+            "created_at": "2024-02-24T17:17:49.772726224Z",
+            "cost": 0
+        },
+        "event": {
+            "broadcaster_user_id": "141981764",
+            "broadcaster_user_login": "twitchdev",
+            "broadcaster_user_name": "TwitchDev",
+            "chatter_user_id": "129546453",
+            "chatter_user_login": "nerixyz",
+            "chatter_user_name": "nerixyz",
+            "message_id": "9d0bcb5e-ee31-4b09-b72f-66eb94ce061e",
+            "message": {
+                "text": "Hello, World! DinoDance",
+                "fragments": [
+                    {
+                        "type": "text",
+                        "text": "Hello, World! ",
+                        "cheermote": null,
+                        "emote": null,
+                        "mention": null
+                    },
+                    {
+                        "type": "emote",
+                        "text": "DinoDance",
+                        "cheermote": null,
+                        "emote": {
+                            "id": "emotesv2_dcd06b30a5c24f6eb871e8f5edbd44f7",
+                            "emote_set_id": "0",
+                            "owner_id": "0",
+                            "format": [
+                                "static",
+                                "animated"
+                            ]
+                        },
+                        "mention": null
+                    }
+                ]
+            },
+            "color": "#FF0000",
+            "badges": [
+                {
+                    "set_id": "no_video",
+                    "id": "1",
+                    "info": ""
+                }
+            ],
+            "message_type": "text",
+            "cheer": null,
+            "reply": null,
+            "channel_points_custom_reward_id": null
+        }
+    }
+    "##;
+
+    let val = dbg!(crate::eventsub::Event::parse(payload).unwrap());
+    crate::tests::roundtrip(&val)
+}

--- a/src/eventsub/channel/chat/mod.rs
+++ b/src/eventsub/channel/chat/mod.rs
@@ -6,6 +6,7 @@ use serde_derive::{Deserialize, Serialize};
 
 pub mod clear;
 pub mod clear_user_messages;
+pub mod message;
 pub mod message_delete;
 pub mod notification;
 
@@ -16,9 +17,22 @@ pub use clear_user_messages::{
     ChannelChatClearUserMessagesV1, ChannelChatClearUserMessagesV1Payload,
 };
 #[doc(inline)]
+pub use message::{ChannelChatMessageV1, ChannelChatMessageV1Payload};
+#[doc(inline)]
 pub use message_delete::{ChannelChatMessageDeleteV1, ChannelChatMessageDeleteV1Payload};
 #[doc(inline)]
 pub use notification::{ChannelChatNotificationV1, ChannelChatNotificationV1Payload};
+
+/// A message
+// XXX: this struct can never be deny_unknown_fields
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct Message {
+    /// The chat message in plain text.
+    pub text: String,
+    /// Ordered list of chat message fragments.
+    pub fragments: Vec<Fragment>,
+}
 
 /// A chat message fragment
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
@@ -111,4 +125,17 @@ pub struct Mention {
     pub user_name: types::DisplayName,
     /// The user login of the mentioned user.
     pub user_login: types::UserName,
+}
+
+/// A badge
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[non_exhaustive]
+pub struct Badge {
+    /// An ID that identifies this set of chat badges. For example, Bits or Subscriber.
+    pub set_id: types::BadgeSetId,
+    /// An ID that identifies this version of the badge. The ID can be any value. For example, for Bits, the ID is the Bits tier level, but for World of Warcraft, it could be Alliance or Horde.
+    pub id: types::ChatBadgeId,
+    /// Contains metadata related to the chat badges in the badges tag. Currently, this tag contains metadata only for subscriber badges, to indicate the number of months the user has been a subscriber.
+    pub info: String,
 }

--- a/src/eventsub/channel/chat/notification.rs
+++ b/src/eventsub/channel/chat/notification.rs
@@ -261,30 +261,6 @@ impl crate::eventsub::NamedField for BitsBadgeTier {
     const NAME: &'static str = "bits_badge_tier";
 }
 
-/// A badge
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
-#[non_exhaustive]
-pub struct Badge {
-    /// An ID that identifies this set of chat badges. For example, Bits or Subscriber.
-    pub set_id: types::BadgeSetId,
-    /// An ID that identifies this version of the badge. The ID can be any value. For example, for Bits, the ID is the Bits tier level, but for World of Warcraft, it could be Alliance or Horde.
-    pub id: types::ChatBadgeId,
-    /// Contains metadata related to the chat badges in the badges tag. Currently, this tag contains metadata only for subscriber badges, to indicate the number of months the user has been a subscriber.
-    pub info: String,
-}
-
-/// A message
-// XXX: this struct can never be deny_unknown_fields
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
-#[non_exhaustive]
-pub struct Message {
-    /// The chat message in plain text.
-    pub text: String,
-    /// Ordered list of chat message fragments.
-    pub fragments: Vec<Fragment>,
-}
-
 /// A subscription notification
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]

--- a/src/eventsub/channel/chat/notification.rs
+++ b/src/eventsub/channel/chat/notification.rs
@@ -78,8 +78,10 @@ pub enum Chatter {
         chatter_user_name: types::DisplayName,
         /// The user login of the user that sent the message.
         chatter_user_login: types::UserName,
-        /// The color of the user’s name in the chat room.
-        color: Option<types::NamedUserColor<'static>>,
+        /// The color of the user's name in the chat room.
+        /// This is a hexadecimal RGB color code in the form, `#<RGB>`.
+        /// This may be empty if it is never set.
+        color: types::HexColor,
     },
     /// Chatter is anonymous
     Anonymous,
@@ -107,7 +109,7 @@ impl serde::Serialize for Chatter {
             chatter_user_id: Option<&'a types::UserIdRef>,
             chatter_user_name: Option<&'a types::DisplayNameRef>,
             chatter_user_login: Option<&'a types::UserNameRef>,
-            color: String,
+            color: Option<&'a types::HexColor>,
             chatter_is_anonymous: bool,
         }
 
@@ -121,7 +123,7 @@ impl serde::Serialize for Chatter {
                 chatter_user_id: Some(chatter_user_id),
                 chatter_user_name: Some(chatter_user_name),
                 chatter_user_login: Some(chatter_user_login),
-                color: color.as_ref().map(|c| c.to_string()).unwrap_or_default(),
+                color: Some(color),
                 chatter_is_anonymous: false,
             },
             Chatter::Anonymous => InnerChatter {
@@ -137,12 +139,11 @@ impl<'de> serde::Deserialize<'de> for Chatter {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where D: serde::Deserializer<'de> {
         #[derive(Deserialize)]
-        struct InnerChatter<'c> {
+        struct InnerChatter {
             chatter_user_id: Option<types::UserId>,
             chatter_user_name: Option<types::DisplayName>,
             chatter_user_login: Option<types::UserName>,
-            #[serde(borrow)]
-            color: Option<types::NamedUserColor<'c>>,
+            color: Option<types::HexColor>,
             chatter_is_anonymous: bool,
         }
 
@@ -150,8 +151,8 @@ impl<'de> serde::Deserialize<'de> for Chatter {
         if chatter.chatter_is_anonymous {
             #[cfg(feature = "tracing")]
             if let Some(c) = chatter.color {
-                if c.as_hex().as_str() != "" {
-                    tracing::error!("got a anonymous user with color set to {c}");
+                if c.as_str() != "" {
+                    tracing::error!("got an anonymous user with color set to {c}");
                 }
             }
             Ok(Chatter::Anonymous)
@@ -166,13 +167,9 @@ impl<'de> serde::Deserialize<'de> for Chatter {
                 chatter_user_login: chatter
                     .chatter_user_login
                     .ok_or_else(|| serde::de::Error::missing_field("chatter_user_login"))?,
-                color: Some(
-                    chatter
-                        .color
-                        .ok_or_else(|| serde::de::Error::missing_field("color"))?
-                        .to_owned(),
-                )
-                .filter(|s| s.as_hex().as_str() != ""),
+                color: chatter
+                    .color
+                    .ok_or_else(|| serde::de::Error::missing_field("color"))?,
             })
         }
     }

--- a/src/eventsub/channel/mod.rs
+++ b/src/eventsub/channel/mod.rs
@@ -66,6 +66,8 @@ pub use chat::{ChannelChatClearV1, ChannelChatClearV1Payload};
 #[doc(inline)]
 pub use chat::{ChannelChatMessageDeleteV1, ChannelChatMessageDeleteV1Payload};
 #[doc(inline)]
+pub use chat::{ChannelChatMessageV1, ChannelChatMessageV1Payload};
+#[doc(inline)]
 pub use chat::{ChannelChatNotificationV1, ChannelChatNotificationV1Payload};
 #[doc(inline)]
 pub use cheer::{ChannelCheerV1, ChannelCheerV1Payload};

--- a/src/eventsub/event.rs
+++ b/src/eventsub/event.rs
@@ -19,6 +19,7 @@ macro_rules! fill_events {
             channel::ChannelCharityCampaignStopV1;
             channel::ChannelChatClearUserMessagesV1;
             channel::ChannelChatClearV1;
+            channel::ChannelChatMessageV1;
             channel::ChannelChatMessageDeleteV1;
             channel::ChannelChatNotificationV1;
             channel::ChannelCheerV1;
@@ -139,6 +140,8 @@ make_event_type!("Event Types": pub enum EventType {
     ChannelChatClear => "channel.chat.clear",
     "a moderator or bot clears all messages for a specific user.":
     ChannelChatClearUserMessages => "channel.chat.clear_user_messages",
+    "any user sends a message to a specific chat room.":
+    ChannelChatMessage => "channel.chat.message",
     "a moderator removes a specific message.":
     ChannelChatMessageDelete => "channel.chat.message_delete",
     "an event that appears in chat occurs, such as someone subscribing to the channel or a subscription is gifted.":
@@ -250,6 +253,8 @@ pub enum Event {
     ChannelChatClearV1(Payload<channel::ChannelChatClearV1>),
     /// Channel Chat ClearUserMessages V1 Event
     ChannelChatClearUserMessagesV1(Payload<channel::ChannelChatClearUserMessagesV1>),
+    /// Channel Chat Message V1 Event
+    ChannelChatMessageV1(Payload<channel::ChannelChatMessageV1>),
     /// Channel Chat MessageDelete V1 Event
     ChannelChatMessageDeleteV1(Payload<channel::ChannelChatMessageDeleteV1>),
     /// Channel Chat Notification V1 Event


### PR DESCRIPTION
After the Helix chat endpoint, this implements the [`channel.chat.message`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#channelchatmessage) event for EventSub. I didn't re-export the `Message` types in`twitch_api::eventsub::chat`, since I wasn't sure if that should be done. There are some similarities with [`twitch_api::pubsub::automod_queue::Message`](https://twitch-rs.github.io/twitch_api/twitch_api/pubsub/automod_queue/struct.Message.html), but they aren't compatible.

I left out `deny_unknown_fields` for the `Fragment`, since the JSON always has all optional metadata.

<sub>As a sidenote, with the chat messages being quite large and frequent, maybe it could be nice to support `simd-json` in place of `serde_json` (I think it can be a drop-in replacement).</sub>