### PR TITLE
fix: add new Twitch message types

### DIFF
--- a/src/eventsub/channel/chat/message.rs
+++ b/src/eventsub/channel/chat/message.rs
@@ -93,6 +93,10 @@ pub enum MessageType {
     ChannelPointsSubOnly,
     /// A first message from a user
     UserIntro,
+    /// A gigantified emote
+    PowerUpsGigantifiedEmote,
+    /// A message sent with effects
+    PowerUpsMessageEffect,
 }
 
 /// Chat badge


### PR DESCRIPTION
Adds the missing types which Twitch has kindly created to mess with us! Should avoid deserialising errors on chat messages. Having a little difficulty testing it locally due to #256 (I think) but happy to try with more guidance: have confirmed the names of the chat message event types via my stream.