### PR TITLE
Address new warnings and update`rustdoc-types`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2202,9 +2202,9 @@ dependencies = [
 
 [[package]]
 name = "rustdoc-types"
-version = "0.30.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89e3124c5a7883153fe3e762da9998cf36c302dbf1cc237869d297f9713e5655"
+checksum = "0958527c2f4e8ff8b64e067bda402306946efc96f9b69f9f691b146f4b17f930"
 dependencies = [
  "serde",
 ]

--- a/src/client.rs
+++ b/src/client.rs
@@ -231,7 +231,7 @@ impl<'c, C: Client + Sync + 'c> twitch_oauth2::client::Client for crate::HelixCl
 }
 
 #[cfg(all(feature = "client", feature = "helix"))]
-impl<'c, C: Client + Sync> twitch_oauth2::client::Client for crate::TwitchClient<'c, C> {
+impl<C: Client + Sync> twitch_oauth2::client::Client for crate::TwitchClient<'_, C> {
     type Error = CompatError<<C as Client>::Error>;
 
     fn req(

--- a/src/helix/client/client_ext.rs
+++ b/src/helix/client/client_ext.rs
@@ -1547,7 +1547,7 @@ impl<'client, C: crate::HttpClient + Sync + 'client> HelixClient<'client, C> {
     ///     "0",
     ///     twitch_api::eventsub::Transport::websocket(session_id),
     /// );
-
+    ///
     /// let response = client
     ///     .update_conduit_shards(conduit_id, vec![shard], &token)
     ///     .await;
@@ -1675,12 +1675,11 @@ where
     }
 
     impl<
-            'a,
             C: crate::HttpClient,
             T: TwitchToken + Send + Sync + ?Sized,
             Req: super::Request + super::RequestGet + super::Paginated,
             Item,
-        > State<'a, C, T, Req, Item>
+        > State<'_, C, T, Req, Item>
     {
         /// Process a request, with a given deq
         fn process(

--- a/src/helix/endpoints/channels/snooze_next_ad.rs
+++ b/src/helix/endpoints/channels/snooze_next_ad.rs
@@ -92,7 +92,7 @@ impl Request for SnoozeNextAdRequest<'_> {
         twitch_oauth2::validator![twitch_oauth2::Scope::ChannelManageAds];
 }
 
-impl<'a> RequestPost for SnoozeNextAdRequest<'a> {
+impl RequestPost for SnoozeNextAdRequest<'_> {
     type Body = helix::EmptyBody;
 
     fn parse_inner_response(

--- a/src/helix/endpoints/chat/send_chat_announcement.rs
+++ b/src/helix/endpoints/chat/send_chat_announcement.rs
@@ -127,7 +127,7 @@ impl<'a> SendChatAnnouncementBody<'a> {
 
 impl helix::private::SealedSerialize for SendChatAnnouncementBody<'_> {}
 
-impl<'a> helix::HelixRequestBody for [SendChatAnnouncementBody<'a>] {
+impl helix::HelixRequestBody for [SendChatAnnouncementBody<'_>] {
     fn try_to_body(&self) -> Result<hyper::body::Bytes, helix::BodyError> {
         #[derive(Serialize)]
         struct InnerBody<'a> {

--- a/src/helix/endpoints/chat/send_chat_message.rs
+++ b/src/helix/endpoints/chat/send_chat_message.rs
@@ -137,7 +137,7 @@ impl<'a> SendChatMessageBody<'a> {
 
 impl helix::private::SealedSerialize for SendChatMessageBody<'_> {}
 
-impl<'a> helix::HelixRequestBody for [SendChatMessageBody<'a>] {
+impl helix::HelixRequestBody for [SendChatMessageBody<'_>] {
     fn try_to_body(&self) -> Result<hyper::body::Bytes, helix::BodyError> {
         #[derive(Serialize)]
         struct InnerBody<'a> {

--- a/src/helix/endpoints/eventsub/create_eventsub_subscription.rs
+++ b/src/helix/endpoints/eventsub/create_eventsub_subscription.rs
@@ -58,7 +58,7 @@ pub struct CreateEventSubSubscriptionBody<E: EventSubscription> {
     pub transport: Transport,
 }
 
-impl<'a, E: EventSubscription> helix::HelixRequestBody for CreateEventSubSubscriptionBody<E> {
+impl<E: EventSubscription> helix::HelixRequestBody for CreateEventSubSubscriptionBody<E> {
     fn try_to_body(&self) -> Result<hyper::body::Bytes, helix::BodyError> {
         #[derive(PartialEq, Serialize, Debug)]
         struct IEventSubRequestBody<'a> {

--- a/src/helix/endpoints/moderation/add_blocked_term.rs
+++ b/src/helix/endpoints/moderation/add_blocked_term.rs
@@ -103,7 +103,7 @@ impl<'a> AddBlockedTermBody<'a> {
 
 impl helix::private::SealedSerialize for AddBlockedTermBody<'_> {}
 
-impl<'a> helix::HelixRequestBody for [AddBlockedTermBody<'a>] {
+impl helix::HelixRequestBody for [AddBlockedTermBody<'_>] {
     fn try_to_body(&self) -> Result<hyper::body::Bytes, helix::BodyError> {
         #[derive(Serialize)]
         struct InnerBody<'a> {

--- a/src/helix/endpoints/moderation/update_shield_mode_status.rs
+++ b/src/helix/endpoints/moderation/update_shield_mode_status.rs
@@ -104,7 +104,7 @@ pub struct UpdateShieldModeStatusBody<'a> {
 
 impl helix::private::SealedSerialize for UpdateShieldModeStatusBody<'_> {}
 
-impl<'a> UpdateShieldModeStatusBody<'a> {
+impl UpdateShieldModeStatusBody<'_> {
     /// Set status of shield mode
     pub fn is_active(is_active: bool) -> Self {
         Self {

--- a/xtask/Cargo.toml
+++ b/xtask/Cargo.toml
@@ -9,7 +9,7 @@ publish = false
 [dependencies]
 clap = { version = "4.5.18", features = ["derive"] }
 color-eyre = "0.6.2"
-rustdoc-types = "0.30.0"
+rustdoc-types = "0.32.0"
 xshell = "0.2.5"
 once_cell = "1.19"
 serde_json = "1.0"


### PR DESCRIPTION
- Fewer explicit lifetimes
- ~~Simplified boolean expression~~ `Option::is_none_or` requires nightly
- Update to `rustdoc-types` 0.32 (changes the ID type from string to int)
- [`too_long_first_doc_paragraph`](https://redirect.github.com/rust-lang/rust-clippy/issues/13315) warnings remain