### PR TITLE
feat: Add "Update Conduit Shards" endpoint

### DIFF
--- a/src/eventsub/mod.rs
+++ b/src/eventsub/mod.rs
@@ -484,6 +484,17 @@ pub struct WebsocketTransport {
     pub session_id: String,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[non_exhaustive]
+/// Conduit transport
+pub struct ConduitTransport {
+    /// An ID that identifies the conduit to send notifications to.
+    ///
+    /// When you create a conduit, the server returns the conduit ID.
+    pub conduit_id: String,
+}
+
 /// Transport setting for event notification
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "method", rename_all = "lowercase")]
@@ -493,6 +504,8 @@ pub enum Transport {
     Webhook(WebhookTransport),
     /// Websocket transport
     Websocket(WebsocketTransport),
+    /// Conduit transport
+    Conduit(ConduitTransport),
 }
 
 impl Transport {
@@ -508,6 +521,13 @@ impl Transport {
     pub fn websocket(session_id: impl std::string::ToString) -> Transport {
         Transport::Websocket(WebsocketTransport {
             session_id: session_id.to_string(),
+        })
+    }
+
+    /// Convenience method for making a conduit transport
+    pub fn conduit(conduit_id: impl std::string::ToString) -> Transport {
+        Transport::Conduit(ConduitTransport {
+            conduit_id: conduit_id.to_string(),
         })
     }
 
@@ -590,6 +610,15 @@ pub struct WebhookTransportResponse {
     pub callback: String,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[non_exhaustive]
+/// Conduit transport
+pub struct ConduitTransportResponse {
+    /// The conduit ID
+    pub conduit_id: String,
+}
+
 /// Transport response on event notification
 ///
 /// Does not include secret.
@@ -601,6 +630,8 @@ pub enum TransportResponse {
     Webhook(WebhookTransportResponse),
     /// Websocket transport response
     Websocket(WebsocketTransportResponse),
+    /// Conduit transport response
+    Conduit(ConduitTransportResponse),
 }
 
 impl TransportResponse {
@@ -763,6 +794,99 @@ pub struct Conduit {
     pub id: String,
     /// Number of shards associated with this conduit
     pub shard_count: usize,
+}
+
+/// General information about a [Shard](https://dev.twitch.tv/docs/eventsub/handling-conduit-events/)
+///
+/// A shard is a Webhook or WebSocket connection, while a conduit is a collection of shards. The conduit transport type is for backend server applications and requires app access tokens.
+#[derive(PartialEq, Eq, Deserialize, Serialize, Debug, Clone)]
+#[non_exhaustive]
+#[cfg(feature = "eventsub")]
+#[cfg_attr(nightly, doc(cfg(feature = "eventsub")))]
+pub struct Shard {
+    /// Shard ID.
+    pub id: String,
+
+    /// The transport details that you want Twitch to use when sending you notifications.
+    pub transport: Transport,
+}
+
+impl Shard {
+    /// Create a shard with a transport set
+    pub fn new(id: impl std::string::ToString, transport: Transport) -> Self {
+        Self {
+            id: id.to_string(),
+
+            transport,
+        }
+    }
+}
+
+/// The shard status.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum ShardStatus {
+    /// The shard is enabled.
+    Enabled,
+
+    /// The shard is pending verification of the specified callback URL.
+    WebhookCallbackVerificationPending,
+
+    /// The specified callback URL failed verification.
+    WebhookCallbackVerificationFailed,
+
+    /// The notification delivery failure rate was too high.
+    NotificationFailuresExceeded,
+
+    /// The client closed the connection.
+    WebsocketDisconnected,
+
+    /// The client failed to respond to a ping message.
+    WebsocketFailedPingPong,
+
+    /// The client sent a non-pong message. Clients may only send pong messages (and only in response to a ping message).
+    WebsocketReceivedInboundTraffic,
+
+    /// The Twitch WebSocket server experienced an unexpected error.
+    WebsocketInternalError,
+
+    /// The Twitch WebSocket server timed out writing the message to the client.
+    WebsocketNetworkTimeout,
+
+    /// The Twitch WebSocket server experienced a network error writing the message to the client.
+    WebsocketNetworkError,
+
+    /// The client failed to reconnect to the Twitch WebSocket server within the required time after a Reconnect Message.
+    WebsocketFailedToReconnect,
+}
+
+/// A structured error that occurred with a shard
+#[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
+#[non_exhaustive]
+pub struct ShardError {
+    /// Shard ID.
+    pub id: String,
+
+    /// The error that occurred while updating the shard.
+    pub message: String,
+
+    /// Error codes used to represent a specific error condition while attempting to update shards.
+    pub code: String,
+}
+
+/// A shard when described by Twitch
+#[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
+#[non_exhaustive]
+pub struct ShardResponse {
+    /// Shard ID.
+    pub id: String,
+
+    /// The shard status. The subscriber receives events only for enabled shards.
+    pub status: ShardStatus,
+
+    /// The transport details that you want Twitch to use when sending you notifications.
+    pub transport: TransportResponse,
 }
 
 pub(crate) trait NamedField {

--- a/src/eventsub/mod.rs
+++ b/src/eventsub/mod.rs
@@ -647,6 +647,12 @@ impl TransportResponse {
     #[must_use]
     pub fn is_websocket(&self) -> bool { matches!(self, Self::Websocket(..)) }
 
+    /// Returns `true` if the transport response is [`Conduit`].
+    ///
+    /// [`Conduit`]: TransportResponse::Conduit
+    #[must_use]
+    pub fn is_conduit(&self) -> bool { matches!(self, Self::Conduit(..)) }
+
     /// Returns `Some(&WebhookTransport)` if this transport response is a [webhook](WebhookTransportResponse)
     pub fn as_webhook(&self) -> Option<&WebhookTransportResponse> {
         if let Self::Webhook(v) = self {
@@ -665,6 +671,15 @@ impl TransportResponse {
         }
     }
 
+    /// Returns `Some(&ConduitTransport)` if this transport response is a [conduit](ConduitTransportResponse)
+    pub fn as_conduit(&self) -> Option<&ConduitTransportResponse> {
+        if let Self::Conduit(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
     /// Returns `Ok(WebhookTransport)` if this transport response is a [webhook](WebhookTransportResponse)
     pub fn try_into_webhook(self) -> Result<WebhookTransportResponse, Self> {
         if let Self::Webhook(v) = self {
@@ -677,6 +692,15 @@ impl TransportResponse {
     /// Returns `Ok(WebsocketTransport)` if this transport response is a [websocket](WebsocketTransportResponse)
     pub fn try_into_websocket(self) -> Result<WebsocketTransportResponse, Self> {
         if let Self::Websocket(v) = self {
+            Ok(v)
+        } else {
+            Err(self)
+        }
+    }
+
+    /// Returns `Ok(ConduitTransport)` if this transport response is a [conduit](ConduitTransportResponse)
+    pub fn try_into_conduit(self) -> Result<ConduitTransportResponse, Self> {
+        if let Self::Conduit(v) = self {
             Ok(v)
         } else {
             Err(self)

--- a/src/eventsub/mod.rs
+++ b/src/eventsub/mod.rs
@@ -543,6 +543,12 @@ impl Transport {
     #[must_use]
     pub fn is_websocket(&self) -> bool { matches!(self, Self::Websocket(..)) }
 
+    /// Returns `true` if the transport is [`Conduit`].
+    ///
+    /// [`Conduit`]: Transport::Conduit
+    #[must_use]
+    pub fn is_conduit(&self) -> bool { matches!(self, Self::Conduit(..)) }
+
     /// Returns `Some(&WebhookTransport)` if this transport is a [webhook](WebhookTransport)
     pub fn as_webhook(&self) -> Option<&WebhookTransport> {
         if let Self::Webhook(v) = self {
@@ -561,6 +567,15 @@ impl Transport {
         }
     }
 
+    /// Returns `Some(&ConduitTransport)` if this transport is a [conduit](ConduitTransport)
+    pub fn as_conduit(&self) -> Option<&ConduitTransport> {
+        if let Self::Conduit(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
     /// Returns `Some(WebhookTransport)` if this transport is a [webhook](WebhookTransport), `None` if not
     pub fn try_into_webhook(self) -> Option<WebhookTransport> {
         if let Self::Webhook(v) = self {
@@ -573,6 +588,15 @@ impl Transport {
     /// Returns `Some(WebsocketTransport)` if this transport is a [websocket](WebsocketTransport), `Err(())` if not
     pub fn try_into_websocket(self) -> Option<WebsocketTransport> {
         if let Self::Websocket(v) = self {
+            Some(v)
+        } else {
+            None
+        }
+    }
+
+    /// Returns `Some(ConduitTransport)` if this transport is a [conduit](ConduitTransport), `Err(())` if not
+    pub fn try_into_conduit(self) -> Option<ConduitTransport> {
+        if let Self::Conduit(v) = self {
             Some(v)
         } else {
             None

--- a/src/helix/endpoints/eventsub/mod.rs
+++ b/src/helix/endpoints/eventsub/mod.rs
@@ -12,6 +12,7 @@ pub mod create_eventsub_subscription;
 pub mod delete_eventsub_subscription;
 pub mod get_conduits;
 pub mod get_eventsub_subscriptions;
+pub mod update_conduit_shards;
 
 #[doc(inline)]
 pub use create_conduit::{CreateConduitBody, CreateConduitRequest};
@@ -27,3 +28,7 @@ pub use delete_eventsub_subscription::{
 pub use get_conduits::GetConduitsRequest;
 #[doc(inline)]
 pub use get_eventsub_subscriptions::{EventSubSubscriptions, GetEventSubSubscriptionsRequest};
+#[doc(inline)]
+pub use update_conduit_shards::{
+    UpdateConduitShardsBody, UpdateConduitShardsRequest, UpdateConduitShardsResponse,
+};

--- a/src/helix/endpoints/eventsub/update_conduit_shards.rs
+++ b/src/helix/endpoints/eventsub/update_conduit_shards.rs
@@ -1,0 +1,209 @@
+//! Updates shard(s) for a [conduit](https://dev.twitch.tv/docs/eventsub/handling-conduit-events).
+//! [`update-conduit-shards`](https://dev.twitch.tv/docs/api/reference/#update-conduit-shards)
+
+use super::*;
+use crate::eventsub;
+use helix::RequestPatch;
+
+/// Query Parameters for [Update Conduit Shards](super::update_conduit_shards)
+///
+/// [`update-conduit-shards`](https://dev.twitch.tv/docs/api/reference/#update-conduit-shards)
+#[derive(PartialEq, Eq, Serialize, Clone, Debug, Default)]
+#[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
+#[must_use]
+#[non_exhaustive]
+pub struct UpdateConduitShardsRequest {}
+
+impl Request for UpdateConduitShardsRequest {
+    type Response = UpdateConduitShardsResponse;
+
+    const PATH: &'static str = "eventsub/conduits/shards";
+    #[cfg(feature = "twitch_oauth2")]
+    const SCOPE: twitch_oauth2::Validator = twitch_oauth2::validator![];
+}
+
+/// The structured response for [Update Conduit Shards](super::update_conduit_shards)
+///
+/// [`update-conduit-shards`](https://dev.twitch.tv/docs/api/reference/#update-conduit-shards)
+#[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
+#[non_exhaustive]
+pub struct UpdateConduitShardsResponse {
+    /// List of successful shard updates.
+    pub shards: Vec<eventsub::ShardResponse>,
+
+    /// List of unsuccessful updates.
+    pub errors: Vec<eventsub::ShardError>,
+}
+
+/// Body Parameters for [Update Conduit Shards](super::update_conduit_shards)
+///
+/// [`update-conduit-shards`](https://dev.twitch.tv/docs/api/reference/#update-conduit-shards)
+#[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
+#[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
+#[non_exhaustive]
+pub struct UpdateConduitShardsBody {
+    /// Conduit ID.
+    pub conduit_id: String,
+
+    /// List of shards to update.
+    pub shards: Vec<eventsub::Shard>,
+}
+
+impl UpdateConduitShardsBody {
+    /// Conduit body settings
+    pub fn new(conduit_id: String, shards: Vec<eventsub::Shard>) -> Self {
+        Self { conduit_id, shards }
+    }
+}
+
+impl helix::private::SealedSerialize for UpdateConduitShardsBody {}
+
+impl RequestPatch for UpdateConduitShardsRequest {
+    type Body = UpdateConduitShardsBody;
+
+    fn parse_inner_response(
+        request: Option<Self>,
+        uri: &http::Uri,
+        response: &str,
+        status: http::StatusCode,
+    ) -> Result<helix::Response<Self, Self::Response>, helix::HelixRequestPatchError>
+    where
+        Self: Sized,
+    {
+        #[derive(PartialEq, Deserialize, Debug)]
+        #[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+        struct InnerResponse {
+            data: Vec<eventsub::ShardResponse>,
+            errors: Vec<eventsub::ShardError>,
+        }
+
+        let inner_response: InnerResponse = helix::parse_json(response, true).map_err(|e| {
+            helix::HelixRequestPatchError::DeserializeError(
+                response.to_string(),
+                e,
+                uri.clone(),
+                status,
+            )
+        })?;
+
+        Ok(helix::Response::new(
+            UpdateConduitShardsResponse {
+                shards: inner_response.data,
+                errors: inner_response.errors,
+            },
+            None,
+            request,
+            None,
+            None,
+        ))
+    }
+}
+
+#[cfg(test)]
+#[test]
+fn test_uri() {
+    use helix::*;
+    let req: UpdateConduitShardsRequest = UpdateConduitShardsRequest::default();
+
+    let uri = req.get_uri().unwrap();
+    assert_eq!(
+        uri.to_string(),
+        "https://api.twitch.tv/helix/eventsub/conduits/shards?"
+    );
+}
+
+#[cfg(test)]
+#[test]
+fn test_successful_response() {
+    use helix::*;
+    let req: UpdateConduitShardsRequest = UpdateConduitShardsRequest::default();
+
+    let data = br#"{
+  "data": [
+    {
+      "id": "0",
+      "status": "enabled",
+      "transport": {
+        "method": "webhook",
+        "callback": "https://this-is-a-callback.com"
+      }
+    },
+    {
+      "id": "1",
+      "status": "webhook_callback_verification_pending",
+      "transport": {
+        "method": "webhook",
+        "callback": "https://this-is-a-callback-2.com"
+      }
+    }
+  ],
+  "errors": [
+    {
+      "id": "3",
+      "message": "The shard id is outside the conduit's range",
+      "code": "invalid_parameter"
+    }
+  ]
+}"#
+    .to_vec();
+    let http_response = http::Response::builder().status(202).body(data).unwrap();
+
+    let uri = req.get_uri().unwrap();
+    let response =
+        UpdateConduitShardsRequest::parse_response(Some(req), &uri, http_response).unwrap();
+
+    assert_eq!(
+        response.data.shards,
+        vec![
+            crate::eventsub::ShardResponse {
+                id: "0".to_string(),
+                status: crate::eventsub::ShardStatus::Enabled,
+                transport: crate::eventsub::TransportResponse::Webhook(
+                    crate::eventsub::WebhookTransportResponse {
+                        callback: "https://this-is-a-callback.com".to_string(),
+                    }
+                ),
+            },
+            crate::eventsub::ShardResponse {
+                id: "1".to_string(),
+                status: crate::eventsub::ShardStatus::WebhookCallbackVerificationPending,
+                transport: crate::eventsub::TransportResponse::Webhook(
+                    crate::eventsub::WebhookTransportResponse {
+                        callback: "https://this-is-a-callback-2.com".to_string(),
+                    }
+                ),
+            }
+        ]
+    );
+
+    assert_eq!(
+        response.data.errors,
+        vec![crate::eventsub::ShardError {
+            id: "3".to_string(),
+            message: "The shard id is outside the conduit's range".to_string(),
+            code: "invalid_parameter".to_string(),
+        },]
+    );
+
+    dbg!("{:#?}", response);
+}
+
+#[cfg(test)]
+#[test]
+fn test_successful_unexpected_response() {
+    use helix::*;
+    let req: UpdateConduitShardsRequest = UpdateConduitShardsRequest::default();
+
+    let data = br#"{
+      "data": []
+    }
+    "#
+    .to_vec();
+    let http_response = http::Response::builder().status(200).body(data).unwrap();
+
+    let uri = req.get_uri().unwrap();
+    let response = UpdateConduitShardsRequest::parse_response(Some(req), &uri, http_response);
+    assert_eq!(response.is_err(), true);
+
+    dbg!("{:#?}", response);
+}


### PR DESCRIPTION
This endpoint is used to update the shards that exist in a previously created conduit.

I have tested this in my own bot, combined with the Create Conduit & Get Conduits endpoint I implemented earlier, and verified that it works as expected (at least for my use case).
I'm not 100% sure if I've covered all edge cases.

I have not updated `eventsub::TransportMethod` because I'm not sure exactly where that's used.

I have not added all helpers to `TransportResponse`/`Transport`, but will do so
