### PR TITLE
Update all actions and use dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -24,7 +24,7 @@ jobs:
     name: Security Audit
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Install rust
@@ -43,7 +43,7 @@ jobs:
           - licenses
           - sources
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - uses: EmbarkStudios/cargo-deny-action@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test, rustfmt, clippy, docs]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0 # fetch tags for publish
@@ -43,7 +43,7 @@ jobs:
         rust: ["", nightly]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Install rust
@@ -57,7 +57,7 @@ jobs:
     name: Rustfmt
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@master
@@ -70,10 +70,9 @@ jobs:
     name: Prettier
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Check formatting with Prettier
-        # Explicit commit, because this isn't tagged yet.
-        uses: actionsx/prettier@3d9f7c3fa44c9cb819e68292a328d7f4384be206
+        uses: actionsx/prettier@v3
         with:
           args: -c .
 
@@ -81,7 +80,7 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@master
@@ -101,7 +100,7 @@ jobs:
     name: Docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@master

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -14,7 +14,7 @@ jobs:
     # cov is broken upstream, see https://github.com/rust-lang/rust/issues/79645, fix in https://github.com/rust-lang/rust/issues/93054
     if: "false"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Toolchain setup
@@ -42,7 +42,7 @@ jobs:
       #   if: ${{ github.ref == 'refs/heads/trying' }}
       #   run: git rev-parse HEAD~1 | awk '{ print "ACTUAL_COMMIT_SHA=" $NF }' >> $GITHUB_ENV
       - name: Upload to codecov.io
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         with:
           files: ./lcov.info
           override_pr: ${{env.PR_NUMBER}}

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,9 +1,11 @@
-# This doesn't work currently there is a bug in the output of grcov
 on:
   push:
     branches:
       - main
-      - trying
+  pull_request:
+
+env:
+  CI_TWITCH_API_FEATURES: "twitch_oauth2/all all unsupported deny_unknown_fields ureq"
 
 name: Code Coverage
 jobs:
@@ -11,8 +13,6 @@ jobs:
     name: Run test coverage
     runs-on: ubuntu-latest
     continue-on-error: true
-    # cov is broken upstream, see https://github.com/rust-lang/rust/issues/79645, fix in https://github.com/rust-lang/rust/issues/93054
-    if: "false"
     steps:
       - uses: actions/checkout@v4
         with:
@@ -23,21 +23,26 @@ jobs:
           toolchain: nightly
           components: llvm-tools-preview
       - uses: Swatinem/rust-cache@v2
+
       - name: Install cargo-llvm-cov
         run: curl -LsSf https://github.com/taiki-e/cargo-llvm-cov/releases/latest/download/cargo-llvm-cov-x86_64-unknown-linux-gnu.tar.gz | tar xzf - -C ~/.cargo/bin
+
       - name: Generate code coverage for tests
-        run: cargo llvm-cov --no-report --tests --features "twitch_oauth2/all all unsupported deny_unknown_fields trace_unknown_fields"
+        run: cargo llvm-cov --no-report --tests --features "${{ env.CI_TWITCH_API_FEATURES }} _all trace_unknown_fields"
       - name: Generate code coverage for tests without any features
         run: cargo llvm-cov --no-report --tests
       - name: Generate code coverage for examples
-        run: cargo llvm-cov --no-report --examples --features "twitch_oauth2/all all unsupported deny_unknown_fields trace_unknown_fields"
-      #- name: Generate code coverage for docs
-      #  run: cargo llvm-cov --no-report --doc --features "twitch_oauth2/all all unsupported deny_unknown_fields trace_unknown_fields"
+        run: cargo llvm-cov --no-report --examples --features "${{ env.CI_TWITCH_API_FEATURES }} _all trace_unknown_fields"
+      # doctests take too long to complete
+      # - name: Generate code coverage for docs
+      #   run: cargo llvm-cov --no-report --doc --features "${{ env.CI_TWITCH_API_FEATURES }} _all"
+
       - name: Merge lcov.info
-        run: cargo llvm-cov --no-run --lcov --ignore-filename-regex "twitch_oauth2" --output-path lcov.info
-      - name: Determine PR number
-        if: ${{ github.ref == 'refs/heads/trying' }}
-        run: git log -1 --pretty=format:"%s" | awk '{ print "PR_NUMBER=" substr($NF,2,length($NF)-2) }' >> $GITHUB_ENV
+        run: cargo llvm-cov report --lcov --ignore-filename-regex "twitch_oauth2" --output-path lcov.info
+
+      # - name: Determine PR number
+      #   if: ${{ github.event_name == 'pull_request' }}
+      #   run: git log -1 --pretty=format:"%s" | awk '{ print "PR_NUMBER=" substr($NF,2,length($NF)-2) }' >> $GITHUB_ENV
       # - name: Determine actual commit
       #   if: ${{ github.ref == 'refs/heads/trying' }}
       #   run: git rev-parse HEAD~1 | awk '{ print "ACTUAL_COMMIT_SHA=" $NF }' >> $GITHUB_ENV
@@ -45,5 +50,5 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           files: ./lcov.info
-          override_pr: ${{env.PR_NUMBER}}
-          # override_commit: ${{env.ACTUAL_COMMIT_SHA}}
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -7,7 +7,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - uses: dtolnay/rust-toolchain@master
@@ -19,7 +19,7 @@ jobs:
       - name: move index.html
         run: cp ./docs/index.html ./target/doc/index.html
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./target/doc


### PR DESCRIPTION
Notably, this updates `@actions/checkout` from v3 to v4, as it used Node 16 which isn't maintained anymore ([notice the warnings at the bottom](https://github.com/twitch-rs/twitch_api/actions/runs/8759927223)). Only `@actionsx/prettier` isn't updated to Node 20 yet (https://github.com/actionsx/prettier/pull/119).

Additionally, I've added Dependabot for GH-Actions to help with keeping them up-to-date.

I noticed, that `lcov` now works, so `codecov.yml` might work again (with some adjustments as bors isn't used anymore).