### PR TITLE
feat: add `Get Shared Chat Session`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ trace_unknown_fields = ["dep:serde_ignored", "tracing"]
 
 serde_json = ["dep:serde_json", "dep:serde_path_to_error"]
 helix = [
+    "twitch_types/chat",
     "twitch_types/color",
     "twitch_types/emote",
     "twitch_types/goal",

--- a/src/helix/client/client_ext.rs
+++ b/src/helix/client/client_ext.rs
@@ -1220,6 +1220,26 @@ impl<'client, C: crate::HttpClient + Sync + 'client> HelixClient<'client, C> {
             .try_flatten_unordered(None)
     }
 
+    /// Retrieves the active shared chat session for a channel
+    ///
+    /// [`None`] is returned if no shared chat session is active.
+    pub async fn get_shared_chat_session<'b, T>(
+        &'client self,
+        broadcaster_id: impl types::IntoCow<'b, types::UserIdRef> + Send + 'b,
+        token: &T,
+    ) -> Result<Option<helix::chat::SharedChatSession>, ClientError<C>>
+    where
+        T: TwitchToken + Send + Sync + ?Sized,
+    {
+        Ok(self
+            .req_get(
+                helix::chat::GetSharedChatSessionRequest::broadcaster_id(broadcaster_id),
+                token,
+            )
+            .await?
+            .first())
+    }
+
     /// Add a channel moderator
     pub async fn add_channel_moderator<'b, T>(
         &'client self,

