### PR TITLE
feat: Add Get Conduits & Create Conduit endpoints

### DIFF
--- a/src/eventsub/mod.rs
+++ b/src/eventsub/mod.rs
@@ -753,6 +753,18 @@ pub struct EventSubSubscription {
     pub version: String,
 }
 
+/// General information about a [Conduit](https://dev.twitch.tv/docs/eventsub/handling-conduit-events/)
+#[derive(PartialEq, Eq, Deserialize, Serialize, Debug, Clone)]
+#[non_exhaustive]
+#[cfg(feature = "eventsub")]
+#[cfg_attr(nightly, doc(cfg(feature = "eventsub")))]
+pub struct Conduit {
+    /// Conduit ID
+    pub id: String,
+    /// Number of shards associated with this conduit
+    pub shard_count: usize,
+}
+
 pub(crate) trait NamedField {
     const NAME: &'static str;
 }

--- a/src/helix/client/client_ext.rs
+++ b/src/helix/client/client_ext.rs
@@ -1204,7 +1204,8 @@ impl<'client, C: crate::HttpClient + Sync + 'client> HelixClient<'client, C> {
     }
 
     #[cfg(feature = "eventsub")]
-    /// Get all [Conduits](crate::eventsub::Conduit) for this [Client](twitch_oauth2::TwitchToken)
+    /// Get all [Conduits](crate::eventsub::Conduit) for the Twitch Developer Application
+    /// associated with this token
     ///
     /// # Notes
     ///
@@ -1238,7 +1239,8 @@ impl<'client, C: crate::HttpClient + Sync + 'client> HelixClient<'client, C> {
     }
 
     #[cfg(feature = "eventsub")]
-    /// Create a [Conduit](crate::eventsub) for this [Client](twitch_oauth2::TwitchToken)
+    /// Create a [Conduit](crate::eventsub) for the Twitch Developer Application
+    /// associated with this token
     ///
     /// # Notes
     ///

--- a/src/helix/client/client_ext.rs
+++ b/src/helix/client/client_ext.rs
@@ -1202,6 +1202,79 @@ impl<'client, C: crate::HttpClient + Sync + 'client> HelixClient<'client, C> {
             vec
         })
     }
+
+    #[cfg(feature = "eventsub")]
+    /// Get all [Conduits](crate::eventsub::Conduit) for this [Client](twitch_oauth2::TwitchToken)
+    ///
+    /// # Notes
+    ///
+    /// The token must be an App Access Token
+    ///
+    /// # Examples
+    ///
+    /// ```rust, no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    /// # let client: helix::HelixClient<'static, twitch_api::client::DummyHttpClient> = helix::HelixClient::default();
+    /// # let client_id = twitch_oauth2::types::ClientId::from_static("your_client_id");
+    /// # let client_secret = twitch_oauth2::types::ClientSecret::from_static("your_client_id");
+    /// # let token = twitch_oauth2::AppAccessToken::get_app_access_token(&client, client_id, client_secret, vec![]).await?;
+    /// use twitch_api::{helix, eventsub};
+    ///
+    /// let conduits = client.get_conduits(&token).await?;
+    ///
+    /// # Ok(()) }
+    /// ```
+    pub async fn get_conduits<'b: 'client, T>(
+        &'client self,
+        token: &'client T,
+    ) -> Result<Vec<crate::eventsub::Conduit>, ClientError<C>>
+    where
+        T: TwitchToken + Send + Sync + ?Sized,
+    {
+        self.req_get(helix::eventsub::GetConduitsRequest {}, token)
+            .await
+            .map(|response| response.data)
+    }
+
+    #[cfg(feature = "eventsub")]
+    /// Create a [Conduit](crate::eventsub) for this [Client](twitch_oauth2::TwitchToken)
+    ///
+    /// # Notes
+    ///
+    /// The token must be an App Access Token
+    ///
+    /// # Examples
+    ///
+    /// ```rust, no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    /// # let client: helix::HelixClient<'static, twitch_api::client::DummyHttpClient> = helix::HelixClient::default();
+    /// # let client_id = twitch_oauth2::types::ClientId::from_static("your_client_id");
+    /// # let client_secret = twitch_oauth2::types::ClientSecret::from_static("your_client_id");
+    /// # let token = twitch_oauth2::AppAccessToken::get_app_access_token(&client, client_id, client_secret, vec![]).await?;
+    /// use twitch_api::{helix, eventsub};
+    ///
+    /// let shard_count = 5;
+    /// let created_conduit = client.create_conduit(shard_count, &token).await?;
+    ///
+    /// # Ok(()) }
+    /// ```
+    pub async fn create_conduit<'b: 'client, T>(
+        &'client self,
+        shard_count: usize,
+        token: &'client T,
+    ) -> Result<crate::eventsub::Conduit, ClientError<C>>
+    where
+        T: TwitchToken + Send + Sync + ?Sized,
+    {
+        let req = helix::eventsub::CreateConduitRequest {};
+        let body = helix::eventsub::CreateConduitBody::new(shard_count);
+
+        self.req_post(req, body, token)
+            .await
+            .map(|response| response.data)
+    }
 }
 
 /// Error type to combine a http client error with a other error

