### PR TITLE
feat: add remaining `Streams` Helix endpoints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3216,7 +3216,7 @@ dependencies = [
 
 [[package]]
 name = "twitch_types"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "serde",
  "serde_derive",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ exclude = ["twitch_types", "twitch_oauth2"]
 [workspace.dependencies]
 twitch_api = { version = "0.7.0-rc.8", path = "." }
 twitch_oauth2 = { version = "0.14.0", path = "twitch_oauth2/" }
-twitch_types = { version = "0.4.6", features = [
+twitch_types = { version = "0.4.7", features = [
     "serde",
 ], path = "./twitch_types" }
 ureq = { version = "2.10.1", default-features = false, features = [

--- a/src/helix/client/client_ext.rs
+++ b/src/helix/client/client_ext.rs
@@ -260,6 +260,42 @@ impl<'client, C: crate::HttpClient + Sync + 'client> HelixClient<'client, C> {
         .map(|res| res.data.stream_key)
     }
 
+    /// Adds a marker to a live stream.
+    ///
+    /// # Examples
+    ///
+    /// ```rust, no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    /// # let client: helix::HelixClient<'static, twitch_api::client::DummyHttpClient> = helix::HelixClient::default();
+    /// # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
+    /// # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
+    /// use twitch_api::helix;
+    /// use twitch_oauth2::TwitchToken;
+    ///
+    /// // use the associated user-id  with the user-access token
+    /// let user_id = token.user_id().expect("no user-id set in token");
+    /// let marker: helix::streams::CreatedStreamMarker = client.create_stream_marker(user_id, "my description", &token).await?;
+    /// # Ok(()) }
+    /// ```
+    pub async fn create_stream_marker<'b, T>(
+        &'client self,
+        user_id: impl types::IntoCow<'b, types::UserIdRef> + 'b + Send,
+        description: impl Into<Cow<'b, str>> + Send,
+        token: &T,
+    ) -> Result<helix::streams::CreatedStreamMarker, ClientError<C>>
+    where
+        T: TwitchToken + Send + Sync + ?Sized,
+    {
+        self.req_post(
+            helix::streams::CreateStreamMarkerRequest::new(),
+            helix::streams::CreateStreamMarkerBody::new(user_id, description),
+            token,
+        )
+        .await
+        .map(|res| res.data)
+    }
+
     /// Get chatters in a stream [Chatter][helix::chat::Chatter]
     ///
     /// `batch_size` sets the amount of chatters to retrieve per api call, max 1000, defaults to 100.

--- a/src/helix/client/client_ext.rs
+++ b/src/helix/client/client_ext.rs
@@ -226,6 +226,40 @@ impl<'client, C: crate::HttpClient + Sync + 'client> HelixClient<'client, C> {
         .flatten_unordered(None)
     }
 
+    /// Gets the channel’s stream key.
+    ///
+    /// # Examples
+    ///
+    /// ```rust, no_run
+    /// # #[tokio::main]
+    /// # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+    /// # let client: helix::HelixClient<'static, twitch_api::client::DummyHttpClient> = helix::HelixClient::default();
+    /// # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
+    /// # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
+    /// use twitch_api::helix;
+    /// use twitch_oauth2::TwitchToken;
+    ///
+    /// // use the associated user-id  with the user-access token
+    /// let user_id = token.user_id().expect("no user-id set in token");
+    /// let key: twitch_types::StreamKey = client.get_stream_key(user_id, &token).await?;
+    /// # Ok(()) }
+    /// ```
+    pub async fn get_stream_key<'b, T>(
+        &'client self,
+        broadcaster_id: impl types::IntoCow<'b, types::UserIdRef> + 'b + Send,
+        token: &T,
+    ) -> Result<types::StreamKey, ClientError<C>>
+    where
+        T: TwitchToken + Send + Sync + ?Sized,
+    {
+        self.req_get(
+            helix::streams::GetStreamKeyRequest::broadcaster_id(broadcaster_id),
+            token,
+        )
+        .await
+        .map(|res| res.data.stream_key)
+    }
+
     /// Get chatters in a stream [Chatter][helix::chat::Chatter]
     ///
     /// `batch_size` sets the amount of chatters to retrieve per api call, max 1000, defaults to 100.

--- a/src/helix/endpoints/streams/create_stream_marker.rs
+++ b/src/helix/endpoints/streams/create_stream_marker.rs
@@ -1,0 +1,211 @@
+//! Adds a marker to a live stream.
+//! [`create-stream-marker`](https://dev.twitch.tv/docs/api/reference#create-stream-marker)
+//!
+//! A marker is an arbitrary point in a live stream that the broadcaster or editor wants to mark, so they can return to that spot later to create video highlights (see Video Producer, Highlights in the Twitch UX).
+//!
+//! # Accessing the endpoint
+//!
+//! ## Request: [CreateStreamMarkerRequest]
+//!
+//! To use this endpoint, construct a [`CreateStreamMarkerRequest`] with the [`CreateStreamMarkerRequest::new()`] method.
+//!
+//! ```rust
+//! use twitch_api::helix::streams::create_stream_marker;
+//! let request = create_stream_marker::CreateStreamMarkerRequest::new();
+//! ```
+//!
+//! ## Body: [CreateStreamMarkerBody]
+//!
+//! We also need to provide a body to the request containing what we want to change.
+//!
+//! ```
+//! # use std::convert::TryFrom;
+//! # use twitch_api::helix::streams::create_stream_marker;
+//! let body = create_stream_marker::CreateStreamMarkerBody::new(
+//!     "123", // user-id of the broadcaster
+//!     "marker description",
+//! );
+//! ```
+//!
+//! ## Response: [CreatedStreamMarker]
+//!
+//! Send the request to receive the response with [`HelixClient::req_post()`](helix::HelixClient::req_post).
+//!
+//! ```rust, no_run
+//! use twitch_api::helix::{self, streams::create_stream_marker};
+//! # use twitch_api::client;
+//! # use std::convert::TryFrom;
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+//! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
+//! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
+//! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
+//! let request =
+//!     create_stream_marker::CreateStreamMarkerRequest::new();
+//! let body =
+//!     create_stream_marker::CreateStreamMarkerBody::new(
+//!         "123",
+//!         "my description"
+//!     );
+//! let response: create_stream_marker::CreatedStreamMarker = client.req_post(request, body, &token).await?.data;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! You can also get the [`http::Request`] with [`request.create_request(&body, &token, &client_id)`](helix::RequestPost::create_request)
+//! and parse the [`http::Response`] with [`CreateStreamMarkerRequest::parse_response(None, &request.get_uri(), response)`](CreateStreamMarkerRequest::parse_response)
+
+use std::marker::PhantomData;
+
+use super::*;
+use helix::RequestPost;
+
+/// Query Parameters for [Create Stream Marker](super::create_stream_marker)
+///
+/// [`create-stream-marker`](https://dev.twitch.tv/docs/api/reference#create-stream-marker)
+#[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug, Default)]
+#[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
+#[must_use]
+#[non_exhaustive]
+pub struct CreateStreamMarkerRequest<'a> {
+    #[cfg_attr(feature = "typed-builder", builder(default))]
+    #[serde(skip)]
+    _marker: PhantomData<&'a ()>,
+}
+
+impl CreateStreamMarkerRequest<'_> {
+    /// Create a new [CreateStreamMarkerRequest]
+    pub fn new() -> Self { Self::default() }
+}
+
+/// Body Parameters for [Create Stream Marker](super::create_stream_marker)
+///
+/// [`create-stream-marker`](https://dev.twitch.tv/docs/api/reference#create-stream-marker)
+#[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
+#[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
+#[non_exhaustive]
+pub struct CreateStreamMarkerBody<'a> {
+    /// The ID of the broadcaster that’s streaming content. This ID must match the user ID in the access token or the user in the access token must be one of the broadcaster’s editors.
+    #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
+    #[cfg_attr(feature = "deser_borrow", serde(borrow = "'a"))]
+    pub user_id: Cow<'a, types::UserIdRef>,
+    /// A short description of the marker to help the user remember why they marked the location. The maximum length of the description is 140 characters.
+    #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[cfg_attr(feature = "deser_borrow", serde(borrow = "'a"))]
+    pub description: Option<Cow<'a, str>>,
+}
+
+impl<'a> CreateStreamMarkerBody<'a> {
+    /// Create a new stream marker with a description
+    pub fn new(
+        user_id: impl types::IntoCow<'a, types::UserIdRef> + 'a,
+        description: impl Into<Cow<'a, str>>,
+    ) -> Self {
+        Self {
+            user_id: user_id.into_cow(),
+            description: Some(description.into()),
+        }
+    }
+
+    /// Create a new stream marker without a description
+    pub fn user_id(user_id: impl types::IntoCow<'a, types::UserIdRef> + 'a) -> Self {
+        Self {
+            user_id: user_id.into_cow(),
+            description: None,
+        }
+    }
+}
+
+impl helix::private::SealedSerialize for CreateStreamMarkerBody<'_> {}
+
+/// Return Value for [Create Stream Marker](super::create_stream_marker)
+///
+/// [`create-stream-marker`](https://dev.twitch.tv/docs/api/reference#create-stream-marker)
+#[derive(PartialEq, Eq, Deserialize, Serialize, Debug, Clone)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[non_exhaustive]
+pub struct CreatedStreamMarker {
+    /// An ID that identifies this marker.
+    pub id: types::StreamMarkerId,
+    /// The UTC date and time (in RFC3339 format) of when the user created the marker.
+    pub created_at: types::Timestamp,
+    /// The relative offset (in seconds) of the marker from the beginning of the stream.
+    pub position_seconds: u64,
+    /// A description that the user gave the marker to help them remember why they marked the location.
+    pub description: String,
+}
+
+impl Request for CreateStreamMarkerRequest<'_> {
+    type Response = CreatedStreamMarker;
+
+    const PATH: &'static str = "streams/markers";
+    #[cfg(feature = "twitch_oauth2")]
+    const SCOPE: twitch_oauth2::Validator =
+        twitch_oauth2::validator![twitch_oauth2::Scope::ChannelManageBroadcast];
+}
+
+impl<'a> RequestPost for CreateStreamMarkerRequest<'a> {
+    type Body = CreateStreamMarkerBody<'a>;
+
+    fn parse_inner_response(
+        request: Option<Self>,
+        uri: &http::Uri,
+        response: &str,
+        status: http::StatusCode,
+    ) -> Result<helix::Response<Self, <Self as Request>::Response>, helix::HelixRequestPostError>
+    where
+        Self: Sized,
+    {
+        helix::parse_single_return(request, uri, response, status)
+    }
+}
+
+#[cfg(test)]
+#[test]
+fn test_request() {
+    use helix::*;
+
+    let req = CreateStreamMarkerRequest::new();
+
+    let body = CreateStreamMarkerBody::new("123", "hello, this is a marker!");
+
+    assert_eq!(
+        std::str::from_utf8(&body.try_to_body().unwrap()).unwrap(),
+        r#"{"user_id":"123","description":"hello, this is a marker!"}"#
+    );
+
+    dbg!(req.create_request(body, "token", "clientid").unwrap());
+
+    // From twitch docs
+    let data = br#"
+    {
+      "data": [
+         {
+            "id": "123",
+            "created_at": "2018-08-20T20:10:03Z",
+            "description": "hello, this is a marker!",
+            "position_seconds": 244
+         }
+      ]
+    }
+    "#
+    .to_vec();
+
+    let http_response = http::Response::builder().body(data).unwrap();
+
+    let uri = req.get_uri().unwrap();
+    assert_eq!(
+        uri.to_string(),
+        "https://api.twitch.tv/helix/streams/markers?"
+    );
+
+    let res = CreateStreamMarkerRequest::parse_response(Some(req), &uri, http_response)
+        .unwrap()
+        .data;
+
+    assert_eq!(res.id.as_str(), "123");
+    assert_eq!(res.created_at.as_str(), "2018-08-20T20:10:03Z");
+    assert_eq!(res.description, "hello, this is a marker!");
+    assert_eq!(res.position_seconds, 244);
+}

