### PR TITLE
Fix `update_shield_mode_status` docs and missing `level` in `ChannelHypeTrainBeginV1Payload`

### DIFF
--- a/src/eventsub/channel/hypetrain/begin.rs
+++ b/src/eventsub/channel/hypetrain/begin.rs
@@ -61,6 +61,8 @@ pub struct ChannelHypeTrainBeginV1Payload {
     pub top_contributions: Vec<Contribution>,
     /// Total points contributed to the hype train.
     pub total: i64,
+    /// The starting level of the Hype Train.
+    pub level: i64,
 }
 
 #[cfg(test)]
@@ -96,6 +98,7 @@ fn parse_payload() {
                 { "user_id": "456", "user_login": "kappa", "user_name": "Kappa", "type": "subscription", "total": 45 }
             ],
             "last_contribution": { "user_id": "123", "user_login": "pogchamp", "user_name": "PogChamp", "type": "bits", "total": 50 },
+            "level": 2,
             "started_at": "2020-07-15T17:16:03.17106713Z",
             "expires_at": "2020-07-15T17:16:11.17106713Z"
         }

--- a/src/helix/endpoints/moderation/update_shield_mode_status.rs
+++ b/src/helix/endpoints/moderation/update_shield_mode_status.rs
@@ -15,7 +15,8 @@
 //! );
 //! ```
 //!
-//! //! ## Body: [UpdateShieldModeStatusBody]
+//! ## Body: [UpdateShieldModeStatusBody]
+//!
 //! We also need to provide a body to the request.
 //!
 //! ```


### PR DESCRIPTION
- `update_shield_mode_status` had a duplicate `//!` and no newline after the heading.
- `ChannelHypeTrainBeginV1Payload` was missing `level` - see https://github.com/orgs/twitch-rs/projects/1/views/3?pane=issue&itemId=14931669