### PR TITLE
feat: add `Get/Resolve Unban Requests` endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@
 - Added `conduit.shard.disable` EventSub event
 - Added `title` and `description` as fields in the response of `Get Channel Chat Badges` and `Get Global Chat Badges`
 - Added `Get AutoMod Settings` and `Update AutoMod Settings` endpoints
+- Added `Get Unban Requests` endpoint
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,7 @@
 - Added `conduit.shard.disable` EventSub event
 - Added `title` and `description` as fields in the response of `Get Channel Chat Badges` and `Get Global Chat Badges`
 - Added `Get AutoMod Settings` and `Update AutoMod Settings` endpoints
-- Added `Get Unban Requests` endpoint
+- Added `Get Unban Requests` and `Resolve Unban Requests` endpoints
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3216,7 +3216,7 @@ dependencies = [
 
 [[package]]
 name = "twitch_types"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "serde",
  "serde_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = ["twitch_types", "twitch_oauth2"]
 [workspace.dependencies]
 twitch_api = { version = "0.7.0-rc.8", path = "." }
 twitch_oauth2 = { version = "0.14.0", path = "twitch_oauth2/" }
-twitch_types = { version = "0.4.5", features = [
+twitch_types = { version = "0.4.6", features = [
     "serde",
 ], path = "./twitch_types" }
 ureq = { version = "2.10.1", default-features = false, features = [

--- a/src/helix/client/client_ext.rs
+++ b/src/helix/client/client_ext.rs
@@ -528,6 +528,41 @@ impl<'client, C: crate::HttpClient + Sync + 'client> HelixClient<'client, C> {
         make_stream(req, token, self, std::collections::VecDeque::from)
     }
 
+    /// Gets a list of unban requests for a broadcaster’s channel. [Get Unban Requests](helix::moderation::GetUnbanRequestsRequest)
+    ///
+    /// # Examples
+    ///
+    /// ```rust, no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    /// # let client: helix::HelixClient<'static, twitch_api::client::DummyHttpClient> = helix::HelixClient::default();
+    /// # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
+    /// # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
+    /// use twitch_api::helix;
+    /// use futures::TryStreamExt;
+    ///
+    /// let requests: Vec<helix::moderation::UnbanRequest> = client.get_unban_requests("1234", "5678", helix::moderation::UnbanRequestStatus::Pending, &token).try_collect().await?;
+    /// # Ok(()) }
+    /// ```
+    pub fn get_unban_requests<'b: 'client, T>(
+        &'client self,
+        broadcaster_id: impl types::IntoCow<'b, types::UserIdRef> + 'b,
+        moderator_id: impl types::IntoCow<'b, types::UserIdRef> + 'b,
+        status: helix::moderation::UnbanRequestStatus,
+        token: &'client T,
+    ) -> impl futures::Stream<Item = Result<helix::moderation::UnbanRequest, ClientError<C>>>
+           + Send
+           + Unpin
+           + 'client
+    where
+        T: TwitchToken + Send + Sync + ?Sized,
+    {
+        let req =
+            helix::moderation::GetUnbanRequestsRequest::new(broadcaster_id, moderator_id, status);
+
+        make_stream(req, token, self, std::collections::VecDeque::from)
+    }
+
     /// Get a users, with login, follow count
     #[deprecated(
         note = "this method will not work anymore on 3 august, see https://discuss.dev.twitch.tv/t/follows-endpoints-and-eventsub-subscription-type-are-now-available-in-open-beta/43322"

--- a/src/helix/endpoints/moderation/get_unban_requests.rs
+++ b/src/helix/endpoints/moderation/get_unban_requests.rs
@@ -1,0 +1,299 @@
+//! Gets a list of unban requests for a broadcaster’s channel.
+//! [`get-unban-requests`](https://dev.twitch.tv/docs/api/reference#get-unban-requests)
+//!
+//! # Accessing the endpoint
+//!
+//! ## Request: [GetUnbanRequestsRequest]
+//!
+//! To use this endpoint, construct a [`GetUnbanRequestsRequest`] with the [`GetUnbanRequestsRequest::new()`] method.
+//!
+//! ```rust
+//! use twitch_api::helix::moderation::get_unban_requests;
+//! // get pending unban requests
+//! let request = get_unban_requests::GetUnbanRequestsRequest::new(
+//!     "1234",
+//!     "5678",
+//!     get_unban_requests::UnbanRequestStatus::Pending,
+//! );
+//! ```
+//!
+//! ## Response: [UnbanRequest]
+//!
+//! Send the request to receive the response with [`HelixClient::req_get()`](helix::HelixClient::req_get).
+//!
+//! ```rust, no_run
+//! use twitch_api::helix::{self, moderation::get_unban_requests};
+//! # use twitch_api::client;
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+//! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
+//! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
+//! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
+//! let request = get_unban_requests::GetUnbanRequestsRequest::new("1234", "5678", get_unban_requests::UnbanRequestStatus::Pending);
+//! let response: Vec<get_unban_requests::UnbanRequest> = client.req_get(request, &token).await?.data;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! You can also get the [`http::Request`] with [`request.create_request(&token, &client_id)`](helix::RequestGet::create_request)
+//! and parse the [`http::Response`] with [`GetUnbanRequestsRequest::parse_response(None, &request.get_uri(), response)`](GetUnbanRequestsRequest::parse_response)
+
+use super::*;
+use helix::RequestGet;
+
+/// The status of an unban request
+#[derive(PartialEq, Eq, Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum UnbanRequestStatus {
+    /// The request has been created, but not yet resolved
+    Pending,
+    /// The request has been approved by a moderator/broadcaster
+    Approved,
+    /// The request has been denied by a moderator/broadcaster
+    Denied,
+    /// The request has been approved and the user acknowledged the resolution
+    Acknowledged,
+    /// The user cancelled the request
+    Canceled,
+}
+
+/// Query Parameters for [Get Unban Requests](super::get_unban_requests)
+///
+/// [`get-unban-requests`](https://dev.twitch.tv/docs/api/reference#get-unban-requests)
+#[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
+#[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
+#[must_use]
+#[non_exhaustive]
+pub struct GetUnbanRequestsRequest<'a> {
+    /// The ID of the broadcaster whose channel is receiving unban requests.
+    #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
+    #[cfg_attr(feature = "deser_borrow", serde(borrow = "'a"))]
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
+    /// The ID of the broadcaster or a user that has permission to moderate the broadcaster’s unban requests. This ID must match the user ID in the user access token.
+    #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
+    #[cfg_attr(feature = "deser_borrow", serde(borrow = "'a"))]
+    pub moderator_id: Cow<'a, types::UserIdRef>,
+    /// Filter by a status.
+    pub status: UnbanRequestStatus,
+    /// The ID used to filter what unban requests are returned.
+    #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
+    #[cfg_attr(feature = "deser_borrow", serde(borrow = "'a"))]
+    pub user_id: Option<Cow<'a, types::UserIdRef>>,
+    /// Cursor used to get next page of results. Pagination object in response contains cursor value.
+    #[cfg_attr(feature = "typed-builder", builder(default))]
+    #[cfg_attr(feature = "deser_borrow", serde(borrow = "'a"))]
+    pub after: Option<Cow<'a, helix::CursorRef>>,
+    /// The maximum number of items to return per page in response
+    #[cfg_attr(feature = "typed-builder", builder(setter(into), default))]
+    pub first: Option<usize>,
+}
+
+impl<'a> GetUnbanRequestsRequest<'a> {
+    /// Get Unban Requests in a broadcasters channel filtered by a status
+    pub fn new(
+        broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
+        moderator_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
+        status: UnbanRequestStatus,
+    ) -> Self {
+        Self {
+            broadcaster_id: broadcaster_id.into_cow(),
+            moderator_id: moderator_id.into_cow(),
+            status,
+            user_id: None,
+            after: None,
+            first: None,
+        }
+    }
+
+    /// Filter for unban requests from a specific user
+    pub fn user(mut self, user_id: impl types::IntoCow<'a, types::UserIdRef> + 'a) -> Self {
+        self.user_id = Some(user_id.into_cow());
+        self
+    }
+
+    /// Set amount of results returned per page.
+    pub fn first(mut self, first: usize) -> Self {
+        self.first = Some(first);
+        self
+    }
+}
+
+/// Return Values for [Get Unban Requests](super::get_unban_requests)
+///
+/// [`get-unban-requests`](https://dev.twitch.tv/docs/api/reference#get-unban-requests)
+#[derive(PartialEq, Eq, Deserialize, Serialize, Debug, Clone)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[non_exhaustive]
+pub struct UnbanRequest {
+    /// Unban request ID.
+    pub id: types::UnbanRequestId,
+    /// User ID of broadcaster whose channel is receiving the unban request.
+    pub broadcaster_id: types::UserId,
+    /// The broadcaster's display name.
+    pub broadcaster_name: types::DisplayName,
+    /// The broadcaster's login name.
+    pub broadcaster_login: types::UserName,
+    /// User ID of moderator who approved/denied the request.
+    pub moderator_id: Option<types::UserId>,
+    /// The moderator's display name.
+    pub moderator_name: Option<types::DisplayName>,
+    /// The moderator's login name.
+    pub moderator_login: Option<types::UserName>,
+    /// User ID of the requestor who is asking for an unban.
+    pub user_id: types::UserId,
+    /// The user's display name.
+    pub user_name: types::DisplayName,
+    /// The user's login name.
+    pub user_login: types::UserName,
+    /// Text of the request from the requesting user.
+    pub text: String,
+    /// Status of the request.
+    pub status: UnbanRequestStatus,
+    /// Timestamp of when the unban request was created.
+    pub created_at: types::Timestamp,
+    /// Timestamp of when moderator/broadcaster approved or denied the request.
+    pub resolved_at: Option<types::Timestamp>,
+    /// Text input by the resolver (moderator) of the unban. request
+    pub resolution_text: Option<String>,
+}
+
+impl Request for GetUnbanRequestsRequest<'_> {
+    type Response = Vec<UnbanRequest>;
+
+    const PATH: &'static str = "moderation/unban_requests";
+    #[cfg(feature = "twitch_oauth2")]
+    const SCOPE: twitch_oauth2::Validator = twitch_oauth2::validator![any(
+        twitch_oauth2::Scope::ModeratorReadUnbanRequests,
+        twitch_oauth2::Scope::ModeratorManageUnbanRequests
+    )];
+}
+
+impl RequestGet for GetUnbanRequestsRequest<'_> {}
+
+impl helix::Paginated for GetUnbanRequestsRequest<'_> {
+    fn set_pagination(&mut self, cursor: Option<helix::Cursor>) {
+        self.after = cursor.map(|c| c.into_cow())
+    }
+}
+
+#[cfg(test)]
+#[test]
+fn test_request_pending() {
+    use helix::*;
+    let req = GetUnbanRequestsRequest::new("274637212", "274637212", UnbanRequestStatus::Pending);
+
+    let data = br#"
+{
+  "data": [
+    {
+      "broadcaster_id": "129546453",
+      "broadcaster_login": "nerixyz",
+      "broadcaster_name": "nerixyz",
+      "created_at": "2024-10-12T18:34:38Z",
+      "id": "1dfff107-17fc-44cb-9f64-570a33757ac0",
+      "moderator_id": null,
+      "moderator_login": null,
+      "moderator_name": null,
+      "resolution_text": null,
+      "resolved_at": null,
+      "status": "pending",
+      "text": "My unban request text",
+      "user_id": "489584266",
+      "user_login": "uint128",
+      "user_name": "uint128"
+    }
+  ],
+  "pagination": {
+    "cursor": "eyJiIjpudWxsLCJhIjp7IkN1cnNvciI6IjEwMDQ3MzA2NDo4NjQwNjU3MToxSVZCVDFKMnY5M1BTOXh3d1E0dUdXMkJOMFcifX0"
+  }
+}
+"#
+        .to_vec();
+
+    let http_response = http::Response::builder().body(data).unwrap();
+
+    let uri = req.get_uri().unwrap();
+    assert_eq!(
+        uri.to_string(),
+        "https://api.twitch.tv/helix/moderation/unban_requests?broadcaster_id=274637212&moderator_id=274637212&status=pending"
+    );
+
+    let data = GetUnbanRequestsRequest::parse_response(Some(req), &uri, http_response)
+        .unwrap()
+        .data;
+    assert_eq!(data.len(), 1);
+    let pending = &data[0];
+
+    assert_eq!(pending.status, UnbanRequestStatus::Pending);
+    assert_eq!(pending.id.as_str(), "1dfff107-17fc-44cb-9f64-570a33757ac0");
+    assert_eq!(pending.broadcaster_login.as_str(), "nerixyz");
+    assert_eq!(pending.moderator_login.as_deref(), None);
+    assert_eq!(pending.user_login.as_str(), "uint128");
+    assert_eq!(pending.resolution_text.as_deref(), None);
+    assert_eq!(pending.resolved_at.as_deref(), None);
+}
+
+#[cfg(test)]
+#[test]
+fn test_request_approved() {
+    use helix::*;
+    let req = GetUnbanRequestsRequest::new("274637212", "274637212", UnbanRequestStatus::Approved);
+
+    // slightly modified from twitch docs
+    let data = br#"
+{
+  "data": [
+    {
+      "id": "92af127c-7326-4483-a52b-b0da0be61c01",
+      "broadcaster_name": "torpedo09",
+      "broadcaster_login": "torpedo09",
+      "broadcaster_id": "274637212",
+      "moderator_id": "141981764",
+      "moderator_login": "twitchdev",
+      "moderator_name": "TwitchDev",
+      "user_id": "424596340",
+      "user_login": "quotrok",
+      "user_name": "quotrok",
+      "text": "Please unban me from the channel?",
+      "status": "approved",
+      "created_at": "2022-08-07T02:07:55Z",
+      "resolved_at": "2022-08-09T02:07:55Z",
+      "resolution_text": ""
+    }
+  ],
+  "pagination": {
+    "cursor": "eyJiIjpudWxsLCJhIjp7IkN1cnNvciI6IjEwMDQ3MzA2NDo4NjQwNjU3MToxSVZCVDFKMnY5M1BTOXh3d1E0dUdXMkJOMFcifX0"
+  }
+}
+"#
+        .to_vec();
+
+    let http_response = http::Response::builder().body(data).unwrap();
+
+    let uri = req.get_uri().unwrap();
+    assert_eq!(
+        uri.to_string(),
+        "https://api.twitch.tv/helix/moderation/unban_requests?broadcaster_id=274637212&moderator_id=274637212&status=approved"
+    );
+
+    let data = GetUnbanRequestsRequest::parse_response(Some(req), &uri, http_response)
+        .unwrap()
+        .data;
+    assert_eq!(data.len(), 1);
+    let approved = &data[0];
+
+    assert_eq!(approved.status, UnbanRequestStatus::Approved);
+    assert_eq!(approved.id.as_str(), "92af127c-7326-4483-a52b-b0da0be61c01");
+    assert_eq!(approved.broadcaster_login.as_str(), "torpedo09");
+    assert_eq!(
+        approved.moderator_login.as_ref().unwrap().as_str(),
+        "twitchdev"
+    );
+    assert_eq!(approved.user_login.as_str(), "quotrok");
+    assert_eq!(approved.resolution_text.as_deref(), Some(""));
+    assert_eq!(
+        approved.resolved_at.as_ref().unwrap().as_str(),
+        "2022-08-09T02:07:55Z"
+    );
+}

