### PR TITLE
deps: update `rustls` to v0.21.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2208,9 +2208,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.21.10"
+version = "0.21.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d5a6813c0759e4609cd494e8e725babae6a2ca7b62a5536a13daaec6fcb7ba"
+checksum = "7fecbfb7b1444f477b345853b1fce097a2c6fb637b2bfb87e6bc5db0f043fae4"
 dependencies = [
  "log",
  "ring",


### PR DESCRIPTION
Addressing [RUSTSEC-2024-0336](https://rustsec.org/advisories/RUSTSEC-2024-0336).