### PR TITLE
fix(clippy): resolve some new clippy warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ twitch_types = { version = "0.4.5", features = [
 
 [dependencies]
 thiserror = "1.0.50"
-displaydoc = "0.2.4"
+displaydoc = "0.2.5"
 http = "1.1.0"
 typed-builder = { version = "0.20.0", optional = true }
 url = "2.5.2"

--- a/src/eventsub/channel/chat/notification.rs
+++ b/src/eventsub/channel/chat/notification.rs
@@ -354,7 +354,7 @@ impl<'de> serde::Deserialize<'de> for Gifter {
         let gifter = InnerGifter::deserialize(deserializer)?;
         if let Some(true) = gifter.gifter_is_anonymous {
             Ok(Gifter::Anonymous)
-        } else if let None = gifter.gifter_is_anonymous {
+        } else if gifter.gifter_is_anonymous.is_none() {
             Ok(Gifter::None)
         } else {
             Ok(Gifter::Gifter {

--- a/src/helix/client/client_ext.rs
+++ b/src/helix/client/client_ext.rs
@@ -1556,7 +1556,7 @@ impl<'client, C: crate::HttpClient + Sync + 'client> HelixClient<'client, C> {
     /// ```
     pub async fn update_conduit_shards<'b: 'client, T>(
         &'client self,
-        conduit_id: impl Into<String>,
+        conduit_id: impl Into<String> + Send,
         shards: Vec<crate::eventsub::Shard>,
         token: &'client T,
     ) -> Result<helix::eventsub::UpdateConduitShardsResponse, ClientError<C>>

--- a/src/helix/endpoints/eventsub/create_conduit.rs
+++ b/src/helix/endpoints/eventsub/create_conduit.rs
@@ -133,7 +133,5 @@ fn test_successful_unexpected_response() {
 
     let uri = req.get_uri().unwrap();
     let response = CreateConduitRequest::parse_response(Some(req), &uri, http_response);
-    assert_eq!(response.is_err(), true);
-
-    dbg!("{:#?}", response);
+    assert!(response.is_err());
 }

--- a/src/helix/endpoints/eventsub/get_conduit_shards.rs
+++ b/src/helix/endpoints/eventsub/get_conduit_shards.rs
@@ -75,8 +75,7 @@ fn test_request() {
     use types::Timestamp;
 
     use crate::eventsub::{
-        ShardStatus, Transport, TransportResponse, WebhookTransportResponse,
-        WebsocketTransportResponse,
+        ShardStatus, TransportResponse, WebhookTransportResponse, WebsocketTransportResponse,
     };
     let req: GetConduitShardsRequest = GetConduitShardsRequest::default();
 

--- a/src/helix/endpoints/eventsub/update_conduit_shards.rs
+++ b/src/helix/endpoints/eventsub/update_conduit_shards.rs
@@ -203,7 +203,5 @@ fn test_successful_unexpected_response() {
 
     let uri = req.get_uri().unwrap();
     let response = UpdateConduitShardsRequest::parse_response(Some(req), &uri, http_response);
-    assert_eq!(response.is_err(), true);
-
-    dbg!("{:#?}", response);
+    assert!(response.is_err());
 }

--- a/src/helix/ser.rs
+++ b/src/helix/ser.rs
@@ -183,8 +183,8 @@ impl<'input, 'output> ser::Serializer for Serializer<'input, 'output> {
         Err(Error::top_level_not_supported())
     }
 
-    fn serialize_some<T: ?Sized>(self, _value: &T) -> Result<Self::Ok, Self::Error>
-    where T: serde::Serialize {
+    fn serialize_some<T>(self, _value: &T) -> Result<Self::Ok, Self::Error>
+    where T: serde::Serialize + ?Sized {
         Err(Error::top_level_not_supported())
     }
 
@@ -205,18 +205,18 @@ impl<'input, 'output> ser::Serializer for Serializer<'input, 'output> {
         Err(Error::top_level_not_supported())
     }
 
-    fn serialize_newtype_struct<T: ?Sized>(
+    fn serialize_newtype_struct<T>(
         self,
         _name: &'static str,
         _value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
-        T: serde::Serialize,
+        T: serde::Serialize + ?Sized,
     {
         Err(Error::top_level_not_supported())
     }
 
-    fn serialize_newtype_variant<T: ?Sized>(
+    fn serialize_newtype_variant<T>(
         self,
         _name: &'static str,
         _variant_index: u32,
@@ -224,7 +224,7 @@ impl<'input, 'output> ser::Serializer for Serializer<'input, 'output> {
         _value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
-        T: serde::Serialize,
+        T: serde::Serialize + ?Sized,
     {
         Err(Error::top_level_not_supported())
     }
@@ -264,15 +264,10 @@ impl<'input, 'output> ser::SerializeMap for MapSerializer<'input, 'output> {
     type Error = Error;
     type Ok = &'output mut UrlEncodedSerializer<'input, String>;
 
-    fn serialize_entry<K: ?Sized, V: ?Sized>(
-        &mut self,
-        key: &K,
-        value: &V,
-    ) -> Result<(), Self::Error>
+    fn serialize_entry<K, V>(&mut self, key: &K, value: &V) -> Result<(), Self::Error>
     where
-        K: serde::Serialize,
-        V: serde::Serialize,
-    {
+        K: serde::Serialize + ?Sized,
+        V: serde::Serialize + ?Sized, {
         self.urlencoder.append_pair(
             &key.serialize(ValueSerializer)?,
             &value.serialize(ValueSerializer)?,
@@ -280,13 +275,13 @@ impl<'input, 'output> ser::SerializeMap for MapSerializer<'input, 'output> {
         Ok(())
     }
 
-    fn serialize_key<T: ?Sized>(&mut self, _key: &T) -> Result<(), Self::Error>
-    where T: serde::Serialize {
+    fn serialize_key<T>(&mut self, _key: &T) -> Result<(), Self::Error>
+    where T: serde::Serialize + ?Sized {
         Ok(())
     }
 
-    fn serialize_value<T: ?Sized>(&mut self, _value: &T) -> Result<(), Self::Error>
-    where T: serde::Serialize {
+    fn serialize_value<T>(&mut self, _value: &T) -> Result<(), Self::Error>
+    where T: serde::Serialize + ?Sized {
         Ok(())
     }
 
@@ -301,14 +296,8 @@ impl<'input, 'output> ser::SerializeStruct for StructSerializer<'input, 'output>
     type Error = Error;
     type Ok = &'output mut UrlEncodedSerializer<'input, String>;
 
-    fn serialize_field<T: ?Sized>(
-        &mut self,
-        key: &'static str,
-        value: &T,
-    ) -> Result<(), Self::Error>
-    where
-        T: serde::Serialize,
-    {
+    fn serialize_field<T>(&mut self, key: &'static str, value: &T) -> Result<(), Self::Error>
+    where T: serde::Serialize + ?Sized {
         value.serialize(FieldSerializer {
             key,
             urlencoder: self.urlencoder,
@@ -350,8 +339,8 @@ impl<'input, 'output> ser::Serializer for FieldSerializer<'input, 'output> {
 
     fn serialize_none(self) -> Result<Self::Ok, Self::Error> { Ok(self.urlencoder) }
 
-    fn serialize_some<T: ?Sized>(self, value: &T) -> Result<Self::Ok, Self::Error>
-    where T: serde::Serialize {
+    fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
+    where T: serde::Serialize + ?Sized {
         //self.urlencoder.append_pair(self.key, v);
         value.serialize(PairSerializer {
             key: self.key,
@@ -479,18 +468,18 @@ impl<'input, 'output> ser::Serializer for FieldSerializer<'input, 'output> {
         Err(Error::field_not_supported())
     }
 
-    fn serialize_newtype_struct<T: ?Sized>(
+    fn serialize_newtype_struct<T>(
         self,
         _name: &'static str,
         _value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
-        T: serde::Serialize,
+        T: serde::Serialize + ?Sized,
     {
         Err(Error::field_not_supported())
     }
 
-    fn serialize_newtype_variant<T: ?Sized>(
+    fn serialize_newtype_variant<T>(
         self,
         _name: &'static str,
         _variant_index: u32,
@@ -498,7 +487,7 @@ impl<'input, 'output> ser::Serializer for FieldSerializer<'input, 'output> {
         _value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
-        T: serde::Serialize,
+        T: serde::Serialize + ?Sized,
     {
         Err(Error::field_not_supported())
     }
@@ -544,8 +533,8 @@ impl<'input, 'output> ser::SerializeSeq for FieldSerializer<'input, 'output> {
     type Error = Error;
     type Ok = &'output mut UrlEncodedSerializer<'input, String>;
 
-    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
-    where T: serde::Serialize {
+    fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
+    where T: serde::Serialize + ?Sized {
         value.serialize(PairSerializer {
             key: self.key,
             urlencoder: self.urlencoder,
@@ -560,8 +549,8 @@ impl<'input, 'output> ser::SerializeTuple for FieldSerializer<'input, 'output> {
     type Error = Error;
     type Ok = &'output mut UrlEncodedSerializer<'input, String>;
 
-    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
-    where T: serde::Serialize {
+    fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
+    where T: serde::Serialize + ?Sized {
         value.serialize(PairSerializer {
             key: self.key,
             urlencoder: self.urlencoder,
@@ -662,8 +651,8 @@ impl<'input, 'output> ser::Serializer for PairSerializer<'input, 'output> {
 
     fn serialize_none(self) -> Result<Self::Ok, Self::Error> { Ok(self.urlencoder) }
 
-    fn serialize_some<T: ?Sized>(self, value: &T) -> Result<Self::Ok, Self::Error>
-    where T: serde::Serialize {
+    fn serialize_some<T>(self, value: &T) -> Result<Self::Ok, Self::Error>
+    where T: serde::Serialize + ?Sized {
         self.urlencoder
             .append_pair(self.key, &value.serialize(ValueSerializer)?);
         Ok(self.urlencoder)
@@ -693,18 +682,18 @@ impl<'input, 'output> ser::Serializer for PairSerializer<'input, 'output> {
         Err(Error::pair_not_supported())
     }
 
-    fn serialize_newtype_struct<T: ?Sized>(
+    fn serialize_newtype_struct<T>(
         self,
         _name: &'static str,
         _value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
-        T: serde::Serialize,
+        T: serde::Serialize + ?Sized,
     {
         Err(Error::pair_not_supported())
     }
 
-    fn serialize_newtype_variant<T: ?Sized>(
+    fn serialize_newtype_variant<T>(
         self,
         _name: &'static str,
         _variant_index: u32,
@@ -712,7 +701,7 @@ impl<'input, 'output> ser::Serializer for PairSerializer<'input, 'output> {
         _value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
-        T: serde::Serialize,
+        T: serde::Serialize + ?Sized,
     {
         Err(Error::pair_not_supported())
     }
@@ -768,8 +757,8 @@ impl<'input, 'output> ser::SerializeTuple for PairSerializer<'input, 'output> {
     type Error = Error;
     type Ok = &'output mut UrlEncodedSerializer<'input, String>;
 
-    fn serialize_element<T: ?Sized>(&mut self, value: &T) -> Result<(), Self::Error>
-    where T: serde::Serialize {
+    fn serialize_element<T>(&mut self, value: &T) -> Result<(), Self::Error>
+    where T: serde::Serialize + ?Sized {
         self.urlencoder
             .append_pair(self.key, &value.serialize(ValueSerializer)?);
         Ok(())
@@ -846,8 +835,8 @@ impl ser::Serializer for ValueSerializer {
 
     fn serialize_none(self) -> Result<Self::Ok, Self::Error> { Err(Error::value_not_supported()) }
 
-    fn serialize_some<T: ?Sized>(self, _value: &T) -> Result<Self::Ok, Self::Error>
-    where T: serde::Serialize {
+    fn serialize_some<T>(self, _value: &T) -> Result<Self::Ok, Self::Error>
+    where T: serde::Serialize + ?Sized {
         Err(Error::value_not_supported())
     }
 
@@ -866,18 +855,18 @@ impl ser::Serializer for ValueSerializer {
         Err(Error::value_not_supported())
     }
 
-    fn serialize_newtype_struct<T: ?Sized>(
+    fn serialize_newtype_struct<T>(
         self,
         _name: &'static str,
         _value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
-        T: serde::Serialize,
+        T: serde::Serialize + ?Sized,
     {
         Err(Error::value_not_supported())
     }
 
-    fn serialize_newtype_variant<T: ?Sized>(
+    fn serialize_newtype_variant<T>(
         self,
         _name: &'static str,
         _variant_index: u32,
@@ -885,7 +874,7 @@ impl ser::Serializer for ValueSerializer {
         _value: &T,
     ) -> Result<Self::Ok, Self::Error>
     where
-        T: serde::Serialize,
+        T: serde::Serialize + ?Sized,
     {
         Err(Error::value_not_supported())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 #![allow(clippy::needless_raw_string_hashes)]
+#![cfg_attr(test, allow(deprecated))] // for pubsub tests
 #![cfg_attr(nightly, feature(doc_cfg))]
 #![cfg_attr(nightly, feature(doc_auto_cfg))]
 #![allow(clippy::needless_raw_string_hashes)]

--- a/src/pubsub/mod.rs
+++ b/src/pubsub/mod.rs
@@ -8,8 +8,8 @@
 //! This crate has some pubsub topics that are not documented by twitch. These may stop working at any time. To enable these, use feature
 //! <span
 //!   class="module-item stab portability"
-//!   style="display: inline; border-radius: 3px; padding: 2px; font-size: 80%; line-height: 1.2;"
-//! ><code>unsupported</code></span>
+//!   style="display: inline; border-radius: 3px; padding: 2px; font-size: 80%; line-height: 1.2;"><code>unsupported</code>
+//! </span>
 //! to use them. Note that this crate doesn't try to keep changes to these pubsub topics semver compatible.
 
 static ERROR_TRYFROM: &str = "no match";
@@ -33,7 +33,6 @@ macro_rules! impl_de_ser {
         }
 
         impl ::std::fmt::Display for $type {
-            ///
             fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
                 let s: String = ::std::convert::TryInto::try_into(self).map_err(|_| ::std::fmt::Error)?;
                 f.write_str(&s)
@@ -113,12 +112,6 @@ use crate::parse_json;
 /// also known as event
 pub trait Topic: serde::Serialize + Into<String> {
     /// Scopes needed by this topic
-    ///
-    /// This constant
-    /// <span
-    ///   class="module-item stab portability"
-    ///   style="display: inline; border-radius: 3px; padding: 2px; font-size: 80%; line-height: 1.2;"
-    /// ><code>unsupported</code></span>
     #[cfg(feature = "twitch_oauth2")]
     #[cfg_attr(nightly, doc(cfg(feature = "twitch_oauth2")))]
     const SCOPE: twitch_oauth2::Validator;


### PR DESCRIPTION
This PR resolves _some_ clippy warnings. `#![cfg_attr(test, allow(deprecated))]` was added in `lib.rs` to make editing with rust-analyzer easier. Adding `#![allow(deprecated)]` for the `pubsub` module doesn't work, because of the test macros ([playground](https://play.rust-lang.org/?version=nightly&mode=debug&edition=2021&gist=e1f2ca45f2ba2a07921ce982b92eb90a)).

The only remaining warnings are from `too_long_first_doc_paragraph` in top-level doc-comments (I don't know how to silence these, as `#[allow(...)]` doesn't work :/).

Other than that, `twitch_types` still has some warnings. These have been fixed, but there's no release yet (also not really needed, imo).

https://github.com/twitch-rs/twitch_api/pull/419 was partly done in https://github.com/twitch-rs/twitch_api/pull/425 (only the edit in `Cargo.toml` was left), so I did it here. Closes https://github.com/twitch-rs/twitch_api/issues/410.