--- a/src/helix/endpoints/moderation/mod.rs
+++ b/src/helix/endpoints/moderation/mod.rs
@@ -22,6 +22,7 @@ pub mod get_unban_requests;
 pub mod manage_held_automod_messages;
 pub mod remove_blocked_term;
 pub mod remove_channel_moderator;
+pub mod resolve_unban_request;
 pub mod unban_user;
 pub mod update_automod_settings;
 pub mod update_shield_mode_status;
@@ -59,6 +60,8 @@ pub use manage_held_automod_messages::{
 pub use remove_blocked_term::{RemoveBlockedTerm, RemoveBlockedTermRequest};
 #[doc(inline)]
 pub use remove_channel_moderator::{RemoveChannelModeratorRequest, RemoveChannelModeratorResponse};
+#[doc(inline)]
+pub use resolve_unban_request::ResolveUnbanRequest;
 #[doc(inline)]
 pub use unban_user::{UnbanUserRequest, UnbanUserResponse};
 #[doc(inline)]

--- a/src/helix/endpoints/moderation/mod.rs
+++ b/src/helix/endpoints/moderation/mod.rs
@@ -18,6 +18,7 @@ pub mod get_banned_users;
 pub mod get_blocked_terms;
 pub mod get_moderators;
 pub mod get_shield_mode_status;
+pub mod get_unban_requests;
 pub mod manage_held_automod_messages;
 pub mod remove_blocked_term;
 pub mod remove_channel_moderator;
@@ -47,6 +48,8 @@ pub use get_banned_users::{BannedUser, GetBannedUsersRequest};
 pub use get_moderators::{GetModeratorsRequest, Moderator};
 #[doc(inline)]
 pub use get_shield_mode_status::{GetShieldModeStatusRequest, LastShieldMode, ShieldModeStatus};
+#[doc(inline)]
+pub use get_unban_requests::{GetUnbanRequestsRequest, UnbanRequest, UnbanRequestStatus};
 #[doc(inline)]
 pub use manage_held_automod_messages::{
     AutoModAction, ManageHeldAutoModMessages, ManageHeldAutoModMessagesBody,

--- a/src/helix/endpoints/moderation/resolve_unban_request.rs
+++ b/src/helix/endpoints/moderation/resolve_unban_request.rs
@@ -1,0 +1,219 @@
+//! Resolves an unban request by approving or denying it.
+//!
+//! [`resolve-unban-requests`](https://dev.twitch.tv/docs/api/reference#resolve-unban-requests)
+//!
+//! # Accessing the endpoint
+//!
+//! ## Request: [ResolveUnbanRequest]
+//!
+//! To use this endpoint, construct an [`ResolveUnbanRequest`] with the [`ResolveUnbanRequest::new()`] method.
+//!
+//! ```rust
+//! use twitch_api::helix::moderation::resolve_unban_request;
+//! let request = resolve_unban_request::ResolveUnbanRequest::approve(
+//!     "123",
+//!     "456",
+//!     "123-456-789",
+//! )
+//! .resolution_text("something");
+//! ```
+//!
+//! ## Response: [UnbanRequest]
+//!
+//! Send the request to receive the response with [`HelixClient::req_patch()`](helix::HelixClient::req_patch).
+//!
+//! ```rust, no_run
+//! use twitch_api::helix::{self, moderation::resolve_unban_request};
+//! # use twitch_api::client;
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+//! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
+//! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
+//! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
+//! let request = resolve_unban_request::ResolveUnbanRequest::approve(
+//!     "123",
+//!     "456",
+//!     "123-456-789",
+//! );
+//! let response: helix::moderation::UnbanRequest = client.req_patch(request, helix::EmptyBody, &token).await?.data;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! You can also get the [`http::Request`] with [`request.create_request(&token, &client_id)`](helix::RequestPut::create_request)
+//! and parse the [`http::Response`] with [`ResolveUnbanRequest::parse_response(None, &request.get_uri(), response)`](ResolveUnbanRequest::parse_response)
+
+use super::*;
+use helix::RequestPatch;
+
+pub use super::{UnbanRequest, UnbanRequestStatus};
+
+/// Query Parameters for [Resolve Unban Request](super::resolve_unban_request)
+///
+/// [`resolve-unban-requests`](https://dev.twitch.tv/docs/api/reference#resolve-unban-requests)
+#[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
+#[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
+#[non_exhaustive]
+pub struct ResolveUnbanRequest<'a> {
+    /// The ID of the broadcaster whose channel is approving or denying the unban request.
+    #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
+    #[cfg_attr(feature = "deser_borrow", serde(borrow = "'a"))]
+    #[cfg_attr(not(feature = "deser_borrow"), serde(bound(deserialize = "'de: 'a")))]
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
+    /// The ID of the broadcaster or a user that has permission to moderate the broadcaster’s unban requests. This ID must match the user ID in the user access token.
+    #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
+    #[cfg_attr(feature = "deser_borrow", serde(borrow = "'a"))]
+    #[cfg_attr(not(feature = "deser_borrow"), serde(bound(deserialize = "'de: 'a")))]
+    pub moderator_id: Cow<'a, types::UserIdRef>,
+    /// The ID of the Unban Request to resolve.
+    #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
+    #[cfg_attr(feature = "deser_borrow", serde(borrow = "'a"))]
+    #[cfg_attr(not(feature = "deser_borrow"), serde(bound(deserialize = "'de: 'a")))]
+    pub unban_request_id: Cow<'a, types::UnbanRequestIdRef>,
+    /// Resolution status.
+    ///
+    /// Only [Approved](UnbanRequestStatus::Approved) and [Denied](UnbanRequestStatus::Denied) are accepted.
+    pub status: UnbanRequestStatus,
+    #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
+    #[cfg_attr(feature = "deser_borrow", serde(borrow = "'a"))]
+    #[cfg_attr(not(feature = "deser_borrow"), serde(bound(deserialize = "'de: 'a")))]
+    /// Message supplied by the unban request resolver. The message is limited to a maximum of 500 characters.
+    pub resolution_text: Option<Cow<'a, str>>,
+}
+
+impl<'a> ResolveUnbanRequest<'a> {
+    /// Approve an unban request
+    pub fn approve(
+        broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
+        moderator_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
+        unban_request_id: impl types::IntoCow<'a, types::UnbanRequestIdRef> + 'a,
+    ) -> Self {
+        Self {
+            broadcaster_id: broadcaster_id.into_cow(),
+            moderator_id: moderator_id.into_cow(),
+            unban_request_id: unban_request_id.into_cow(),
+            status: UnbanRequestStatus::Approved,
+            resolution_text: None,
+        }
+    }
+
+    /// Deny an unban request
+    pub fn deny(
+        broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
+        moderator_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
+        unban_request_id: impl types::IntoCow<'a, types::UnbanRequestIdRef> + 'a,
+    ) -> Self {
+        Self {
+            broadcaster_id: broadcaster_id.into_cow(),
+            moderator_id: moderator_id.into_cow(),
+            unban_request_id: unban_request_id.into_cow(),
+            status: UnbanRequestStatus::Denied,
+            resolution_text: None,
+        }
+    }
+
+    /// Resolve an unban request
+    ///
+    /// Only [Approved](UnbanRequestStatus::Approved) and [Denied](UnbanRequestStatus::Denied) are accepted as the status.
+    pub fn new(
+        broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
+        moderator_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
+        unban_request_id: impl types::IntoCow<'a, types::UnbanRequestIdRef> + 'a,
+        status: UnbanRequestStatus,
+    ) -> Self {
+        Self {
+            broadcaster_id: broadcaster_id.into_cow(),
+            moderator_id: moderator_id.into_cow(),
+            unban_request_id: unban_request_id.into_cow(),
+            status,
+            resolution_text: None,
+        }
+    }
+
+    /// Set the resolution text for a request
+    pub fn resolution_text(mut self, text: impl types::IntoCow<'a, str> + 'a) -> Self {
+        self.resolution_text = Some(text.into_cow());
+        self
+    }
+}
+
+impl Request for ResolveUnbanRequest<'_> {
+    type Response = super::UnbanRequest;
+
+    const PATH: &'static str = "moderation/unban_requests";
+    #[cfg(feature = "twitch_oauth2")]
+    const SCOPE: twitch_oauth2::Validator =
+        twitch_oauth2::validator![twitch_oauth2::Scope::ModeratorManageUnbanRequests];
+}
+
+impl RequestPatch for ResolveUnbanRequest<'_> {
+    type Body = helix::EmptyBody;
+
+    fn parse_inner_response(
+        request: Option<Self>,
+        uri: &http::Uri,
+        response: &str,
+        status: http::StatusCode,
+    ) -> Result<helix::Response<Self, <Self as Request>::Response>, helix::HelixRequestPatchError>
+    where
+        Self: Sized,
+    {
+        helix::parse_single_return(request, uri, response, status)
+    }
+}
+
+#[cfg(test)]
+#[test]
+fn test_request() {
+    use helix::*;
+    // modified from twitch example (they specified no resolution and the wrong moderator)
+    let req = ResolveUnbanRequest::approve(
+        "274637212",
+        "141981764",
+        "92af127c-7326-4483-a52b-b0da0be61c01",
+    )
+    .resolution_text("okay");
+
+    req.create_request(helix::EmptyBody, "token", "clientid")
+        .unwrap();
+
+    // Own response because the docs are wrong
+    let data = br#"
+    {
+        "data": [
+            {
+                "broadcaster_id": "129546453",
+                "broadcaster_login": "nerixyz",
+                "broadcaster_name": "nerixyz",
+                "created_at": "2024-10-12T18:34:38Z",
+                "id": "1dfff107-17fc-44cb-9f64-570a33757ac0",
+                "moderator_id": "129546453",
+                "moderator_login": "nerixyz",
+                "moderator_name": "nerixyz",
+                "resolution_text": "",
+                "resolved_at": "2024-10-12T18:45:47Z",
+                "status": "approved",
+                "text": "My unban request text",
+                "user_id": "489584266",
+                "user_login": "uint128",
+                "user_name": "uint128"
+            }
+        ]
+    }
+    "#
+    .to_vec();
+
+    let http_response = http::Response::builder().status(200).body(data).unwrap();
+
+    let uri = req.get_uri().unwrap();
+    assert_eq!(
+        uri.to_string(),
+        "https://api.twitch.tv/helix/moderation/unban_requests?broadcaster_id=274637212&moderator_id=141981764&unban_request_id=92af127c-7326-4483-a52b-b0da0be61c01&status=approved&resolution_text=okay"
+    );
+
+    let res = ResolveUnbanRequest::parse_response(Some(req), &uri, http_response)
+        .unwrap()
+        .data;
+    assert_eq!(res.status, UnbanRequestStatus::Approved);
+    assert_eq!(res.resolution_text.as_deref(), Some(""));
+}

