### PR TITLE
Fix eventsub_websocket example 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -492,6 +492,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "basic-toml"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1426,6 +1432,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ee4be2c948921a1a5320b629c4193916ed787a7f7f293fd3f7f5a6c9de74155"
+dependencies = [
+ "futures-util",
+ "http 1.1.0",
+ "hyper",
+ "hyper-util",
+ "rustls 0.23.11",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1786,9 +1809,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.63"
+version = "0.10.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15c9d69dd87a29568d4d017cfe8ec518706046a05184e5aea92d0af890b803c8"
+checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
 dependencies = [
  "bitflags 2.4.2",
  "cfg-if",
@@ -1818,9 +1841,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.99"
+version = "0.9.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e1bf214306098e4832460f797824c05d25aacdf896f64a985fb0fd992454ae"
+checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
 dependencies = [
  "cc",
  "libc",
@@ -2104,11 +2127,11 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reqwest"
-version = "0.12.2"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d66674f2b6fb864665eea7a3c1ac4e3dfacd2fda83cf6f935a612e01b0e3338"
+checksum = "c7d6d2a27d57148378eb5e111173f4276ad26340ecc5c49a4a2152167a2d6a37"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "bytes 1.6.0",
  "encoding_rs",
  "futures-core",
@@ -2118,6 +2141,7 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-tls",
  "hyper-util",
  "ipnet",
@@ -2132,7 +2156,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 0.1.2",
+ "sync_wrapper 1.0.0",
  "system-configuration",
  "tokio",
  "tokio-native-tls",
@@ -2220,18 +2244,38 @@ checksum = "7fecbfb7b1444f477b345853b1fce097a2c6fb637b2bfb87e6bc5db0f043fae4"
 dependencies = [
  "log",
  "ring",
- "rustls-webpki",
+ "rustls-webpki 0.101.7",
  "sct",
 ]
 
 [[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
+name = "rustls"
+version = "0.23.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+checksum = "4828ea528154ae444e5a642dbb7d5623354030dc9822b83fd9bb79683c7399d0"
 dependencies = [
- "base64 0.21.7",
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki 0.102.6",
+ "subtle",
+ "zeroize",
 ]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29993a25686778eb88d4189742cd713c9bce943bc54251a33509dc63cbacf73d"
+dependencies = [
+ "base64 0.22.1",
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
 
 [[package]]
 name = "rustls-webpki"
@@ -2240,6 +2284,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b6275d1ee7a1cd780b64aca7726599a1dbc893b1e64144529e55c3c2f745765"
 dependencies = [
  "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e6b52d4fda176fd835fdc55a835d4a89b8499cad995885a21149d5ad62f852e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
  "untrusted",
 ]
 
@@ -2833,6 +2888,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+dependencies = [
+ "rustls 0.23.11",
+ "rustls-pki-types",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-tungstenite"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3234,8 +3300,8 @@ dependencies = [
  "base64 0.21.7",
  "log",
  "once_cell",
- "rustls",
- "rustls-webpki",
+ "rustls 0.21.11",
+ "rustls-webpki 0.101.7",
  "url",
  "webpki-roots",
 ]
@@ -3553,9 +3619,9 @@ checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
 
 [[package]]
 name = "winreg"
-version = "0.50.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
@@ -3588,3 +3654,9 @@ dependencies = [
  "serde_json",
  "xshell",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ tracing = { version = "0.1.40", optional = true }
 ureq = { version = "2.8.0", optional = true, default-features = false, features = [
     "tls",
 ] }
-reqwest = { version = "0.12.2", optional = true, default-features = false }
+reqwest = { version = "0.12.5", optional = true, default-features = false }
 surf = { version = "2.3.2", optional = true, default-features = false }
 http-types = { version = "2.12.0", optional = true, features = [
     "hyperium_http",

--- a/examples/eventsub_websocket/src/websocket.rs
+++ b/examples/eventsub_websocket/src/websocket.rs
@@ -40,7 +40,6 @@ impl WebsocketClient {
     > {
         tracing::info!("connecting to twitch");
         let config = tungstenite::protocol::WebSocketConfig {
-            max_write_buffer_size: 2048,
             max_message_size: Some(64 << 20), // 64 MiB
             max_frame_size: Some(16 << 20),   // 16 MiB
             accept_unmasked_frames: false,

--- a/src/eventsub/channel/chat/message.rs
+++ b/src/eventsub/channel/chat/message.rs
@@ -217,7 +217,8 @@ fn parse_payload() {
             "message_type": "text",
             "cheer": null,
             "reply": null,
-            "channel_points_custom_reward_id": null
+            "channel_points_custom_reward_id": null,
+            "channel_points_animation_id": null
         }
     }
     "##;

--- a/src/eventsub/channel/chat/message.rs
+++ b/src/eventsub/channel/chat/message.rs
@@ -78,6 +78,8 @@ pub struct ChannelChatMessageV1Payload {
     pub reply: Option<Reply>,
     /// The ID of a channel points custom reward that was redeemed.
     pub channel_points_custom_reward_id: Option<types::RewardId>,
+    /// An ID for the type of animation selected as part of an “animate my message” redemption.
+    pub channel_points_animation_id: Option<String>,
 }
 
 /// The type a message.

--- a/src/eventsub/event/websocket.rs
+++ b/src/eventsub/event/websocket.rs
@@ -62,6 +62,9 @@ pub struct SessionData<'a> {
     /// The UTC date and time that the connection was created.
     #[serde(borrow = "'a")]
     pub connected_at: Cow<'a, types::TimestampRef>,
+    /// Undocumented field
+    #[serde(borrow = "'a")]
+    pub recovery_url: Option<Cow<'a, str>>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/eventsub/event/websocket.rs
+++ b/src/eventsub/event/websocket.rs
@@ -263,7 +263,8 @@ mod tests {
                 "status": "connected",
                 "connected_at": "2022-10-19T14:56:51.616329898Z",
                 "keepalive_timeout_seconds": 10,
-                "reconnect_url": null
+                "reconnect_url": null,
+                "recovery_url": null
               }
             }
           }

--- a/src/eventsub/event/websocket.rs
+++ b/src/eventsub/event/websocket.rs
@@ -62,7 +62,7 @@ pub struct SessionData<'a> {
     /// The UTC date and time that the connection was created.
     #[serde(borrow = "'a")]
     pub connected_at: Cow<'a, types::TimestampRef>,
-    /// Undocumented field
+    #[doc(hidden)]
     #[serde(borrow = "'a")]
     pub recovery_url: Option<Cow<'a, str>>,
 }


### PR DESCRIPTION
The `max_write_buffer_size: 2048` looks like it might have been a mistake but it's definitely wrong. I'm not sure what the original intention was, but I don't think it matters for a simple example so I'm letting it take the default. Lemme know if you want something else there. 

For the undocumented new field on the welcome message, idk 