### PR TITLE
feat: add `Get Moderated Channels`

### DIFF
--- a/src/helix/client/client_ext.rs
+++ b/src/helix/client/client_ext.rs
@@ -563,6 +563,40 @@ impl<'client, C: crate::HttpClient + Sync + 'client> HelixClient<'client, C> {
         make_stream(req, token, self, std::collections::VecDeque::from)
     }
 
+    /// Gets a list of channels that the specified user has moderator privileges in. [Get Moderated Channels](helix::moderation::GetModeratedChannelsRequest)
+    ///
+    /// # Examples
+    ///
+    /// ```rust, no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    /// # let client: helix::HelixClient<'static, twitch_api::client::DummyHttpClient> = helix::HelixClient::default();
+    /// # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
+    /// # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
+    /// use twitch_api::helix;
+    /// use twitch_oauth2::TwitchToken;
+    /// use futures::TryStreamExt;
+    ///
+    /// // use the associated user-id  with the user-access token
+    /// let user_id = token.user_id().expect("no user-id set in token");
+    /// let requests: Vec<helix::moderation::ModeratedChannel> = client.get_moderated_channels(user_id, &token).try_collect().await?;
+    /// # Ok(()) }
+    /// ```
+    pub fn get_moderated_channels<'b: 'client, T>(
+        &'client self,
+        user_id: impl types::IntoCow<'b, types::UserIdRef> + 'b,
+        token: &'client T,
+    ) -> impl futures::Stream<Item = Result<helix::moderation::ModeratedChannel, ClientError<C>>>
+           + Send
+           + Unpin
+           + 'client
+    where
+        T: TwitchToken + Send + Sync + ?Sized,
+    {
+        let req = helix::moderation::GetModeratedChannelsRequest::user_id(user_id);
+        make_stream(req, token, self, std::collections::VecDeque::from)
+    }
+
     /// Get a users, with login, follow count
     #[deprecated(
         note = "this method will not work anymore on 3 august, see https://discuss.dev.twitch.tv/t/follows-endpoints-and-eventsub-subscription-type-are-now-available-in-open-beta/43322"

