### PR TITLE
Update to http 1, reqwest 0.12, and hyper 1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,8 +156,9 @@ checksum = "080e9890a082662b09c1ad45f567faeeb47f22b5fb23895fbe1e651e718e25ca"
 
 [[package]]
 name = "askama"
-version = "0.11.2"
-source = "git+https://github.com/djc/askama?rev=eeec6f0#eeec6f0654f32270aec4e4a0d0f42e4ad39bc28e"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b79091df18a97caea757e28cd2d5fda49c6cd4bd01ddffd7ff01ace0c0ad2c28"
 dependencies = [
  "askama_derive",
  "askama_escape",
@@ -168,33 +169,45 @@ dependencies = [
 
 [[package]]
 name = "askama_axum"
-version = "0.1.0"
-source = "git+https://github.com/djc/askama?rev=eeec6f0#eeec6f0654f32270aec4e4a0d0f42e4ad39bc28e"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a41603f7cdbf5ac4af60760f17253eb6adf6ec5b6f14a7ed830cf687d375f163"
 dependencies = [
  "askama",
  "axum-core",
- "http",
+ "http 1.1.0",
 ]
 
 [[package]]
 name = "askama_derive"
-version = "0.12.0"
-source = "git+https://github.com/djc/askama?rev=eeec6f0#eeec6f0654f32270aec4e4a0d0f42e4ad39bc28e"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19fe8d6cb13c4714962c072ea496f3392015f0989b1a2847bb4b2d9effd71d83"
 dependencies = [
+ "askama_parser",
+ "basic-toml",
  "mime",
  "mime_guess",
- "nom",
  "proc-macro2",
  "quote",
  "serde",
- "syn 1.0.109",
- "toml",
+ "syn 2.0.48",
 ]
 
 [[package]]
 name = "askama_escape"
 version = "0.10.3"
-source = "git+https://github.com/djc/askama?rev=eeec6f0#eeec6f0654f32270aec4e4a0d0f42e4ad39bc28e"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
+
+[[package]]
+name = "askama_parser"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acb1161c6b64d1c3d83108213c2a2533a342ac225aabd0bda218278c2ddb00c0"
+dependencies = [
+ "nom",
+]
 
 [[package]]
 name = "async-channel"
@@ -389,19 +402,20 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "axum"
-version = "0.6.20"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+checksum = "3a6c9af12842a67734c9a2e355436e5d03b22383ed60cf13cd0c18fbfe3dcbcf"
 dependencies = [
  "async-trait",
  "axum-core",
  "base64 0.21.7",
- "bitflags 1.3.2",
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "futures-util",
- "http",
+ "http 1.1.0",
  "http-body",
+ "http-body-util",
  "hyper",
+ "hyper-util",
  "itoa",
  "matchit",
  "memchr",
@@ -414,29 +428,34 @@ dependencies = [
  "serde_path_to_error",
  "serde_urlencoded",
  "sha1 0.10.6",
- "sync_wrapper",
+ "sync_wrapper 1.0.0",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.21.0",
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
 name = "axum-core"
-version = "0.3.4"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+checksum = "a15c63fd72d41492dc4f497196f5da1fb04fb7529e631d73630d1b491e47a2e3"
 dependencies = [
  "async-trait",
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "futures-util",
- "http",
+ "http 1.1.0",
  "http-body",
+ "http-body-util",
  "mime",
+ "pin-project-lite",
  "rustversion",
+ "sync_wrapper 0.1.2",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -471,6 +490,15 @@ name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "basic-toml"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "823388e228f614e9558c6804262db37960ec8821856535f5c3f59913140558f8"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -538,9 +566,9 @@ checksum = "0e4cec68f03f32e44924783795810fa50a7035d8c8ebe78580ad7e6c703fba38"
 
 [[package]]
 name = "bytes"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "cc"
@@ -899,6 +927,7 @@ dependencies = [
  "dotenvy",
  "eyre",
  "futures",
+ "http-body-util",
  "hyper",
  "reqwest",
  "retainer",
@@ -906,7 +935,7 @@ dependencies = [
  "serde_derive",
  "serde_json",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.20.1",
  "tower",
  "tower-http",
  "tracing",
@@ -931,7 +960,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.20.1",
  "tracing",
  "tracing-error",
  "tracing-log",
@@ -1196,16 +1225,16 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.26"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+checksum = "816ec7294445779408f36fe57bc5b7fc1cf59664059096c65f905c1c61f58069"
 dependencies = [
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "fnv",
  "futures-core",
  "futures-sink",
  "futures-util",
- "http",
+ "http 1.1.0",
  "indexmap",
  "slab",
  "tokio",
@@ -1272,19 +1301,42 @@ version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8947b1a6fad4393052c7ba1f4cd97bed3e953a95c79c92ad9b051a04611d9fbb"
 dependencies = [
- "bytes 1.5.0",
+ "bytes 1.6.0",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21b9ddb458710bc376481b842f5da65cdf31522de232c1ca8146abce2a358258"
+dependencies = [
+ "bytes 1.6.0",
  "fnv",
  "itoa",
 ]
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+checksum = "1cac85db508abc24a2e48553ba12a996e87244a0395ce011e62b37158745d643"
 dependencies = [
- "bytes 1.5.0",
- "http",
+ "bytes 1.6.0",
+ "http 1.1.0",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0475f8b2ac86659c21b64320d5d653f9efe42acd2a4e560073ec61a155a34f1d"
+dependencies = [
+ "bytes 1.6.0",
+ "futures-core",
+ "http 1.1.0",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -1304,9 +1356,9 @@ dependencies = [
 
 [[package]]
 name = "http-range-header"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "add0ab9360ddbd88cfeb3bd9574a1d85cfdfa14db10b3e21d3700dbc4328758f"
+checksum = "3ce4ef31cda248bbdb6e6820603b82dfcd9e833db65a43e997a0ccec777d11fe"
 
 [[package]]
 name = "http-types"
@@ -1320,7 +1372,7 @@ dependencies = [
  "base64 0.13.1",
  "cookie",
  "futures-lite 1.13.0",
- "http",
+ "http 0.2.11",
  "infer",
  "pin-project-lite",
  "rand 0.7.3",
@@ -1354,39 +1406,59 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.14.28"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf96e135eb83a2a8ddf766e426a841d8ddd7449d5f00d34ea02b41d2f19eef80"
+checksum = "186548d73ac615b32a73aafe38fb4f56c0d340e110e5a200bcadbaf2e199263a"
 dependencies = [
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "futures-channel",
- "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 1.1.0",
  "http-body",
  "httparse",
  "httpdate",
  "itoa",
  "pin-project-lite",
- "socket2 0.4.10",
+ "smallvec",
  "tokio",
- "tower-service",
- "tracing",
  "want",
 ]
 
 [[package]]
 name = "hyper-tls"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
- "bytes 1.5.0",
+ "bytes 1.6.0",
+ "http-body-util",
  "hyper",
+ "hyper-util",
  "native-tls",
  "tokio",
  "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca38ef113da30126bbff9cd1705f9273e15d45498615d138b0c20279ac7a76aa"
+dependencies = [
+ "bytes 1.6.0",
+ "futures-channel",
+ "futures-util",
+ "http 1.1.0",
+ "http-body",
+ "hyper",
+ "pin-project-lite",
+ "socket2 0.5.5",
+ "tokio",
+ "tower",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1459,7 +1531,7 @@ dependencies = [
  "curl-sys",
  "flume",
  "futures-lite 1.13.0",
- "http",
+ "http 0.2.11",
  "log",
  "once_cell",
  "slab",
@@ -2026,20 +2098,22 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reqwest"
-version = "0.11.23"
+version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37b1ae8d9ac08420c66222fb9096fc5de435c3c48542bc5336c51892cffafb41"
+checksum = "2d66674f2b6fb864665eea7a3c1ac4e3dfacd2fda83cf6f935a612e01b0e3338"
 dependencies = [
  "base64 0.21.7",
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "encoding_rs",
  "futures-core",
  "futures-util",
  "h2",
- "http",
+ "http 1.1.0",
  "http-body",
+ "http-body-util",
  "hyper",
  "hyper-tls",
+ "hyper-util",
  "ipnet",
  "js-sys",
  "log",
@@ -2048,9 +2122,11 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "sync_wrapper 0.1.2",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
@@ -2140,6 +2216,15 @@ dependencies = [
  "ring",
  "rustls-webpki",
  "sct",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -2550,6 +2635,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384595c11a4e2969895cad5a8c4029115f5ab956a9e5ef4de79d11a426e5f20c"
+
+[[package]]
 name = "system-configuration"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2702,7 +2793,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c89b4efa943be685f629b149f53829423f8f5531ea21249408e8e2f8671ec104"
 dependencies = [
  "backtrace",
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "libc",
  "mio",
  "num_cpus",
@@ -2744,7 +2835,19 @@ dependencies = [
  "native-tls",
  "tokio",
  "tokio-native-tls",
- "tungstenite",
+ "tungstenite 0.20.1",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.21.0",
 ]
 
 [[package]]
@@ -2753,21 +2856,12 @@ version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
 dependencies = [
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "futures-core",
  "futures-sink",
  "pin-project-lite",
  "tokio",
  "tracing",
-]
-
-[[package]]
-name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -2789,17 +2883,18 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.4.4"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c5bb1d698276a2443e5ecfabc1008bf15a36c12e6a7176e7bf089ea9131140"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
  "async-compression",
  "bitflags 2.4.2",
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "futures-core",
  "futures-util",
- "http",
+ "http 1.1.0",
  "http-body",
+ "http-body-util",
  "http-range-header",
  "httpdate",
  "mime",
@@ -2831,9 +2926,11 @@ version = "0.1.0"
 dependencies = [
  "dotenvy",
  "futures",
- "http",
+ "http 1.1.0",
+ "http-body-util",
  "hyper",
  "hyper-tls",
+ "hyper-util",
  "tokio",
  "tower",
  "tower-http",
@@ -2938,12 +3035,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e3dac10fd62eaf6617d3a904ae222845979aec67c615d1c842b4002c7666fb9"
 dependencies = [
  "byteorder",
- "bytes 1.5.0",
+ "bytes 1.6.0",
  "data-encoding",
- "http",
+ "http 0.2.11",
  "httparse",
  "log",
  "native-tls",
+ "rand 0.8.5",
+ "sha1 0.10.6",
+ "thiserror",
+ "url",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
+dependencies = [
+ "byteorder",
+ "bytes 1.6.0",
+ "data-encoding",
+ "http 1.1.0",
+ "httparse",
+ "log",
  "rand 0.8.5",
  "sha1 0.10.6",
  "thiserror",
@@ -2961,7 +3077,8 @@ dependencies = [
  "dotenvy",
  "futures",
  "hmac 0.12.1",
- "http",
+ "http 1.1.0",
+ "http-body-util",
  "http-types",
  "hyper",
  "once_cell",
@@ -2989,13 +3106,13 @@ dependencies = [
 
 [[package]]
 name = "twitch_oauth2"
-version = "0.12.9"
+version = "0.13.0"
 dependencies = [
  "aliri_braid",
  "async-trait",
  "base64 0.21.7",
  "displaydoc",
- "http",
+ "http 1.1.0",
  "http-types",
  "once_cell",
  "rand 0.8.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ exclude = ["twitch_types", "twitch_oauth2"]
 
 [workspace.dependencies]
 twitch_api = { version = "0.7.0-rc.6", path = "." }
-twitch_oauth2 = { version = "0.12.8", path = "twitch_oauth2/" }
+twitch_oauth2 = { version = "0.13.0", path = "twitch_oauth2/" }
 twitch_types = { version = "0.4.3", features = [
     "serde",
 ], path = "./twitch_types" }
@@ -36,7 +36,7 @@ twitch_types = { version = "0.4.3", features = [
 [dependencies]
 thiserror = "1.0.50"
 displaydoc = "0.2.4"
-http = "0.2.9"
+http = "1.1.0"
 typed-builder = { version = "0.18.0", optional = true }
 url = "2.4.1"
 once_cell = "1.18.0"
@@ -51,7 +51,7 @@ tracing = { version = "0.1.40", optional = true }
 ureq = { version = "2.8.0", optional = true, default-features = false, features = [
     "tls",
 ] }
-reqwest = { version = "0.11.22", optional = true, default-features = false }
+reqwest = { version = "0.12.2", optional = true, default-features = false }
 surf = { version = "2.3.2", optional = true, default-features = false }
 http-types = { version = "2.12.0", optional = true, features = [
     "hyperium_http",
@@ -60,7 +60,8 @@ sha2 = { version = "0.10.8", optional = true }
 crypto_hmac = { package = "hmac", version = "0.12.1", optional = true }
 aliri_braid = "0.4.0"
 futures = { version = "0.3.28", optional = true }
-hyper = { version = "0.14.27", optional = true }
+hyper = { version = "1.2.0", optional = true }
+http-body-util = { version = "0.1.1", optional = true }
 twitch_types = { workspace = true }
 tower-service = { version = "0.3.2", optional = true }
 
@@ -98,14 +99,13 @@ surf = [
     "dep:http-types",
     "client",
     "twitch_oauth2/surf",
-    "hyper?/stream",
 ]
 
 ureq = ["dep:ureq", "client"]
 
 reqwest = ["dep:reqwest", "client", "twitch_oauth2/reqwest"]
 
-tower = ["dep:tower-service", "client"]
+tower = ["dep:tower-service", "dep:http-body-util", "client"]
 
 pubsub = [
     "serde_json",
@@ -162,8 +162,8 @@ dotenvy = "0.15.7"
 futures = "0.3.28"
 serde_cbor = "0.11.2"
 serde_json = "1.0.107"
-reqwest = "0.11.22"
-hyper = "0.14.27"
+reqwest = "0.12.2"
+hyper = "1.2.0"
 
 [build-dependencies]
 tower = "0.4.13"

--- a/examples/eventsub/Cargo.toml
+++ b/examples/eventsub/Cargo.toml
@@ -6,16 +6,17 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-askama = { version = "0.11", features = ["with-axum"], git = "https://github.com/djc/askama", rev = "eeec6f0", default-features = false }
-askama_axum = { version = "0.1", git = "https://github.com/djc/askama", rev = "eeec6f0" }
-axum = { version = "0.6.20", features = ["tower-log", "http2", "ws"] }
+askama = { version = "0.12", features = ["with-axum"], default-features = false }
+askama_axum = "0.4"
+axum = { version = "0.7.5", features = ["tower-log", "http2", "ws"] }
 clap = { version = "4.4.7", features = ["derive", "env"] }
 color-eyre = { version = "0.6", features = ["capture-spantrace"] }
 dotenvy = "0.15.7"
 eyre = { version = "0.6" }
 futures = "0.3.28"
-hyper = "0.14"
-reqwest = "0.11.22"
+hyper = "1.2.0"
+http-body-util = "0.1.1"
+reqwest = "0.12.2"
 retainer = "0.3.0"
 serde = "1.0.190"
 serde_derive = "1.0.190"
@@ -23,7 +24,7 @@ serde_json = { version = "1" }
 tokio = { version = "1.33.0", features = ["macros", "rt-multi-thread"] }
 tokio-tungstenite = "0.20.1"
 tower = "0.4"
-tower-http = { version = "0.4.4", features = ["fs", "trace", "catch-panic"] }
+tower-http = { version = "0.5.2", features = ["fs", "trace", "catch-panic"] }
 tracing = "0.1.40"
 tracing-error = "0.2.0"
 tracing-log = "0.2.0"

--- a/examples/eventsub/src/twitch.rs
+++ b/examples/eventsub/src/twitch.rs
@@ -8,6 +8,7 @@ use axum::{
 };
 use eyre::Context;
 use futures::TryStreamExt;
+use http_body_util::BodyExt;
 use hyper::StatusCode;
 use tokio::sync::{watch, RwLock};
 use twitch_api::{
@@ -143,7 +144,7 @@ pub async fn twitch_eventsub(
         None => MAX_ALLOWED_RESPONSE_SIZE + 1, /* Just to protect ourselves from a malicious response */
     };
     let body = if response_content_length < MAX_ALLOWED_RESPONSE_SIZE {
-        hyper::body::to_bytes(body).await.unwrap()
+        body.collect().await.unwrap().to_bytes().to_vec()
     } else {
         panic!("too big data given")
     };

--- a/examples/eventsub_websocket/Cargo.toml
+++ b/examples/eventsub_websocket/Cargo.toml
@@ -11,8 +11,8 @@ color-eyre = { version = "0.6", features = ["capture-spantrace"] }
 dotenvy = "0.15.7"
 eyre = { version = "0.6" }
 futures = "0.3.28"
-hyper = "0.14"
-reqwest = { version = "0.11.22", features = ["json"] }
+hyper = "1.2.0"
+reqwest = { version = "0.12.2", features = ["json"] }
 serde = "1"
 serde_json = { version = "1" }
 tokio = { version = "1.33.0", features = ["macros", "rt-multi-thread"] }

--- a/examples/tower_client/Cargo.toml
+++ b/examples/tower_client/Cargo.toml
@@ -8,12 +8,14 @@ edition = "2021"
 [dependencies]
 dotenvy = "0.15.7"
 futures = "0.3.28"
-http = "0.2.9"
-hyper = { version = "0.14.27", features = ["client", "http1", "tcp"] }
-hyper-tls = "0.5.0"
+http = "1.1.0"
+http-body-util = "0.1.1"
+hyper = { version = "1.2.0", features = ["http1"] }
+hyper-tls = "0.6.0"
+hyper-util = { version = "0.1.3", features = ["client-legacy"] }
 tokio = { version = "1.33.0", features = ["macros", "rt-multi-thread"] }
 tower = { version = "0.4.13", features = ["retry", "util", "limit", "buffer"] }
-tower-http = { version = "0.4.4", features = ["set-header", "trace", "decompression-gzip"] }
+tower-http = { version = "0.5.2", features = ["set-header", "trace", "decompression-gzip"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 twitch_api = { workspace = true, features = ["tower", "helix", "tracing"] }

--- a/examples/tower_client/src/main.rs
+++ b/examples/tower_client/src/main.rs
@@ -1,5 +1,7 @@
 use futures::TryStreamExt;
 use http::header::USER_AGENT;
+use hyper_tls::HttpsConnector;
+use hyper_util::rt::TokioExecutor;
 use tower::ServiceBuilder;
 use tower_http::{
     classify::StatusInRangeAsFailures, decompression::DecompressionLayer,
@@ -52,7 +54,8 @@ async fn run() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>>
         ))
         // Use hyper
         .service(
-            hyper::Client::builder().build::<_, hyper::Body>(hyper_tls::HttpsConnector::new()),
+            hyper_util::client::legacy::Builder::new(TokioExecutor::new())
+                .build::<_, http_body_util::Full<hyper::body::Bytes>>(HttpsConnector::new()),
         );
 
     tracing::info!("Creating client");

--- a/examples/twitch_oauth2-integration/Cargo.toml
+++ b/examples/twitch_oauth2-integration/Cargo.toml
@@ -8,5 +8,5 @@ edition = "2021"
 [dependencies]
 twitch_api = { workspace = true, features = ["reqwest", "helix"] }
 twitch_oauth2 = { workspace = true }
-reqwest = { version = "0.11.22" }
+reqwest = { version = "0.12.2" }
 tokio = { version = "1.33.0", features = ["macros"] }

--- a/src/client/reqwest_impl.rs
+++ b/src/client/reqwest_impl.rs
@@ -26,7 +26,7 @@ impl Client for ReqwestClient {
             std::mem::swap(headers, response.headers_mut());
             let result = result.version(response.version());
             Ok(result
-                .body(response.bytes().await?.into())
+                .body(response.bytes().await?)
                 .expect("mismatch reqwest -> http conversion should not fail"))
         })
     }

--- a/src/client/ureq_impl.rs
+++ b/src/client/ureq_impl.rs
@@ -86,7 +86,7 @@ impl Client for UreqAgent {
                 .bytes()
                 .collect::<Result<hyper::body::Bytes, _>>()
             {
-                Ok(v) => result.body(v.into()).map_err(Into::into),
+                Ok(v) => result.body(v).map_err(Into::into),
                 Err(e) => Err(e.into()),
             }
         })

--- a/src/helix/client.rs
+++ b/src/helix/client.rs
@@ -147,8 +147,7 @@ impl<'a, C: crate::HttpClient + 'a> HelixClient<'a, C> {
             .req(req)
             .await
             .map_err(ClientRequestError::RequestError)?
-            .into_response_vec()
-            .await?;
+            .into_response_vec();
         <R>::parse_response(Some(request), &uri, response).map_err(Into::into)
     }
 
@@ -173,8 +172,7 @@ impl<'a, C: crate::HttpClient + 'a> HelixClient<'a, C> {
             .req(req)
             .await
             .map_err(ClientRequestError::RequestError)?
-            .into_response_vec()
-            .await?;
+            .into_response_vec();
         <R>::parse_response(Some(request), &uri, response).map_err(Into::into)
     }
 
@@ -199,8 +197,7 @@ impl<'a, C: crate::HttpClient + 'a> HelixClient<'a, C> {
             .req(req)
             .await
             .map_err(ClientRequestError::RequestError)?
-            .into_response_vec()
-            .await?;
+            .into_response_vec();
         <R>::parse_response(Some(request), &uri, response).map_err(Into::into)
     }
 
@@ -222,8 +219,7 @@ impl<'a, C: crate::HttpClient + 'a> HelixClient<'a, C> {
             .req(req)
             .await
             .map_err(ClientRequestError::RequestError)?
-            .into_response_vec()
-            .await?;
+            .into_response_vec();
         <R>::parse_response(Some(request), &uri, response).map_err(Into::into)
     }
 
@@ -248,8 +244,7 @@ impl<'a, C: crate::HttpClient + 'a> HelixClient<'a, C> {
             .req(req)
             .await
             .map_err(ClientRequestError::RequestError)?
-            .into_response_vec()
-            .await?;
+            .into_response_vec();
         <R>::parse_response(Some(request), &uri, response).map_err(Into::into)
     }
 }

--- a/src/helix/client/custom.rs
+++ b/src/helix/client/custom.rs
@@ -52,9 +52,7 @@ impl<C: crate::HttpClient> HelixClient<'_, C> {
             .client
             .req(req)
             .await
-            .map_err(ClientRequestError::RequestError)?
-            .into_response_bytes()
-            .await?;
+            .map_err(ClientRequestError::RequestError)?;
         {
             let request = Some(request);
             let uri = &uri;
@@ -116,9 +114,7 @@ impl<C: crate::HttpClient> HelixClient<'_, C> {
             .client
             .req(req)
             .await
-            .map_err(ClientRequestError::RequestError)?
-            .into_response_bytes()
-            .await?;
+            .map_err(ClientRequestError::RequestError)?;
         {
             let request = Some(request);
             let uri = &uri;
@@ -187,9 +183,7 @@ impl<C: crate::HttpClient> HelixClient<'_, C> {
             .client
             .req(req)
             .await
-            .map_err(ClientRequestError::RequestError)?
-            .into_response_bytes()
-            .await?;
+            .map_err(ClientRequestError::RequestError)?;
         {
             let uri = &uri;
             let text = std::str::from_utf8(response.body()).map_err(|e| {
@@ -254,9 +248,7 @@ impl<C: crate::HttpClient> HelixClient<'_, C> {
             .client
             .req(req)
             .await
-            .map_err(ClientRequestError::RequestError)?
-            .into_response_bytes()
-            .await?;
+            .map_err(ClientRequestError::RequestError)?;
         {
             let uri = &uri;
             let text = std::str::from_utf8(response.body()).map_err(|e| {
@@ -324,9 +316,7 @@ impl<C: crate::HttpClient> HelixClient<'_, C> {
             .client
             .req(req)
             .await
-            .map_err(ClientRequestError::RequestError)?
-            .into_response_bytes()
-            .await?;
+            .map_err(ClientRequestError::RequestError)?;
         {
             let uri = &uri;
             let text = std::str::from_utf8(response.body()).map_err(|e| {

--- a/src/tmi/mod.rs
+++ b/src/tmi/mod.rs
@@ -90,10 +90,10 @@ impl<'a, C: crate::HttpClient + 'a> TmiClient<'a, C> {
             .req(req)
             .await
             .map_err(|e| RequestError::RequestError(Box::new(e)))?;
-        let (parts, mut body) = resp.into_parts();
-        let resp = http::Response::from_parts(parts, hyper::body::to_bytes(&mut body).await?);
+        let (parts, body) = resp.into_parts();
+        let resp = http::Response::from_parts(parts, body.to_vec());
         let text = std::str::from_utf8(resp.body())
-            .map_err(|e| RequestError::Utf8Error(resp.body().to_vec(), e))?;
+            .map_err(|e| RequestError::Utf8Error(resp.body().clone(), e))?;
         crate::parse_json(text, true).map_err(Into::into)
     }
 }


### PR DESCRIPTION
Additionally, the examples were updated to use dependencies that use http1.

Fixes #401.