--- a/src/helix/mod.rs
+++ b/src/helix/mod.rs
@@ -231,7 +231,7 @@
 //!
 //! </details>
 //!
-//! <details><summary style="cursor: pointer">Moderation 🟡 20/23</summary>
+//! <details><summary style="cursor: pointer">Moderation 🟡 21/23</summary>
 //!
 //! | Endpoint | Helper | Module |
 //! |---|---|---|
@@ -242,7 +242,7 @@
 //! | [Get Banned Users](https://dev.twitch.tv/docs/api/reference#get-banned-users) | - | [`moderation::get_banned_users`] |
 //! | [Ban User](https://dev.twitch.tv/docs/api/reference#ban-user) | [`HelixClient::ban_user`] | [`moderation::ban_user`] |
 //! | [Unban User](https://dev.twitch.tv/docs/api/reference#unban-user) | [`HelixClient::unban_user`] | [`moderation::unban_user`] |
-//! | [Get Unban Requests](https://dev.twitch.tv/docs/api/reference#get-unban-requests) | - | - |
+//! | [Get Unban Requests](https://dev.twitch.tv/docs/api/reference#get-unban-requests) | [`HelixClient::get_unban_requests`] | [`moderation::get_unban_requests`] |
 //! | [Resolve Unban Requests](https://dev.twitch.tv/docs/api/reference#resolve-unban-requests) | - | - |
 //! | [Get Blocked Terms](https://dev.twitch.tv/docs/api/reference#get-blocked-terms) | - | [`moderation::get_blocked_terms`] |
 //! | [Add Blocked Term](https://dev.twitch.tv/docs/api/reference#add-blocked-term) | - | [`moderation::add_blocked_term`] |