--- a/src/helix/endpoints/chat/get_shared_chat_session.rs
+++ b/src/helix/endpoints/chat/get_shared_chat_session.rs
@@ -1,0 +1,202 @@
+//! Retrieves the active shared chat session for a channel.
+//! [`get-shared-chat-session`](https://dev.twitch.tv/docs/api/reference#get-shared-chat-session)
+//!
+//! # Accessing the endpoint
+//!
+//! ## Request: [GetSharedChatSessionRequest]
+//!
+//! To use this endpoint, construct a [`GetSharedChatSessionRequest`] with the [`GetSharedChatSessionRequest::broadcaster_id`] method.
+//!
+//! ```rust
+//! use twitch_api::helix::chat::get_shared_chat_session;
+//! let request =
+//!     get_shared_chat_session::GetSharedChatSessionRequest::broadcaster_id(
+//!         "12345",
+//!     );
+//! ```
+//!
+//! ## Response: [SharedChatSession]
+//!
+//! Send the request to receive the response with [`HelixClient::req_get()`](helix::HelixClient::req_get).
+//!
+//! ```rust, no_run
+//! use twitch_api::helix::{self, chat::get_shared_chat_session};
+//! # use twitch_api::client;
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+//! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
+//! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
+//! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
+//! let request = get_shared_chat_session::GetSharedChatSessionRequest::broadcaster_id("12345");
+//! let response: Option<helix::chat::SharedChatSession> = client.req_get(request, &token).await?.data;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! You can also get the [`http::Request`] with [`request.create_request(&token, &client_id)`](helix::RequestGet::create_request)
+//! and parse the [`http::Response`] with [`GetSharedChatSessionRequest::parse_response(None, &request.get_uri(), response)`](GetSharedChatSessionRequest::parse_response)
+use super::*;
+use helix::RequestGet;
+
+/// Query Parameters for [Get Shared Chat Session](super::get_shared_chat_session)
+///
+/// [`get-shared-chat-session`](https://dev.twitch.tv/docs/api/reference#get-shared-chat-session)
+#[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
+#[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
+#[must_use]
+#[non_exhaustive]
+pub struct GetSharedChatSessionRequest<'a> {
+    /// The User ID of the channel broadcaster.
+    #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
+    #[cfg_attr(feature = "deser_borrow", serde(borrow = "'a"))]
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
+}
+
+impl<'a> GetSharedChatSessionRequest<'a> {
+    /// Retrieve the active shared chat session for a channel
+    pub fn broadcaster_id(broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a) -> Self {
+        Self {
+            broadcaster_id: broadcaster_id.into_cow(),
+        }
+    }
+}
+
+/// Return Values for [Get Shared Chat Session](super::get_shared_chat_session)
+///
+/// [`get-shared-chat-session`](https://dev.twitch.tv/docs/api/reference#get-shared-chat-session)
+#[derive(PartialEq, Eq, Deserialize, Serialize, Debug, Clone)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[non_exhaustive]
+pub struct SharedChatSession {
+    /// The unique identifier for the shared chat session.
+    pub session_id: types::SharedChatSessionId,
+    /// The User ID of the host channel.
+    pub host_broadcaster_id: types::UserId,
+    /// The list of participants in the session.
+    pub participants: Vec<SharedChatParticipant>,
+    /// The UTC date and time (in RFC3339 format) for when the session was created.
+    pub created_at: types::Timestamp,
+    /// The UTC date and time (in RFC3339 format) for when the session was last updated.
+    pub updated_at: types::Timestamp,
+}
+
+/// A participant in a shared chat session
+#[derive(PartialEq, Eq, Deserialize, Serialize, Debug, Clone)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[non_exhaustive]
+pub struct SharedChatParticipant {
+    /// The User ID of the participant channel.
+    pub broadcaster_id: types::UserId,
+}
+
+impl Request for GetSharedChatSessionRequest<'_> {
+    type Response = Option<SharedChatSession>;
+
+    const PATH: &'static str = "shared_chat/session";
+    #[cfg(feature = "twitch_oauth2")]
+    const SCOPE: twitch_oauth2::Validator = twitch_oauth2::validator![];
+}
+
+impl RequestGet for GetSharedChatSessionRequest<'_> {
+    fn parse_inner_response(
+        request: Option<Self>,
+        uri: &http::Uri,
+        response: &str,
+        status: http::StatusCode,
+    ) -> Result<helix::Response<Self, <Self as Request>::Response>, helix::HelixRequestGetError>
+    where
+        Self: Sized,
+    {
+        let resp = match status {
+            http::StatusCode::OK => {
+                let resp: helix::InnerResponse<helix::request::ZeroOrOne<SharedChatSession>> =
+                    helix::parse_json(response, true).map_err(|e| {
+                        helix::HelixRequestGetError::DeserializeError(
+                            response.to_string(),
+                            e,
+                            uri.clone(),
+                            status,
+                        )
+                    })?;
+                resp.data.0
+            }
+            _ => {
+                return Err(helix::HelixRequestGetError::InvalidResponse {
+                    reason: "unexpected status code",
+                    response: response.to_string(),
+                    status,
+                    uri: uri.clone(),
+                })
+            }
+        };
+        Ok(helix::Response::with_data(resp, request))
+    }
+}
+
+#[cfg(test)]
+#[test]
+fn test_request() {
+    use helix::*;
+    let req = GetSharedChatSessionRequest::broadcaster_id("198704263");
+
+    // From twitch docs (modified `updated_at`)
+    let data = br#"
+        {
+          "data": [
+            {
+              "session_id": "359bce59-fa4e-41a5-bd6f-9bc0c8360485",
+              "host_broadcaster_id": "198704263",
+              "participants": [{
+                  "broadcaster_id": "198704263"
+              }, {
+                  "broadcaster_id": "487263401"
+              }],
+              "created_at": "2024-09-29T19:45:37Z",
+              "updated_at": "2024-09-29T19:50:01Z"
+            }
+          ]
+        }
+        "#
+    .to_vec();
+
+    let http_response = http::Response::builder().body(data).unwrap();
+
+    let uri = req.get_uri().unwrap();
+    assert_eq!(
+        uri.to_string(),
+        "https://api.twitch.tv/helix/shared_chat/session?broadcaster_id=198704263"
+    );
+
+    let res = GetSharedChatSessionRequest::parse_response(Some(req), &uri, http_response).unwrap();
+    let res = res.data.unwrap();
+    assert_eq!(
+        res.session_id.as_str(),
+        "359bce59-fa4e-41a5-bd6f-9bc0c8360485"
+    );
+    assert_eq!(res.host_broadcaster_id.as_str(), "198704263");
+    assert_eq!(res.participants.len(), 2);
+    assert_eq!(res.participants[0].broadcaster_id.as_str(), "198704263");
+    assert_eq!(res.participants[1].broadcaster_id.as_str(), "487263401");
+    assert_eq!(res.created_at.as_str(), "2024-09-29T19:45:37Z");
+    assert_eq!(res.updated_at.as_str(), "2024-09-29T19:50:01Z");
+}
+
+#[cfg(test)]
+#[test]
+fn test_request_empty() {
+    use helix::*;
+    let req = GetSharedChatSessionRequest::broadcaster_id("198704263");
+
+    let data = br#"{ "data": [] }"#.to_vec();
+
+    let http_response = http::Response::builder().body(data).unwrap();
+
+    let uri = req.get_uri().unwrap();
+    assert_eq!(
+        uri.to_string(),
+        "https://api.twitch.tv/helix/shared_chat/session?broadcaster_id=198704263"
+    );
+
+    let res = GetSharedChatSessionRequest::parse_response(Some(req), &uri, http_response).unwrap();
+    assert!(res.data.is_none());
+}

--- a/src/helix/endpoints/chat/mod.rs
+++ b/src/helix/endpoints/chat/mod.rs
@@ -4,7 +4,7 @@
 //!
 //! <!-- generate with "cargo xtask overview" (with a nightly toolchain) -->
 //! <!-- BEGIN-OVERVIEW -->
-//! <details open><summary style="cursor: pointer">Chat 🟡 14/15</summary>
+//! <details open><summary style="cursor: pointer">Chat 🟢 15/15</summary>
 //!
 //! | Endpoint | Helper | Module |
 //! |---|---|---|