--- a/src/helix/endpoints/moderation/get_moderated_channels.rs
+++ b/src/helix/endpoints/moderation/get_moderated_channels.rs
@@ -1,0 +1,157 @@
+//! Gets a list of channels that the specified user has moderator privileges in.
+//! [`get-moderated-channels`](https://dev.twitch.tv/docs/api/reference#get-moderated-channels)
+//!
+//! # Accessing the endpoint
+//!
+//! ## Request: [GetModeratedChannelsRequest]
+//!
+//! To use this endpoint, construct a [`GetModeratedChannelsRequest`] with the [`GetModeratedChannelsRequest::user_id()`] method.
+//!
+//! ```rust
+//! use twitch_api::helix::moderation::get_moderated_channels;
+//! let request =
+//!     get_moderated_channels::GetModeratedChannelsRequest::user_id("1234");
+//! ```
+//!
+//! ## Response: [ModeratedChannel]
+//!
+//! Send the request to receive the response with [`HelixClient::req_get()`](helix::HelixClient::req_get).
+//!
+//! ```rust, no_run
+//! use twitch_api::helix::{self, moderation::get_moderated_channels};
+//! # use twitch_api::client;
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+//! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
+//! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
+//! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
+//! let request = get_moderated_channels::GetModeratedChannelsRequest::user_id("1234");
+//! let response: Vec<get_moderated_channels::ModeratedChannel> = client.req_get(request, &token).await?.data;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! You can also get the [`http::Request`] with [`request.create_request(&token, &client_id)`](helix::RequestGet::create_request)
+//! and parse the [`http::Response`] with [`GetModeratedChannelsRequest::parse_response(None, &request.get_uri(), response)`](GetModeratedChannelsRequest::parse_response)
+use super::*;
+use helix::RequestGet;
+
+/// Query Parameters for [Get Moderated Channels](super::get_moderated_channels)
+///
+/// [`get-moderated-channels`](https://dev.twitch.tv/docs/api/reference#get-moderated-channels)
+#[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
+#[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
+#[must_use]
+#[non_exhaustive]
+pub struct GetModeratedChannelsRequest<'a> {
+    /// A user’s ID. Returns the list of channels that this user has moderator privileges in. This ID must match the user ID in the user OAuth token.
+    #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
+    #[cfg_attr(feature = "deser_borrow", serde(borrow = "'a"))]
+    pub user_id: Cow<'a, types::UserIdRef>,
+    /// The cursor used to get the next page of results. The Pagination object in the response contains the cursor’s value.
+    #[cfg_attr(feature = "typed-builder", builder(default))]
+    #[cfg_attr(feature = "deser_borrow", serde(borrow = "'a"))]
+    pub after: Option<Cow<'a, helix::CursorRef>>,
+    /// The maximum number of items to return per page in the response. Limit: 100. Default: 20.
+    #[cfg_attr(feature = "typed-builder", builder(setter(into), default))]
+    pub first: Option<usize>,
+}
+
+impl<'a> GetModeratedChannelsRequest<'a> {
+    /// Get Moderated Channels for an authenticated user.
+    pub fn user_id(user_id: impl types::IntoCow<'a, types::UserIdRef> + 'a) -> Self {
+        Self {
+            user_id: user_id.into_cow(),
+            after: Default::default(),
+            first: Default::default(),
+        }
+    }
+
+    /// Set amount of results returned per page.
+    pub fn first(mut self, first: usize) -> Self {
+        self.first = Some(first);
+        self
+    }
+}
+
+/// Return Values for [Get Moderated Channels](super::get_moderated_channels)
+///
+/// [`get-moderated-channels`](https://dev.twitch.tv/docs/api/reference#get-moderated-channels)
+#[derive(PartialEq, Eq, Deserialize, Serialize, Debug, Clone)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[non_exhaustive]
+pub struct ModeratedChannel {
+    /// An ID that uniquely identifies the channel this user can moderate.
+    pub broadcaster_id: types::UserId,
+    /// The channel’s login name.
+    pub broadcaster_login: types::UserName,
+    /// The channels’ display name.
+    pub broadcaster_name: types::DisplayName,
+}
+
+impl Request for GetModeratedChannelsRequest<'_> {
+    type Response = Vec<ModeratedChannel>;
+
+    const PATH: &'static str = "moderation/channels";
+    #[cfg(feature = "twitch_oauth2")]
+    const SCOPE: twitch_oauth2::Validator =
+        twitch_oauth2::validator![twitch_oauth2::Scope::UserReadModeratedChannels];
+}
+
+impl RequestGet for GetModeratedChannelsRequest<'_> {}
+
+impl helix::Paginated for GetModeratedChannelsRequest<'_> {
+    fn set_pagination(&mut self, cursor: Option<helix::Cursor>) {
+        self.after = cursor.map(|c| c.into_cow())
+    }
+}
+
+#[cfg(test)]
+#[test]
+fn test_request() {
+    use helix::*;
+    let req = GetModeratedChannelsRequest::user_id("931931");
+
+    // From twitch docs
+    let data = br#"
+    {
+        "data": [
+            {
+                "broadcaster_id" : "12345",
+                "broadcaster_login" : "grateful_broadcaster",
+                "broadcaster_name" : "Grateful_Broadcaster"
+            },
+            {
+                "broadcaster_id" : "98765",
+                "broadcaster_login" : "bashfulgamer",
+                "broadcaster_name" : "BashfulGamer"
+            }
+        ],
+        "pagination" : {
+            "cursor" : "eyJiIjpudWxsLCJhIjp7IkN1cnNvciI6IjEwMDQ3MzA2NDo4NjQwNjU3MToxSVZCVDFKMnY5M1BTOXh3d1E0dUdXMkJOMFcifX0"
+        }
+    }
+"#
+        .to_vec();
+
+    let http_response = http::Response::builder().body(data).unwrap();
+
+    let uri = req.get_uri().unwrap();
+    assert_eq!(
+        uri.to_string(),
+        "https://api.twitch.tv/helix/moderation/channels?user_id=931931"
+    );
+
+    let res = GetModeratedChannelsRequest::parse_response(Some(req), &uri, http_response)
+        .unwrap()
+        .data;
+    assert_eq!(res.len(), 2);
+
+    let (first, second) = (&res[0], &res[1]);
+    assert_eq!(first.broadcaster_id.as_str(), "12345");
+    assert_eq!(first.broadcaster_login.as_str(), "grateful_broadcaster");
+    assert_eq!(first.broadcaster_name.as_str(), "Grateful_Broadcaster");
+    assert_eq!(second.broadcaster_id.as_str(), "98765");
+    assert_eq!(second.broadcaster_login.as_str(), "bashfulgamer");
+    assert_eq!(second.broadcaster_name.as_str(), "BashfulGamer");
+}