--- a/src/helix/mod.rs
+++ b/src/helix/mod.rs
@@ -231,7 +231,7 @@
 //!
 //! </details>
 //!
-//! <details><summary style="cursor: pointer">Moderation 🟡 21/23</summary>
+//! <details><summary style="cursor: pointer">Moderation 🟡 22/23</summary>
 //!
 //! | Endpoint | Helper | Module |
 //! |---|---|---|
@@ -243,7 +243,7 @@
 //! | [Ban User](https://dev.twitch.tv/docs/api/reference#ban-user) | [`HelixClient::ban_user`] | [`moderation::ban_user`] |
 //! | [Unban User](https://dev.twitch.tv/docs/api/reference#unban-user) | [`HelixClient::unban_user`] | [`moderation::unban_user`] |
 //! | [Get Unban Requests](https://dev.twitch.tv/docs/api/reference#get-unban-requests) | [`HelixClient::get_unban_requests`] | [`moderation::get_unban_requests`] |
-//! | [Resolve Unban Requests](https://dev.twitch.tv/docs/api/reference#resolve-unban-requests) | - | - |
+//! | [Resolve Unban Requests](https://dev.twitch.tv/docs/api/reference#resolve-unban-requests) | - | [`moderation::resolve_unban_request`] |
 //! | [Get Blocked Terms](https://dev.twitch.tv/docs/api/reference#get-blocked-terms) | - | [`moderation::get_blocked_terms`] |
 //! | [Add Blocked Term](https://dev.twitch.tv/docs/api/reference#add-blocked-term) | - | [`moderation::add_blocked_term`] |
 //! | [Remove Blocked Term](https://dev.twitch.tv/docs/api/reference#remove-blocked-term) | - | [`moderation::remove_blocked_term`] |

--- a/xtask/src/collect_endpoints/helix.rs
+++ b/xtask/src/collect_endpoints/helix.rs
@@ -121,6 +121,7 @@ fn category_override(c: String) -> String {
 fn item_override(i: String) -> String {
     match i.as_str() {
         "create_conduits" => "create_conduit".to_owned(),
+        "resolve_unban_requests" => "resolve_unban_request".to_owned(),
         _ => i,
     }
 }


### PR DESCRIPTION
Adds
- [Get Unban Requests](https://dev.twitch.tv/docs/api/reference/#get-unban-requests)
- [Resolve Unban Requests](https://dev.twitch.tv/docs/api/reference/#resolve-unban-requests) (renamed to `resolve_unban_request` since only one can be resolved at a time)

Updates `twitch_types` to 0.4.6.