@@ -15,7 +15,7 @@
 //! | [Get Channel Chat Badges](https://dev.twitch.tv/docs/api/reference#get-channel-chat-badges) | - | [`get_channel_chat_badges`] |
 //! | [Get Global Chat Badges](https://dev.twitch.tv/docs/api/reference#get-global-chat-badges) | - | [`get_global_chat_badges`] |
 //! | [Get Chat Settings](https://dev.twitch.tv/docs/api/reference#get-chat-settings) | [`HelixClient::get_chat_settings`](crate::helix::HelixClient::get_chat_settings) | [`get_chat_settings`] |
-//! | [Get Shared Chat Session](https://dev.twitch.tv/docs/api/reference#get-shared-chat-session) | - | - |
+//! | [Get Shared Chat Session](https://dev.twitch.tv/docs/api/reference#get-shared-chat-session) | [`HelixClient::get_shared_chat_session`](crate::helix::HelixClient::get_shared_chat_session) | [`get_shared_chat_session`] |
 //! | [Get User Emotes](https://dev.twitch.tv/docs/api/reference#get-user-emotes) | [`HelixClient::get_user_emotes`](crate::helix::HelixClient::get_user_emotes), [`HelixClient::get_user_emotes_in_channel`](crate::helix::HelixClient::get_user_emotes_in_channel) | [`get_user_emotes`] |
 //! | [Update Chat Settings](https://dev.twitch.tv/docs/api/reference#update-chat-settings) | - | [`update_chat_settings`] |
 //! | [Send Chat Announcement](https://dev.twitch.tv/docs/api/reference#send-chat-announcement) | [`HelixClient::send_chat_announcement`](crate::helix::HelixClient::send_chat_announcement) | [`send_chat_announcement`] |
@@ -42,6 +42,7 @@ pub mod get_chatters;
 pub mod get_emote_sets;
 pub mod get_global_chat_badges;
 pub mod get_global_emotes;
+pub mod get_shared_chat_session;
 pub mod get_user_chat_color;
 pub mod get_user_emotes;
 pub mod send_a_shoutout;
@@ -64,6 +65,10 @@ pub use get_emote_sets::GetEmoteSetsRequest;
 pub use get_global_chat_badges::GetGlobalChatBadgesRequest;
 #[doc(inline)]
 pub use get_global_emotes::GetGlobalEmotesRequest;
+#[doc(inline)]
+pub use get_shared_chat_session::{
+    GetSharedChatSessionRequest, SharedChatParticipant, SharedChatSession,
+};
 #[doc(inline)]
 pub use get_user_chat_color::{GetUserChatColorRequest, UserChatColor};
 #[doc(inline)]

--- a/src/helix/mod.rs
+++ b/src/helix/mod.rs
@@ -105,7 +105,7 @@
 //!
 //! </details>
 //!
-//! <details><summary style="cursor: pointer">Chat 🟡 14/15</summary>
+//! <details><summary style="cursor: pointer">Chat 🟢 15/15</summary>
 //!
 //! | Endpoint | Helper | Module |
 //! |---|---|---|
@@ -116,7 +116,7 @@
 //! | [Get Channel Chat Badges](https://dev.twitch.tv/docs/api/reference#get-channel-chat-badges) | - | [`chat::get_channel_chat_badges`] |
 //! | [Get Global Chat Badges](https://dev.twitch.tv/docs/api/reference#get-global-chat-badges) | - | [`chat::get_global_chat_badges`] |
 //! | [Get Chat Settings](https://dev.twitch.tv/docs/api/reference#get-chat-settings) | [`HelixClient::get_chat_settings`] | [`chat::get_chat_settings`] |
-//! | [Get Shared Chat Session](https://dev.twitch.tv/docs/api/reference#get-shared-chat-session) | - | - |
+//! | [Get Shared Chat Session](https://dev.twitch.tv/docs/api/reference#get-shared-chat-session) | [`HelixClient::get_shared_chat_session`] | [`chat::get_shared_chat_session`] |
 //! | [Get User Emotes](https://dev.twitch.tv/docs/api/reference#get-user-emotes) | [`HelixClient::get_user_emotes`], [`HelixClient::get_user_emotes_in_channel`] | [`chat::get_user_emotes`] |
 //! | [Update Chat Settings](https://dev.twitch.tv/docs/api/reference#update-chat-settings) | - | [`chat::update_chat_settings`] |
 //! | [Send Chat Announcement](https://dev.twitch.tv/docs/api/reference#send-chat-announcement) | [`HelixClient::send_chat_announcement`] | [`chat::send_chat_announcement`] |


### PR DESCRIPTION
Adds [`Get Shared Chat Session`](https://dev.twitch.tv/docs/api/reference#get-shared-chat-session). I added a `ZeroOrOne` helper to deserialize an array that must contain zero or one item to a `Option<T>` (without going through a `Vec<T>` in the middle).