--- a/src/helix/endpoints/moderation/mod.rs
+++ b/src/helix/endpoints/moderation/mod.rs
@@ -16,6 +16,7 @@ pub mod delete_chat_messages;
 pub mod get_automod_settings;
 pub mod get_banned_users;
 pub mod get_blocked_terms;
+pub mod get_moderated_channels;
 pub mod get_moderators;
 pub mod get_shield_mode_status;
 pub mod get_unban_requests;
@@ -45,6 +46,8 @@ pub use delete_chat_messages::{DeleteChatMessagesRequest, DeleteChatMessagesResp
 pub use get_automod_settings::{AutoModSettings, GetAutoModSettingsRequest};
 #[doc(inline)]
 pub use get_banned_users::{BannedUser, GetBannedUsersRequest};
+#[doc(inline)]
+pub use get_moderated_channels::{GetModeratedChannelsRequest, ModeratedChannel};
 #[doc(inline)]
 pub use get_moderators::{GetModeratorsRequest, Moderator};
 #[doc(inline)]

--- a/src/helix/mod.rs
+++ b/src/helix/mod.rs
@@ -231,7 +231,7 @@
 //!
 //! </details>
 //!
-//! <details><summary style="cursor: pointer">Moderation 🟡 22/23</summary>
+//! <details><summary style="cursor: pointer">Moderation 🟢 23/23</summary>
 //!
 //! | Endpoint | Helper | Module |
 //! |---|---|---|
@@ -248,7 +248,7 @@
 //! | [Add Blocked Term](https://dev.twitch.tv/docs/api/reference#add-blocked-term) | - | [`moderation::add_blocked_term`] |
 //! | [Remove Blocked Term](https://dev.twitch.tv/docs/api/reference#remove-blocked-term) | - | [`moderation::remove_blocked_term`] |
 //! | [Delete Chat Messages](https://dev.twitch.tv/docs/api/reference#delete-chat-messages) | - | [`moderation::delete_chat_messages`] |
-//! | [Get Moderated Channels](https://dev.twitch.tv/docs/api/reference#get-moderated-channels) | - | - |
+//! | [Get Moderated Channels](https://dev.twitch.tv/docs/api/reference#get-moderated-channels) | [`HelixClient::get_moderated_channels`] | [`moderation::get_moderated_channels`] |
 //! | [Get Moderators](https://dev.twitch.tv/docs/api/reference#get-moderators) | - | [`moderation::get_moderators`] |
 //! | [Add Channel Moderator](https://dev.twitch.tv/docs/api/reference#add-channel-moderator) | [`HelixClient::add_channel_moderator`] | [`moderation::add_channel_moderator`] |
 //! | [Remove Channel Moderator](https://dev.twitch.tv/docs/api/reference#remove-channel-moderator) | [`HelixClient::remove_channel_moderator`] | [`moderation::remove_channel_moderator`] |


### PR DESCRIPTION
Adds [`Get Moderated Channels`](https://dev.twitch.tv/docs/api/reference#get-moderated-channels). Now we support all moderation endpoints.