--- a/src/helix/endpoints/eventsub/create_conduit.rs
+++ b/src/helix/endpoints/eventsub/create_conduit.rs
@@ -1,0 +1,139 @@
+//! Creates a new conduit for your Client.
+//! [`create-conduit`](https://dev.twitch.tv/docs/api/reference/#create-conduits)
+
+use super::*;
+use crate::eventsub;
+use helix::RequestPost;
+
+/// Query Parameters for [Create Conduit](super::create_conduit)
+///
+/// [`create-conduit`](https://dev.twitch.tv/docs/api/reference/#create-conduits)
+#[derive(PartialEq, Eq, Serialize, Clone, Debug, Default)]
+#[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
+#[must_use]
+#[non_exhaustive]
+pub struct CreateConduitRequest {}
+
+impl Request for CreateConduitRequest {
+    type Response = eventsub::Conduit;
+
+    const PATH: &'static str = "eventsub/conduits";
+    #[cfg(feature = "twitch_oauth2")]
+    const SCOPE: twitch_oauth2::Validator = twitch_oauth2::validator![];
+}
+
+/// Body Parameters for [Create Conduit](super::create_conduit)
+///
+/// [`create-conduit`](https://dev.twitch.tv/docs/api/reference/#create-conduits)
+#[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
+#[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
+#[non_exhaustive]
+pub struct CreateConduitBody {
+    /// The number of shards to create for this conduit.
+    pub shard_count: usize,
+}
+
+impl CreateConduitBody {
+    /// Conduit body settings
+    pub fn new(shard_count: usize) -> Self { Self { shard_count } }
+}
+
+impl helix::private::SealedSerialize for CreateConduitBody {}
+
+impl RequestPost for CreateConduitRequest {
+    type Body = CreateConduitBody;
+
+    fn parse_inner_response(
+        request: Option<Self>,
+        uri: &http::Uri,
+        response: &str,
+        status: http::StatusCode,
+    ) -> Result<helix::Response<Self, Self::Response>, helix::HelixRequestPostError>
+    where
+        Self: Sized,
+    {
+        #[derive(PartialEq, Deserialize, Debug)]
+        #[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+        struct InnerResponse {
+            data: [eventsub::Conduit; 1],
+        }
+
+        let inner_response: InnerResponse = helix::parse_json(response, true).map_err(|e| {
+            helix::HelixRequestPostError::DeserializeError(
+                response.to_string(),
+                e,
+                uri.clone(),
+                status,
+            )
+        })?;
+
+        let [conduit] = inner_response.data;
+
+        Ok(helix::Response::new(conduit, None, request, None, None))
+    }
+}
+
+#[cfg(test)]
+#[test]
+fn test_uri() {
+    use helix::*;
+    let req: CreateConduitRequest = CreateConduitRequest::default();
+
+    let uri = req.get_uri().unwrap();
+    assert_eq!(
+        uri.to_string(),
+        "https://api.twitch.tv/helix/eventsub/conduits?"
+    );
+}
+
+#[cfg(test)]
+#[test]
+fn test_successful_response() {
+    use helix::*;
+    let req: CreateConduitRequest = CreateConduitRequest::default();
+
+    let data = br#"{
+      "data": [
+        {
+          "id": "bfcfc993-26b1-b876-44d9-afe75a379dac",
+          "shard_count": 5
+        }
+      ]
+    }
+    "#
+    .to_vec();
+    let http_response = http::Response::builder().status(200).body(data).unwrap();
+
+    let uri = req.get_uri().unwrap();
+    let response = CreateConduitRequest::parse_response(Some(req), &uri, http_response).unwrap();
+
+    assert_eq!(
+        response.data,
+        crate::eventsub::Conduit {
+            id: "bfcfc993-26b1-b876-44d9-afe75a379dac".to_string(),
+            shard_count: 5,
+        },
+    );
+
+    dbg!("{:#?}", response);
+}
+
+#[cfg(test)]
+#[test]
+fn test_successful_unexpected_response() {
+    use helix::*;
+    let req: CreateConduitRequest = CreateConduitRequest::default();
+
+    let data = br#"{
+      "data": []
+    }
+    "#
+    .to_vec();
+    let http_response = http::Response::builder().status(200).body(data).unwrap();
+
+    let uri = req.get_uri().unwrap();
+    let response = CreateConduitRequest::parse_response(Some(req), &uri, http_response);
+    assert_eq!(response.is_err(), true);
+
+    dbg!("{:#?}", response);
+}