--- a/src/helix/endpoints/streams/get_stream_key.rs
+++ b/src/helix/endpoints/streams/get_stream_key.rs
@@ -1,0 +1,126 @@
+//! Gets the channel’s stream key.
+//! [`get-stream-key`](https://dev.twitch.tv/docs/api/reference#get-stream-key)
+//!
+//! # Accessing the endpoint
+//!
+//! ## Request: [GetStreamKeyRequest]
+//!
+//! To use this endpoint, construct a [`GetStreamKeyRequest`] with the [`GetStreamKeyRequest::broadcaster_id()`] method.
+//!
+//! ```rust
+//! use twitch_api::helix::streams::get_stream_key;
+//! let request = get_stream_key::GetStreamKeyRequest::broadcaster_id("1234");
+//! ```
+//!
+//! ## Response: [GetStreamKeyResponse](helix::streams::GetStreamKeyResponse)
+//!
+//! Send the request to receive the response with [`HelixClient::req_get()`](helix::HelixClient::req_get).
+//!
+//! ```rust, no_run
+//! use twitch_api::helix::{self, streams::get_stream_key};
+//! # use twitch_api::client;
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+//! # let client: helix::HelixClient<'static, client::DummyHttpClient> = helix::HelixClient::default();
+//! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
+//! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
+//! let request = get_stream_key::GetStreamKeyRequest::broadcaster_id("1234");
+//! let response: get_stream_key::GetStreamKeyResponse = client.req_get(request, &token).await?.data;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! You can also get the [`http::Request`] with [`request.create_request(&token, &client_id)`](helix::RequestGet::create_request)
+//! and parse the [`http::Response`] with [`GetStreamKeyRequest::parse_response(None, &request.get_uri(), response)`](GetStreamKeyRequest::parse_response)
+
+use super::*;
+use helix::RequestGet;
+
+/// Query Parameters for [Get Stream Key](super::get_stream_key)
+///
+/// [`get-stream-key`](https://dev.twitch.tv/docs/api/reference#get-stream-key)
+#[derive(PartialEq, Eq, Deserialize, Serialize, Clone, Debug)]
+#[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
+#[non_exhaustive]
+pub struct GetStreamKeyRequest<'a> {
+    /// The ID of the broadcaster that owns the channel. The ID must match the user ID in the access token.
+    #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
+    #[cfg_attr(feature = "deser_borrow", serde(borrow = "'a"))]
+    pub broadcaster_id: Cow<'a, types::UserIdRef>,
+}
+
+impl<'a> GetStreamKeyRequest<'a> {
+    /// ID of the broadcaster whose stream key should be retrieved
+    pub fn broadcaster_id(broadcaster_id: impl types::IntoCow<'a, types::UserIdRef> + 'a) -> Self {
+        Self {
+            broadcaster_id: broadcaster_id.into_cow(),
+        }
+    }
+}
+
+/// Return Values for [Get Stream Key](super::get_stream_key)
+///
+/// [`get-stream-key`](https://dev.twitch.tv/docs/api/reference#get-stream-key)
+#[derive(PartialEq, Eq, Deserialize, Debug, Clone)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[non_exhaustive]
+pub struct GetStreamKeyResponse {
+    /// The channel’s stream key.
+    pub stream_key: types::StreamKey,
+}
+
+impl Request for GetStreamKeyRequest<'_> {
+    type Response = GetStreamKeyResponse;
+
+    const PATH: &'static str = "streams/key";
+    #[cfg(feature = "twitch_oauth2")]
+    const SCOPE: twitch_oauth2::Validator =
+        twitch_oauth2::validator![twitch_oauth2::Scope::ChannelReadStreamKey];
+}
+
+impl RequestGet for GetStreamKeyRequest<'_> {
+    fn parse_inner_response(
+        request: Option<Self>,
+        uri: &http::Uri,
+        response: &str,
+        status: http::StatusCode,
+    ) -> Result<helix::Response<Self, <Self as Request>::Response>, helix::HelixRequestGetError>
+    where
+        Self: Sized,
+    {
+        helix::parse_single_return(request, uri, response, status)
+    }
+}
+
+#[cfg(test)]
+#[test]
+fn test_request() {
+    use helix::*;
+    let req = GetStreamKeyRequest::broadcaster_id("198704263");
+
+    // From twitch docs
+    let data = br#"
+        {
+          "data": [
+            {
+              "stream_key": "live_44322889_a34ub37c8ajv98a0"
+            }
+          ]
+        }
+    "#
+    .to_vec();
+
+    let http_response = http::Response::builder().body(data).unwrap();
+
+    let uri = req.get_uri().unwrap();
+    assert_eq!(
+        uri.to_string(),
+        "https://api.twitch.tv/helix/streams/key?broadcaster_id=198704263"
+    );
+
+    let res = GetStreamKeyRequest::parse_response(Some(req), &uri, http_response)
+        .unwrap()
+        .data;
+
+    assert_eq!(res.stream_key.as_str(), "live_44322889_a34ub37c8ajv98a0");
+}

