### PR TITLE
export `ClientExtError`

### DIFF
--- a/src/helix/client.rs
+++ b/src/helix/client.rs
@@ -7,6 +7,9 @@ pub(crate) mod client_ext;
 #[cfg(feature = "unsupported")]
 mod custom;
 
+#[doc(inline)]
+pub use client_ext::ClientExtError;
+
 #[cfg(feature = "client")]
 impl<C: crate::HttpClient + crate::client::ClientDefault<'static>> Default
     for HelixClient<'static, C>

--- a/src/helix/client/client_ext.rs
+++ b/src/helix/client/client_ext.rs
@@ -1204,10 +1204,13 @@ impl<'client, C: crate::HttpClient + Sync + 'client> HelixClient<'client, C> {
     }
 }
 
+/// Error type to combine a http client error with a other error
 #[derive(Debug, thiserror::Error)]
 pub enum ClientExtError<C: crate::HttpClient, E> {
+    /// Http client error
     #[error(transparent)]
     ClientError(ClientError<C>),
+    /// Other error
     #[error(transparent)]
     Other(#[from] E),
 }


### PR DESCRIPTION
The error type is part of the public api, so it makes sense to expose it as well.