--- a/src/helix/endpoints/eventsub/get_conduits.rs
+++ b/src/helix/endpoints/eventsub/get_conduits.rs
@@ -1,0 +1,112 @@
+//! Get the conduits for your Client.
+//! [`get-conduits`](https://dev.twitch.tv/docs/api/reference/#get-conduits)
+
+use super::*;
+use crate::eventsub;
+use helix::RequestGet;
+
+/// Query Parameters for [Get Conduits](super::create_conduit)
+///
+/// [`get-conduits`](https://dev.twitch.tv/docs/api/reference/#get-conduits)
+#[derive(PartialEq, Eq, Serialize, Clone, Debug, Default)]
+#[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
+#[must_use]
+#[non_exhaustive]
+pub struct GetConduitsRequest {}
+
+impl Request for GetConduitsRequest {
+    type Response = Vec<eventsub::Conduit>;
+
+    const PATH: &'static str = "eventsub/conduits";
+    #[cfg(feature = "twitch_oauth2")]
+    const SCOPE: twitch_oauth2::Validator = twitch_oauth2::validator![];
+}
+
+impl RequestGet for GetConduitsRequest {
+    fn parse_inner_response(
+        request: Option<Self>,
+        uri: &http::Uri,
+        response: &str,
+        status: http::StatusCode,
+    ) -> Result<helix::Response<Self, Self::Response>, helix::HelixRequestGetError>
+    where
+        Self: Sized,
+    {
+        #[derive(PartialEq, Deserialize, Debug)]
+        #[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+        struct InnerResponse {
+            data: Vec<eventsub::Conduit>,
+        }
+
+        let response: InnerResponse = helix::parse_json(response, true).map_err(|e| {
+            helix::HelixRequestGetError::DeserializeError(
+                response.to_string(),
+                e,
+                uri.clone(),
+                status,
+            )
+        })?;
+        Ok(helix::Response::new(
+            response.data,
+            None,
+            request,
+            None,
+            None,
+        ))
+    }
+}
+
+#[cfg(test)]
+#[test]
+fn test_uri() {
+    use helix::*;
+    let req: GetConduitsRequest = GetConduitsRequest::default();
+
+    let uri = req.get_uri().unwrap();
+    assert_eq!(
+        uri.to_string(),
+        "https://api.twitch.tv/helix/eventsub/conduits?"
+    );
+}
+
+#[cfg(test)]
+#[test]
+fn test_request() {
+    use helix::*;
+    let req: GetConduitsRequest = GetConduitsRequest::default();
+
+    let data = br#"{
+      "data": [
+        {
+          "id": "26b1c993-bfcf-44d9-b876-379dacafe75a",
+          "shard_count": 15
+        },
+        {
+          "id": "bfcfc993-26b1-b876-44d9-afe75a379dac",
+          "shard_count": 5
+        }
+      ]
+    }
+    "#
+    .to_vec();
+    let http_response = http::Response::builder().status(200).body(data).unwrap();
+
+    let uri = req.get_uri().unwrap();
+    let response = GetConduitsRequest::parse_response(Some(req), &uri, http_response).unwrap();
+
+    assert_eq!(
+        response.data,
+        vec![
+            crate::eventsub::Conduit {
+                id: "26b1c993-bfcf-44d9-b876-379dacafe75a".to_string(),
+                shard_count: 15,
+            },
+            crate::eventsub::Conduit {
+                id: "bfcfc993-26b1-b876-44d9-afe75a379dac".to_string(),
+                shard_count: 5,
+            },
+        ]
+    );
+
+    dbg!("{:#?}", response);
+}