--- a/src/helix/endpoints/streams/get_stream_markers.rs
+++ b/src/helix/endpoints/streams/get_stream_markers.rs
@@ -1,0 +1,233 @@
+//! Gets a list of markers from the user’s most recent stream or from the specified VOD/video.
+//! [`get-stream-markers`](https://dev.twitch.tv/docs/api/reference#get-stream-markers)
+//!
+//! A marker is an arbitrary point in a live stream that the broadcaster or editor marked, so they can return to that spot later to create video highlights (see Video Producer, Highlights in the Twitch UX).
+//!
+//! # Accessing the endpoint
+//!
+//! ## Notes
+//!
+//! See also [`HelixClient::get_stream_markers_from_video`](crate::helix::HelixClient::get_stream_markers_from_video).
+//!
+//! ## Request: [GetStreamMarkersRequest]
+//!
+//! To use this endpoint, construct a [`GetStreamMarkersRequest`] with the [`GetStreamMarkersRequest::video_id()`], or [`GetStreamMarkersRequest::user_id()`] method.
+//!
+//! ```rust
+//! use twitch_api::helix::streams::get_stream_markers;
+//! let request = get_stream_markers::GetStreamMarkersRequest::video_id("1234");
+//! ```
+//!
+//! ## Response: [StreamMarkerGroup]
+//!
+//! Send the request to receive the response with [`HelixClient::req_get()`](helix::HelixClient::req_get).
+//!
+//! ```rust, no_run
+//! use twitch_api::helix::{self, streams::get_stream_markers};
+//! # use twitch_api::{client, types};
+//! # #[tokio::main]
+//! # async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync + 'static>> {
+//! let client: helix::HelixClient<'static, client::DummyHttpClient> =
+//!     helix::HelixClient::default();
+//! # let token = twitch_oauth2::AccessToken::new("validtoken".to_string());
+//! # let token = twitch_oauth2::UserToken::from_existing(&client, token, None, None).await?;
+//! let request = get_stream_markers::GetStreamMarkersRequest::video_id("1234");
+//! let response: Vec<helix::streams::StreamMarkerGroup> = client.req_get(request, &token).await?.data;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! You can also get the [`http::Request`] with [`request.create_request(&token, &client_id)`](helix::RequestGet::create_request)
+//! and parse the [`http::Response`] with [`GetStreamMarkersRequest::parse_response(None, &request.get_uri(), response)`](GetStreamMarkersRequest::parse_response)
+
+use super::*;
+use helix::RequestGet;
+
+/// Query Parameters for [Get Stream Markers](super::get_stream_markers)
+///
+/// [`get-stream-markers`](https://dev.twitch.tv/docs/api/reference#get-stream-markers)
+#[derive(PartialEq, Deserialize, Serialize, Clone, Debug)]
+#[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
+#[must_use]
+#[non_exhaustive]
+pub struct GetStreamMarkersRequest<'a> {
+    /// A user ID. The request returns the markers from this user’s most recent video. This ID must match the user ID in the access token or the user in the access token must be one of the broadcaster’s editors.
+    ///
+    /// This parameter and the `video_id`` query parameter are mutually exclusive.
+    #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
+    #[cfg_attr(feature = "deser_borrow", serde(borrow = "'a"))]
+    pub user_id: Option<Cow<'a, types::UserIdRef>>,
+    /// A video on demand (VOD)/video ID. The request returns the markers from this VOD/video. The user in the access token must own the video or the user must be one of the broadcaster’s editors.
+    ///
+    /// This parameter and the user_id query parameter are mutually exclusive.
+    #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
+    #[cfg_attr(feature = "deser_borrow", serde(borrow = "'a"))]
+    pub video_id: Option<Cow<'a, types::VideoIdRef>>,
+    /// Cursor for forward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
+    #[cfg_attr(feature = "typed-builder", builder(default))]
+    #[cfg_attr(feature = "deser_borrow", serde(borrow = "'a"))]
+    pub after: Option<Cow<'a, helix::CursorRef>>,
+    /// Cursor for backward pagination: tells the server where to start fetching the next set of results, in a multi-page response. The cursor value specified here is from the pagination response field of a prior query.
+    #[cfg_attr(feature = "typed-builder", builder(default))]
+    #[cfg_attr(feature = "deser_borrow", serde(borrow = "'a"))]
+    pub before: Option<Cow<'a, helix::CursorRef>>,
+    /// Maximum number of objects to return. Maximum: 100. Default: 20.
+    #[cfg_attr(feature = "typed-builder", builder(default, setter(into)))]
+    pub first: Option<usize>,
+}
+
+impl<'a> GetStreamMarkersRequest<'a> {
+    /// Return stream markers from the most recent video of the specified user.
+    pub fn user_id(user_id: impl types::IntoCow<'a, types::UserIdRef> + 'a) -> Self {
+        Self {
+            user_id: Some(user_id.into_cow()),
+            video_id: None,
+            after: None,
+            before: None,
+            first: None,
+        }
+    }
+
+    /// Return stream markers for a specific video.
+    pub fn video_id(video_id: impl types::IntoCow<'a, types::VideoIdRef> + 'a) -> Self {
+        Self {
+            user_id: None,
+            video_id: Some(video_id.into_cow()),
+            after: None,
+            before: None,
+            first: None,
+        }
+    }
+
+    /// Set amount of results returned per page.
+    pub fn first(mut self, first: usize) -> Self {
+        self.first = Some(first);
+        self
+    }
+}
+
+/// Return Values for [Get Stream Markers](super::get_stream_markers)
+///
+/// [`get-stream-markers`](https://dev.twitch.tv/docs/api/reference#get-stream-markers)
+#[derive(PartialEq, Eq, Deserialize, Serialize, Debug, Clone)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[non_exhaustive]
+pub struct StreamMarkerGroup {
+    /// The ID of the user that created the marker.
+    pub user_id: types::UserId,
+    /// The user’s display name.
+    pub user_name: types::DisplayName,
+    /// The user’s login name.
+    pub user_login: types::UserName,
+    /// A list of videos that contain markers. The list contains a single video.
+    pub videos: Vec<StreamMarkerVideo>,
+}
+
+/// A video with markers
+#[derive(PartialEq, Eq, Deserialize, Serialize, Debug, Clone)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[non_exhaustive]
+pub struct StreamMarkerVideo {
+    /// An ID that identifies this video.
+    pub video_id: types::VideoId,
+    /// The list of markers in this video. The list in ascending order by when the marker was created.
+    pub markers: Vec<StreamMarker>,
+}
+
+/// A marker on a video
+#[derive(PartialEq, Eq, Deserialize, Serialize, Debug, Clone)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[non_exhaustive]
+pub struct StreamMarker {
+    /// An ID that identifies this marker.
+    pub id: types::StreamMarkerId,
+    /// The UTC date and time (in RFC3339 format) of when the user created the marker.
+    pub created_at: types::Timestamp,
+    /// The relative offset (in seconds) of the marker from the beginning of the stream.
+    pub position_seconds: u64,
+    /// The description that the user gave the marker to help them remember why they marked the location. Is an empty string if the user didn’t provide one.
+    pub description: String,
+    /// A URL that opens the video in Twitch Highlighter.
+    pub url: String,
+}
+
+impl Request for GetStreamMarkersRequest<'_> {
+    type Response = Vec<StreamMarkerGroup>;
+
+    const PATH: &'static str = "streams/markers";
+    #[cfg(feature = "twitch_oauth2")]
+    const SCOPE: twitch_oauth2::Validator = twitch_oauth2::validator![any(
+        twitch_oauth2::Scope::UserReadBroadcast,
+        twitch_oauth2::Scope::ChannelManageBroadcast,
+    )];
+}
+
+impl RequestGet for GetStreamMarkersRequest<'_> {}
+
+impl helix::Paginated for GetStreamMarkersRequest<'_> {
+    fn set_pagination(&mut self, cursor: Option<helix::Cursor>) {
+        self.after = cursor.map(|c| c.into_cow())
+    }
+}
+
+#[cfg(test)]
+#[test]
+fn test_request() {
+    use helix::*;
+    let req = GetStreamMarkersRequest::user_id("123").first(5);
+
+    // From twitch docs (except 'URL' is 'url' here)
+    let data = r#"
+    {
+      "data": [
+        {
+          "user_id": "123",
+          "user_name": "TwitchName",
+          "user_login": "twitchname",
+          "videos": [
+            {
+              "video_id": "456",
+              "markers": [
+                {
+                  "id": "106b8d6243a4f883d25ad75e6cdffdc4",
+                  "created_at": "2018-08-20T20:10:03Z",
+                  "description": "hello, this is a marker!",
+                  "position_seconds": 244,
+                  "url": "https://twitch.tv/twitchname/manager/highlighter/456?t=0h4m06s"
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "pagination": {
+        "cursor": "eyJiIjpudWxsLCJhIjoiMjk1MjA0Mzk3OjI1Mzpib29rbWFyazoxMDZiOGQ1Y"
+      }
+    }
+    "#
+    .as_bytes()
+    .to_vec();
+
+    let http_response = http::Response::builder().body(data).unwrap();
+
+    let uri = req.get_uri().unwrap();
+    assert_eq!(
+        uri.to_string(),
+        "https://api.twitch.tv/helix/streams/markers?user_id=123&first=5"
+    );
+
+    let res = GetStreamMarkersRequest::parse_response(Some(req), &uri, http_response)
+        .unwrap()
+        .data;
+
+    assert_eq!(res.len(), 1);
+    assert_eq!(res[0].user_name.as_str(), "TwitchName");
+    assert_eq!(res[0].videos.len(), 1);
+    assert_eq!(res[0].videos[0].video_id.as_str(), "456");
+    assert_eq!(res[0].videos[0].markers.len(), 1);
+    assert_eq!(res[0].videos[0].markers[0].position_seconds, 244);
+    assert_eq!(
+        res[0].videos[0].markers[0].url,
+        "https://twitch.tv/twitchname/manager/highlighter/456?t=0h4m06s"
+    );
+}

--- a/src/helix/endpoints/streams/mod.rs
+++ b/src/helix/endpoints/streams/mod.rs
@@ -28,7 +28,7 @@
 //!
 //! <!-- generate with "cargo xtask overview" (with a nightly toolchain) -->
 //! <!-- BEGIN-OVERVIEW -->
-//! <details open><summary style="cursor: pointer">Streams 🟡 4/5</summary>
+//! <details open><summary style="cursor: pointer">Streams 🟢 5/5</summary>
 //!
 //! | Endpoint | Helper | Module |
 //! |---|---|---|
@@ -36,7 +36,7 @@
 //! | [Get Streams](https://dev.twitch.tv/docs/api/reference#get-streams) | [`HelixClient::get_streams_from_ids`](crate::helix::HelixClient::get_streams_from_ids), [`HelixClient::get_streams_from_logins`](crate::helix::HelixClient::get_streams_from_logins) | [`get_streams`] |
 //! | [Get Followed Streams](https://dev.twitch.tv/docs/api/reference#get-followed-streams) | [`HelixClient::get_followed_streams`](crate::helix::HelixClient::get_followed_streams) | [`get_followed_streams`] |
 //! | [Create Stream Marker](https://dev.twitch.tv/docs/api/reference#create-stream-marker) | [`HelixClient::create_stream_marker`](crate::helix::HelixClient::create_stream_marker) | [`create_stream_marker`] |
-//! | [Get Stream Markers](https://dev.twitch.tv/docs/api/reference#get-stream-markers) | - | - |
+//! | [Get Stream Markers](https://dev.twitch.tv/docs/api/reference#get-stream-markers) | - | [`get_stream_markers`] |
 //!
 //! </details>
 //!
@@ -57,6 +57,10 @@ pub use get_followed_streams::GetFollowedStreamsRequest;
 #[doc(inline)]
 pub use get_stream_key::{GetStreamKeyRequest, GetStreamKeyResponse};
 #[doc(inline)]
+pub use get_stream_markers::{
+    GetStreamMarkersRequest, StreamMarker, StreamMarkerGroup, StreamMarkerVideo,
+};
+#[doc(inline)]
 #[allow(deprecated)]
 pub use get_stream_tags::{GetStreamTagsRequest, Tag};
 #[doc(inline)]
@@ -68,6 +72,7 @@ pub use replace_stream_tags::{ReplaceStreamTags, ReplaceStreamTagsBody, ReplaceS
 pub mod create_stream_marker;
 pub mod get_followed_streams;
 pub mod get_stream_key;
+pub mod get_stream_markers;
 pub mod get_stream_tags;
 pub mod get_streams;
 pub mod replace_stream_tags;

--- a/src/helix/endpoints/streams/mod.rs
+++ b/src/helix/endpoints/streams/mod.rs
@@ -28,14 +28,14 @@
 //!
 //! <!-- generate with "cargo xtask overview" (with a nightly toolchain) -->
 //! <!-- BEGIN-OVERVIEW -->
-//! <details open><summary style="cursor: pointer">Streams 🟡 3/5</summary>
+//! <details open><summary style="cursor: pointer">Streams 🟡 4/5</summary>
 //!
 //! | Endpoint | Helper | Module |
 //! |---|---|---|
 //! | [Get Stream Key](https://dev.twitch.tv/docs/api/reference#get-stream-key) | [`HelixClient::get_stream_key`](crate::helix::HelixClient::get_stream_key) | [`get_stream_key`] |
 //! | [Get Streams](https://dev.twitch.tv/docs/api/reference#get-streams) | [`HelixClient::get_streams_from_ids`](crate::helix::HelixClient::get_streams_from_ids), [`HelixClient::get_streams_from_logins`](crate::helix::HelixClient::get_streams_from_logins) | [`get_streams`] |
 //! | [Get Followed Streams](https://dev.twitch.tv/docs/api/reference#get-followed-streams) | [`HelixClient::get_followed_streams`](crate::helix::HelixClient::get_followed_streams) | [`get_followed_streams`] |
-//! | [Create Stream Marker](https://dev.twitch.tv/docs/api/reference#create-stream-marker) | - | - |
+//! | [Create Stream Marker](https://dev.twitch.tv/docs/api/reference#create-stream-marker) | [`HelixClient::create_stream_marker`](crate::helix::HelixClient::create_stream_marker) | [`create_stream_marker`] |
 //! | [Get Stream Markers](https://dev.twitch.tv/docs/api/reference#get-stream-markers) | - | - |
 //!
 //! </details>
@@ -49,6 +49,10 @@ use serde_derive::{Deserialize, Serialize};
 use std::borrow::Cow;
 
 #[doc(inline)]
+pub use create_stream_marker::{
+    CreateStreamMarkerBody, CreateStreamMarkerRequest, CreatedStreamMarker,
+};
+#[doc(inline)]
 pub use get_followed_streams::GetFollowedStreamsRequest;
 #[doc(inline)]
 pub use get_stream_key::{GetStreamKeyRequest, GetStreamKeyResponse};
@@ -61,6 +65,7 @@ pub use get_streams::{GetStreamsRequest, Stream};
 #[allow(deprecated)]
 pub use replace_stream_tags::{ReplaceStreamTags, ReplaceStreamTagsBody, ReplaceStreamTagsRequest};
 
+pub mod create_stream_marker;
 pub mod get_followed_streams;
 pub mod get_stream_key;
 pub mod get_stream_tags;

--- a/src/helix/endpoints/streams/mod.rs
+++ b/src/helix/endpoints/streams/mod.rs
@@ -28,11 +28,11 @@
 //!
 //! <!-- generate with "cargo xtask overview" (with a nightly toolchain) -->
 //! <!-- BEGIN-OVERVIEW -->
-//! <details open><summary style="cursor: pointer">Streams 🟡 2/5</summary>
+//! <details open><summary style="cursor: pointer">Streams 🟡 3/5</summary>
 //!
 //! | Endpoint | Helper | Module |
 //! |---|---|---|
-//! | [Get Stream Key](https://dev.twitch.tv/docs/api/reference#get-stream-key) | - | - |
+//! | [Get Stream Key](https://dev.twitch.tv/docs/api/reference#get-stream-key) | [`HelixClient::get_stream_key`](crate::helix::HelixClient::get_stream_key) | [`get_stream_key`] |
 //! | [Get Streams](https://dev.twitch.tv/docs/api/reference#get-streams) | [`HelixClient::get_streams_from_ids`](crate::helix::HelixClient::get_streams_from_ids), [`HelixClient::get_streams_from_logins`](crate::helix::HelixClient::get_streams_from_logins) | [`get_streams`] |
 //! | [Get Followed Streams](https://dev.twitch.tv/docs/api/reference#get-followed-streams) | [`HelixClient::get_followed_streams`](crate::helix::HelixClient::get_followed_streams) | [`get_followed_streams`] |
 //! | [Create Stream Marker](https://dev.twitch.tv/docs/api/reference#create-stream-marker) | - | - |
@@ -51,6 +51,8 @@ use std::borrow::Cow;
 #[doc(inline)]
 pub use get_followed_streams::GetFollowedStreamsRequest;
 #[doc(inline)]
+pub use get_stream_key::{GetStreamKeyRequest, GetStreamKeyResponse};
+#[doc(inline)]
 #[allow(deprecated)]
 pub use get_stream_tags::{GetStreamTagsRequest, Tag};
 #[doc(inline)]
@@ -60,6 +62,7 @@ pub use get_streams::{GetStreamsRequest, Stream};
 pub use replace_stream_tags::{ReplaceStreamTags, ReplaceStreamTagsBody, ReplaceStreamTagsRequest};
 
 pub mod get_followed_streams;
+pub mod get_stream_key;
 pub mod get_stream_tags;
 pub mod get_streams;
 pub mod replace_stream_tags;

--- a/src/helix/mod.rs
+++ b/src/helix/mod.rs
@@ -312,14 +312,14 @@
 //!
 //! </details>
 //!
-//! <details><summary style="cursor: pointer">Streams 🟡 3/5</summary>
+//! <details><summary style="cursor: pointer">Streams 🟡 4/5</summary>
 //!
 //! | Endpoint | Helper | Module |
 //! |---|---|---|
 //! | [Get Stream Key](https://dev.twitch.tv/docs/api/reference#get-stream-key) | [`HelixClient::get_stream_key`] | [`streams::get_stream_key`] |
 //! | [Get Streams](https://dev.twitch.tv/docs/api/reference#get-streams) | [`HelixClient::get_streams_from_ids`], [`HelixClient::get_streams_from_logins`] | [`streams::get_streams`] |
 //! | [Get Followed Streams](https://dev.twitch.tv/docs/api/reference#get-followed-streams) | [`HelixClient::get_followed_streams`] | [`streams::get_followed_streams`] |
-//! | [Create Stream Marker](https://dev.twitch.tv/docs/api/reference#create-stream-marker) | - | - |
+//! | [Create Stream Marker](https://dev.twitch.tv/docs/api/reference#create-stream-marker) | [`HelixClient::create_stream_marker`] | [`streams::create_stream_marker`] |
 //! | [Get Stream Markers](https://dev.twitch.tv/docs/api/reference#get-stream-markers) | - | - |
 //!
 //! </details>

--- a/src/helix/mod.rs
+++ b/src/helix/mod.rs
@@ -312,7 +312,7 @@
 //!
 //! </details>
 //!
-//! <details><summary style="cursor: pointer">Streams 🟡 4/5</summary>
+//! <details><summary style="cursor: pointer">Streams 🟢 5/5</summary>
 //!
 //! | Endpoint | Helper | Module |
 //! |---|---|---|
@@ -320,7 +320,7 @@
 //! | [Get Streams](https://dev.twitch.tv/docs/api/reference#get-streams) | [`HelixClient::get_streams_from_ids`], [`HelixClient::get_streams_from_logins`] | [`streams::get_streams`] |
 //! | [Get Followed Streams](https://dev.twitch.tv/docs/api/reference#get-followed-streams) | [`HelixClient::get_followed_streams`] | [`streams::get_followed_streams`] |
 //! | [Create Stream Marker](https://dev.twitch.tv/docs/api/reference#create-stream-marker) | [`HelixClient::create_stream_marker`] | [`streams::create_stream_marker`] |
-//! | [Get Stream Markers](https://dev.twitch.tv/docs/api/reference#get-stream-markers) | - | - |
+//! | [Get Stream Markers](https://dev.twitch.tv/docs/api/reference#get-stream-markers) | - | [`streams::get_stream_markers`] |
 //!
 //! </details>
 //!

--- a/src/helix/mod.rs
+++ b/src/helix/mod.rs
@@ -312,11 +312,11 @@
 //!
 //! </details>
 //!
-//! <details><summary style="cursor: pointer">Streams 🟡 2/5</summary>
+//! <details><summary style="cursor: pointer">Streams 🟡 3/5</summary>
 //!
 //! | Endpoint | Helper | Module |
 //! |---|---|---|
-//! | [Get Stream Key](https://dev.twitch.tv/docs/api/reference#get-stream-key) | - | - |
+//! | [Get Stream Key](https://dev.twitch.tv/docs/api/reference#get-stream-key) | [`HelixClient::get_stream_key`] | [`streams::get_stream_key`] |
 //! | [Get Streams](https://dev.twitch.tv/docs/api/reference#get-streams) | [`HelixClient::get_streams_from_ids`], [`HelixClient::get_streams_from_logins`] | [`streams::get_streams`] |
 //! | [Get Followed Streams](https://dev.twitch.tv/docs/api/reference#get-followed-streams) | [`HelixClient::get_followed_streams`] | [`streams::get_followed_streams`] |
 //! | [Create Stream Marker](https://dev.twitch.tv/docs/api/reference#create-stream-marker) | - | - |


### PR DESCRIPTION
Adds

- [`Get Stream Key`](https://dev.twitch.tv/docs/api/reference/#get-stream-key)
- [`Create Stream Marker`](https://dev.twitch.tv/docs/api/reference/#create-stream-marker)
- [`Get Stream Markers`](https://dev.twitch.tv/docs/api/reference/#get-stream-markers)

The markers returned by the endpoints are different (according to the docs). `Get Stream Markers` returns a marker with a `url`, but `Create Stream Marker` doesn't include that URL.