### PR TITLE
feat(eventsub): add `conduit.shard.disabled`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,7 @@
 - Added `is_featured` to Get Clips
 - Added beta `Get Ad Schedule` and `Snooze Next Ad` endpoint
 - Added beta `channel.ad_break.begin` eventsub event
+- Added `conduit.shard.disable` EventSub event
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1739,6 +1739,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
 name = "num-traits"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2721,16 +2727,17 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.31"
+version = "0.3.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f657ba42c3f86e7680e53c8cd3af8abbe56b5491790b46e22e19c0d57463583e"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
 dependencies = [
  "deranged",
  "itoa",
+ "num-conv",
  "powerfmt",
  "serde",
  "time-core",
- "time-macros 0.2.16",
+ "time-macros 0.2.18",
 ]
 
 [[package]]
@@ -2751,10 +2758,11 @@ dependencies = [
 
 [[package]]
 name = "time-macros"
-version = "0.2.16"
+version = "0.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26197e33420244aeb70c3e8c78376ca46571bc4e701e4791c2cd9f57dcb3a43f"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
 dependencies = [
+ "num-conv",
  "time-core",
 ]
 
@@ -3142,7 +3150,7 @@ version = "0.4.5"
 dependencies = [
  "serde",
  "serde_derive",
- "time 0.3.31",
+ "time 0.3.36",
 ]
 
 [[package]]

--- a/src/eventsub/conduit/mod.rs
+++ b/src/eventsub/conduit/mod.rs
@@ -1,4 +1,3 @@
-#![doc()]
 //! Subscription types regarding conduits.
 use super::{EventSubscription, EventType};
 

--- a/src/eventsub/conduit/mod.rs
+++ b/src/eventsub/conduit/mod.rs
@@ -1,0 +1,8 @@
+#![doc()]
+//! Subscription types regarding conduits.
+use super::{EventSubscription, EventType};
+
+pub mod shard;
+
+#[doc(inline)]
+pub use shard::disabled::{ConduitShardDisabledV1, ConduitShardDisabledV1Payload};

--- a/src/eventsub/conduit/shard/disabled.rs
+++ b/src/eventsub/conduit/shard/disabled.rs
@@ -11,7 +11,7 @@ use super::*;
 pub struct ConduitShardDisabledV1 {
     /// Your application’s client id. The provided client_id must match the client ID in the application access token.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
-    pub client_id: twitch_oauth2::ClientId,
+    pub client_id: String,
     /// Optional. The conduit ID to receive events for. If omitted, events for all of this client’s conduits are sent.
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     pub conduit_id: Option<String>,
@@ -19,7 +19,7 @@ pub struct ConduitShardDisabledV1 {
 
 impl ConduitShardDisabledV1 {
     /// Your application’s client id. The provided client_id must match the client ID in the application access token.
-    pub fn client_id(client_id: impl Into<twitch_oauth2::ClientId>) -> Self {
+    pub fn client_id(client_id: impl Into<String>) -> Self {
         Self {
             client_id: client_id.into(),
             conduit_id: None,

--- a/src/eventsub/conduit/shard/disabled.rs
+++ b/src/eventsub/conduit/shard/disabled.rs
@@ -1,0 +1,98 @@
+#![doc(alias = "conduit.shard.disabled")]
+//! A conduit shard is disabled by twitch.
+
+use super::*;
+
+/// [`conduit.shard.disabled`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#conduitsharddisabled)
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[non_exhaustive]
+pub struct ConduitShardDisabledV1 {
+    /// Your application’s client id. The provided client_id must match the client ID in the application access token.
+    #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
+    pub client_id: twitch_oauth2::ClientId,
+    /// Optional. The conduit ID to receive events for. If omitted, events for all of this client’s conduits are sent.
+    #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
+    pub conduit_id: Option<String>,
+}
+
+impl ConduitShardDisabledV1 {
+    /// Your application’s client id. The provided client_id must match the client ID in the application access token.
+    pub fn client_id(client_id: impl Into<twitch_oauth2::ClientId>) -> Self {
+        Self {
+            client_id: client_id.into(),
+            conduit_id: None,
+        }
+    }
+
+    /// The conduit ID to receive events for. If omitted, events for all of this client’s conduits are sent.
+    pub fn conduit_id(mut self, conduit_id: impl Into<String>) -> Self {
+        self.conduit_id = Some(conduit_id.into());
+        self
+    }
+}
+
+impl EventSubscription for ConduitShardDisabledV1 {
+    type Payload = ConduitShardDisabledV1Payload;
+
+    const EVENT_TYPE: EventType = EventType::ConduitShardDisabled;
+    #[cfg(feature = "twitch_oauth2")]
+    /// App access token where the client ID matches the client ID in the condition.
+    /// If conduit_id is specified, the client must be the owner of the conduit.
+    const SCOPE: twitch_oauth2::Validator = twitch_oauth2::validator![];
+    const VERSION: &'static str = "1";
+}
+
+/// [`conduit.shard.disabled`](ConduitShardDisabledV1) response payload.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[non_exhaustive]
+pub struct ConduitShardDisabledV1Payload {
+    /// The conduit ID.
+    pub conduit_id: String,
+    /// The shard ID within the conduit.
+    pub shard_id: String,
+    /// The status of the disabled shard.
+    pub status: eventsub::ShardStatus,
+    /// The transport details about the disable shard.
+    pub transport: eventsub::TransportResponse,
+}
+
+#[cfg(test)]
+#[test]
+fn parse_payload() {
+    let payload = r##"
+    {
+        "subscription": {
+            "id": "f1c2a387-161a-49f9-a165-0f21d7a4e1c4",
+            "type": "conduit.shard.disabled",
+            "version": "1",
+            "status": "enabled",
+            "cost": 0,
+            "condition": {
+                "client_id": "uo6dggojyb8d6soh92zknwmi5ej1q2"
+            },
+            "transport": {
+                "method": "webhook",
+                "callback": "https://example.com/webhooks/callback"
+            },
+            "created_at": "2023-04-11T10:11:12.123Z"
+        },
+        "event": {
+            "conduit_id": "bfcfc993-26b1-b876-44d9-afe75a379dac",
+            "shard_id": "4",
+            "status": "websocket_disconnected",
+            "transport": {
+                "method": "websocket",
+                "session_id": "ad1c9fc3-0d99-4eb7-8a04-8608e8ff9ec9",
+                "connected_at": "2020-11-10T14:32:18.730260295Z",
+                "disconnected_at": "2020-11-11T14:32:18.730260295Z"
+            }
+        }
+    }
+    "##;
+
+    let val = dbg!(eventsub::Event::parse(payload).unwrap());
+    crate::tests::roundtrip(&val);
+}

--- a/src/eventsub/conduit/shard/mod.rs
+++ b/src/eventsub/conduit/shard/mod.rs
@@ -1,0 +1,7 @@
+#![doc(alias = "conduit.shard")]
+//! Subscription types regarding conduit shards.
+use super::{EventSubscription, EventType};
+use crate::eventsub;
+use serde_derive::{Deserialize, Serialize};
+
+pub mod disabled;

--- a/src/eventsub/event.rs
+++ b/src/eventsub/event.rs
@@ -55,6 +55,7 @@ macro_rules! fill_events {
             channel::ChannelUnbanV1;
             channel::ChannelUpdateV1;
             channel::ChannelUpdateV2;
+            conduit::ConduitShardDisabledV1;
             stream::StreamOfflineV1;
             stream::StreamOnlineV1;
             user::UserAuthorizationGrantV1;
@@ -218,6 +219,8 @@ make_event_type!("Event Types": pub enum EventType {
     ChannelHypeTrainProgress => "channel.hype_train.progress",
     "a hype train ends on the specified channel.":
     ChannelHypeTrainEnd => "channel.hype_train.end",
+    "sends a notification when eventsub disables a shard due to the status of the underlying transport changing.":
+    ConduitShardDisabled => "conduit.shard.disabled",
     "the specified broadcaster starts a stream.":
     StreamOnline => "stream.online",
     "the specified broadcaster stops a stream.":
@@ -335,6 +338,8 @@ pub enum Event {
     ChannelHypeTrainProgressV1(Payload<channel::ChannelHypeTrainProgressV1>),
     /// Channel Hype Train End V1 Event
     ChannelHypeTrainEndV1(Payload<channel::ChannelHypeTrainEndV1>),
+    /// Conduit Shard Disabled V1 Event
+    ConduitShardDisabledV1(Payload<conduit::ConduitShardDisabledV1>),
     /// StreamOnline V1 Event
     StreamOnlineV1(Payload<stream::StreamOnlineV1>),
     /// StreamOffline V1 Event

--- a/src/eventsub/mod.rs
+++ b/src/eventsub/mod.rs
@@ -84,6 +84,7 @@ use serde_derive::{Deserialize, Serialize};
 use crate::parse_json;
 
 pub mod channel;
+pub mod conduit;
 pub mod event;
 pub mod stream;
 pub mod user;


### PR DESCRIPTION
Adds the [`conduit.shard.disabled`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#conduitsharddisabled) event for EventSub as twitch recommends listening to those when using the conduit transport method.

(First pr for a big rust project like this so I would appreciate any constructive feedback)