--- a/src/helix/endpoints/eventsub/get_conduits.rs
+++ b/src/helix/endpoints/eventsub/get_conduits.rs
@@ -5,7 +5,7 @@ use super::*;
 use crate::eventsub;
 use helix::RequestGet;
 
-/// Query Parameters for [Get Conduits](super::create_conduit)
+/// Query Parameters for [Get Conduits](super::get_conduits)
 ///
 /// [`get-conduits`](https://dev.twitch.tv/docs/api/reference/#get-conduits)
 #[derive(PartialEq, Eq, Serialize, Clone, Debug, Default)]

--- a/src/helix/endpoints/eventsub/mod.rs
+++ b/src/helix/endpoints/eventsub/mod.rs
@@ -7,10 +7,14 @@ use crate::{
 use serde_derive::{Deserialize, Serialize};
 use std::borrow::Cow;
 
+pub mod create_conduit;
 pub mod create_eventsub_subscription;
 pub mod delete_eventsub_subscription;
+pub mod get_conduits;
 pub mod get_eventsub_subscriptions;
 
+#[doc(inline)]
+pub use create_conduit::{CreateConduitBody, CreateConduitRequest};
 #[doc(inline)]
 pub use create_eventsub_subscription::{
     CreateEventSubSubscription, CreateEventSubSubscriptionBody, CreateEventSubSubscriptionRequest,
@@ -19,5 +23,7 @@ pub use create_eventsub_subscription::{
 pub use delete_eventsub_subscription::{
     DeleteEventSubSubscription, DeleteEventSubSubscriptionRequest,
 };
+#[doc(inline)]
+pub use get_conduits::GetConduitsRequest;
 #[doc(inline)]
 pub use get_eventsub_subscriptions::{EventSubSubscriptions, GetEventSubSubscriptionsRequest};


### PR DESCRIPTION
This doesn't implement all conduit-related endpoints on purpose since I'm slow/not sure what I'm doing so I thought doing little by little is a better idea

Questions:
1) The token for create_conduit & get_conduits must be an app access token. Can I check that compile-time somehow with a trait or something?
2) I've left a bunch of stuff on the bodies/requests (like typed-builder) that I don't really understand. Please let me know if they should be removed
