### PR TITLE
feat(eventsub): add more automod related events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -97,7 +97,7 @@ checksum = "d1eb7c4fcde1858a6796c18a729b661346d38e05a207e2d9028bce822fc20283"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -191,7 +191,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.48",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -385,7 +385,7 @@ checksum = "c980ee35e870bd1a4d2c8294d4c04d0499e67bca1e4b5cefcc693c2fa00caea9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -631,7 +631,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -860,7 +860,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1069,9 +1069,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1079,9 +1079,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
+checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
 
 [[package]]
 name = "futures-executor"
@@ -1096,9 +1096,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
@@ -1130,32 +1130,32 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.58",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
 name = "futures-util"
-version = "0.3.30"
+version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1821,7 +1821,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1883,7 +1883,7 @@ checksum = "266c042b60c9c76b8d53061e52b2e0d1116abc57cefc8c5cd671619a56ac3690"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -2370,7 +2370,7 @@ checksum = "33c85360c95e7d137454dc81d9a4ed2b8efd8fbe19cee57357b32b9771fccb67"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -2650,9 +2650,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.48"
+version = "2.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f3531638e407dfc0814761abb7c00a5b54992b849452a0646b7f65c9f770f3f"
+checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2722,7 +2722,7 @@ checksum = "fa0faa943b50f3db30a20aa7e265dbc66076993efed8463e8de414e5d06d3471"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -2849,7 +2849,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -3038,7 +3038,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -3240,7 +3240,7 @@ checksum = "560b82d656506509d43abe30e0ba64c56b1953ab3d4fe7ba5902747a7a3cedd5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -3406,7 +3406,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.58",
  "wasm-bindgen-shared",
 ]
 
@@ -3440,7 +3440,7 @@ checksum = "bae1abb6806dc1ad9e560ed242107c0f6c84335f1749dd4e8ddb012ebd5e25a7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.48",
+ "syn 2.0.58",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,6 +124,7 @@ eventsub = [
     "twitch_types/emote",
     "twitch_types/eventsub",
     "twitch_types/goal",
+    "twitch_types/moderation",
     "twitch_types/points",
     "twitch_types/stream",
     "twitch_types/timestamp",

--- a/deny.toml
+++ b/deny.toml
@@ -28,7 +28,11 @@ ignore = [
   # https://rustsec.org/advisories/RUSTSEC-2021-0060
   # `aes-soft` has been merged into the `aes` crate
   # Dependent on via surf (and http-types)
-  "RUSTSEC-2021-0060"
+  "RUSTSEC-2021-0060",
+  # https://rustsec.org/advisories/RUSTSEC-2024-0384
+  # `instant` is unmaintained
+  # Dependent on via surf (and http-types)
+  "RUSTSEC-2024-0384",
 ]
 
 # This section is considered when running `cargo deny check licenses`
@@ -39,14 +43,14 @@ ignore = [
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.7 short identifier (+ optional exception)].
 allow = [
-    "MIT",
-    "Apache-2.0",
-    "Apache-2.0 WITH LLVM-exception",
-    "BSD-3-Clause",
-    "MPL-2.0", # Considered fair
-    "ISC",
-    "OpenSSL",
-    "Unicode-DFS-2016",
+  "MIT",
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "BSD-3-Clause",
+  "MPL-2.0",                        # Considered fair
+  "ISC",
+  "OpenSSL",
+  "Unicode-DFS-2016",
 ]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the
@@ -56,9 +60,9 @@ confidence-threshold = 0.8
 # Allow 1 or more licenses on a per-crate basis, so that particular licenses
 # aren't accepted for every possible crate as with the normal allow list
 exceptions = [
-    # Each entry is the crate and version constraint, and its specific allow
-    # list
-    #{ allow = ["Zlib"], name = "adler32", version = "*" },
+  # Each entry is the crate and version constraint, and its specific allow
+  # list
+  #{ allow = ["Zlib"], name = "adler32", version = "*" },
 ]
 
 # Some crates don't have (easily) machine readable licensing information,
@@ -77,8 +81,8 @@ expression = "MIT AND ISC AND OpenSSL"
 # and the crate will be checked normally, which may produce warnings or errors
 # depending on the rest of your configuration
 license-files = [
-    # Each entry is a crate relative path, and the (opaque) hash of its contents
-    { path = "LICENSE", hash = 0xbd0eed23 },
+  # Each entry is a crate relative path, and the (opaque) hash of its contents
+  { path = "LICENSE", hash = 0xbd0eed23 },
 ]
 
 [licenses.private]
@@ -89,7 +93,7 @@ ignore = true
 # is only published to private registries, and ignore is true, the crate will
 # not have its license(s) checked
 registries = [
-    #"https://sekretz.com/registry
+  #"https://sekretz.com/registry
 ]
 
 # This section is considered when running `cargo deny check bans`.
@@ -108,28 +112,28 @@ wildcards = "deny"
 highlight = "all"
 # List of crates that are allowed. Use with care!
 allow = [
-    #{ name = "ansi_term", version = "=0.11.0" },
+  #{ name = "ansi_term", version = "=0.11.0" },
 ]
 # List of crates to deny
 deny = [
-    # Each entry the name of a crate and a version range. If version is
-    # not specified, all versions will be matched.
-    #{ name = "ansi_term", version = "=0.11.0" },
-    #
-    # Wrapper crates can optionally be specified to allow the crate when it
-    # is a direct dependency of the otherwise banned crate
-    #{ name = "ansi_term", version = "=0.11.0", wrappers = [] },
+  # Each entry the name of a crate and a version range. If version is
+  # not specified, all versions will be matched.
+  #{ name = "ansi_term", version = "=0.11.0" },
+  #
+  # Wrapper crates can optionally be specified to allow the crate when it
+  # is a direct dependency of the otherwise banned crate
+  #{ name = "ansi_term", version = "=0.11.0", wrappers = [] },
 ]
 # Certain crates/versions that will be skipped when doing duplicate detection.
 skip = [
-    #{ name = "ansi_term", version = "=0.11.0" },
+  #{ name = "ansi_term", version = "=0.11.0" },
 ]
 # Similarly to `skip` allows you to skip certain crates during duplicate
 # detection. Unlike skip, it also includes the entire tree of transitive
 # dependencies starting at the specified crate, up to a certain depth, which is
 # by default infinite
 skip-tree = [
-    #{ name = "ansi_term", version = "=0.11.0", depth = 20 },
+  #{ name = "ansi_term", version = "=0.11.0", depth = 20 },
 ]
 
 # This section is considered when running `cargo deny check sources`.

--- a/src/eventsub/automod/message/hold.rs
+++ b/src/eventsub/automod/message/hold.rs
@@ -59,7 +59,7 @@ pub struct AutomodMessageHoldV1Payload {
     /// The ID of the message that was flagged by automod.
     pub message_id: types::MsgId,
     /// The body of the message.
-    pub message: crate::eventsub::channel::chat::Message,
+    pub message: AutomodMessage,
     /// The category of the message.
     pub category: super::AutomodCategory,
     /// The level of severity. Measured between 1 to 4.

--- a/src/eventsub/automod/message/hold.rs
+++ b/src/eventsub/automod/message/hold.rs
@@ -70,7 +70,7 @@ pub struct AutomodMessageHoldV1Payload {
 
 #[cfg(test)]
 #[test]
-fn parse_payload() {
+fn parse_payload_v1() {
     use crate::eventsub::{Event, Message};
 
     let payload = r##"
@@ -131,4 +131,310 @@ fn parse_payload() {
     assert_eq!(notif.category, AutomodCategory::Sexwords);
     assert_eq!(notif.level, 4);
     assert_eq!(notif.message.fragments.len(), 1);
+}
+
+/// [`automod.message.hold`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#automodmessagehold-v2): a message was caught by automod for review.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[non_exhaustive]
+#[cfg(feature = "beta")]
+pub struct AutomodMessageHoldBeta {
+    /// User ID of the broadcaster (channel).
+    #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
+    pub broadcaster_user_id: types::UserId,
+    /// User ID of the moderator.
+    #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
+    pub moderator_user_id: types::UserId,
+}
+
+#[cfg(feature = "beta")]
+impl AutomodMessageHoldBeta {
+    /// Get automod hold notifications for this channel as a moderator
+    pub fn new(
+        broadcaster_user_id: impl Into<types::UserId>,
+        moderator_user_id: impl Into<types::UserId>,
+    ) -> Self {
+        Self {
+            broadcaster_user_id: broadcaster_user_id.into(),
+            moderator_user_id: moderator_user_id.into(),
+        }
+    }
+}
+
+#[cfg(feature = "beta")]
+impl EventSubscription for AutomodMessageHoldBeta {
+    type Payload = AutomodMessageHoldBetaPayload;
+
+    const EVENT_TYPE: EventType = EventType::AutomodMessageHold;
+    #[cfg(feature = "twitch_oauth2")]
+    const SCOPE: twitch_oauth2::Validator =
+        twitch_oauth2::validator![twitch_oauth2::Scope::ModeratorManageAutoMod];
+    const VERSION: &'static str = "beta";
+}
+
+/// [`automod.message.hold`](AutomodMessageHoldBeta) response payload.
+// XXX: this struct can't be deny-unknown-fields because of the flattened reason
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+#[cfg(feature = "beta")]
+pub struct AutomodMessageHoldBetaPayload {
+    /// The ID of the broadcaster specified in the request.
+    pub broadcaster_user_id: types::UserId,
+    /// The login of the broadcaster specified in the request.
+    pub broadcaster_user_login: types::UserName,
+    /// The user name of the broadcaster specified in the request.
+    pub broadcaster_user_name: types::DisplayName,
+    /// The message sender’s user ID.
+    pub user_id: types::UserId,
+    /// The message sender’s login name.
+    pub user_login: types::UserName,
+    /// The message sender’s display name.
+    pub user_name: types::DisplayName,
+    /// The ID of the message that was flagged by automod.
+    pub message_id: types::MsgId,
+    /// The body of the message.
+    pub message: AutomodMessage,
+    /// The reason why a message was held
+    #[serde(flatten)]
+    pub reason: AutomodHeldReason,
+    /// The timestamp of when automod saved the message.
+    pub held_at: types::Timestamp,
+}
+
+#[cfg(all(test, feature = "beta"))]
+#[test]
+fn parse_payload_v2_automod() {
+    use crate::eventsub::{Event, Message};
+
+    let payload = r##"
+    {
+        "subscription": {
+            "id": "85c8dcb0-7af4-4581-b684-32087d386384",
+            "status": "enabled",
+            "type": "automod.message.hold",
+            "version": "beta",
+            "condition": {
+                "broadcaster_user_id": "129546453",
+                "moderator_user_id": "129546453"
+            },
+            "transport": {
+                "method": "websocket",
+                "session_id": "AgoQREw4FYBWQ5quz4J-S4VYkRIGY2VsbC1j"
+            },
+            "created_at": "2024-11-18T16:36:08.691979783Z",
+            "cost": 0
+        },
+        "event": {
+            "broadcaster_user_id": "129546453",
+            "broadcaster_user_login": "nerixyz",
+            "broadcaster_user_name": "nerixyz",
+            "user_id": "489584266",
+            "user_login": "uint128",
+            "user_name": "uint128",
+            "message_id": "78ccd959-3e7e-4f8d-bd8b-f92c359b0a7d",
+            "message": {
+                "text": "😂 ass",
+                "fragments": [
+                    {
+                        "type": "text",
+                        "text": "😂 ",
+                        "cheermote": null,
+                        "emote": null
+                    },
+                    {
+                        "type": "text",
+                        "text": "ass",
+                        "cheermote": null,
+                        "emote": null
+                    }
+                ]
+            },
+            "reason": "automod",
+            "automod": {
+                "category": "swearing",
+                "level": 4,
+                "boundaries": [
+                    {
+                        "start_pos": 2,
+                        "end_pos": 4
+                    }
+                ]
+            },
+            "blocked_term": null,
+            "held_at": "2024-11-18T16:59:46.323937273Z"
+        }
+    }
+    "##;
+
+    let val = Event::parse(payload).unwrap();
+    crate::tests::roundtrip(&val);
+
+    let Event::AutomodMessageHoldBeta(val) = val else {
+        panic!("invalid event type");
+    };
+    let Message::Notification(notif) = val.message else {
+        panic!("invalid message type");
+    };
+
+    assert_eq!(notif.broadcaster_user_id.as_str(), "129546453");
+    assert_eq!(notif.message.fragments.len(), 2);
+
+    let AutomodHeldReason::Automod { automod } = &notif.reason else {
+        panic!("invalid held reason");
+    };
+    assert_eq!(
+        automod.category,
+        AutomodCategory::Unknown("swearing".to_string())
+    );
+    assert_eq!(automod.level, 4);
+    assert_eq!(
+        automod.boundaries,
+        &[AutomodMessageBoundary {
+            start_pos: 2,
+            end_pos: 4
+        }]
+    );
+}
+
+#[cfg(all(test, feature = "beta"))]
+#[test]
+fn parse_payload_v2_blocked_term() {
+    use crate::eventsub::{Event, Message};
+
+    let payload = r##"
+    {
+        "subscription": {
+            "id": "85c8dcb0-7af4-4581-b684-32087d386384",
+            "status": "enabled",
+            "type": "automod.message.hold",
+            "version": "beta",
+            "condition": {
+                "broadcaster_user_id": "129546453",
+                "moderator_user_id": "129546453"
+            },
+            "transport": {
+                "method": "websocket",
+                "session_id": "AgoQREw4FYBWQ5quz4J-S4VYkRIGY2VsbC1j"
+            },
+            "created_at": "2024-11-18T16:36:08.691979783Z",
+            "cost": 0
+        },
+        "event": {
+            "broadcaster_user_id": "129546453",
+            "broadcaster_user_login": "nerixyz",
+            "broadcaster_user_name": "nerixyz",
+            "user_id": "489584266",
+            "user_login": "uint128",
+            "user_name": "uint128",
+            "message_id": "dcfc6b48-0fd1-446c-8cf5-d1810bb55b73",
+            "message": {
+                "text": "boobs Kappa 😂😂 foo private",
+                "fragments": [
+                    {
+                        "type": "text",
+                        "text": "boobs",
+                        "cheermote": null,
+                        "emote": null
+                    },
+                    {
+                        "type": "text",
+                        "text": " ",
+                        "cheermote": null,
+                        "emote": null
+                    },
+                    {
+                        "type": "emote",
+                        "text": "Kappa",
+                        "cheermote": null,
+                        "emote": {
+                            "id": "25",
+                            "emote_set_id": "0"
+                        }
+                    },
+                    {
+                        "type": "text",
+                        "text": " 😂😂 ",
+                        "cheermote": null,
+                        "emote": null
+                    },
+                    {
+                        "type": "text",
+                        "text": "foo",
+                        "cheermote": null,
+                        "emote": null
+                    },
+                    {
+                        "type": "text",
+                        "text": " ",
+                        "cheermote": null,
+                        "emote": null
+                    },
+                    {
+                        "type": "text",
+                        "text": "private",
+                        "cheermote": null,
+                        "emote": null
+                    }
+                ]
+            },
+            "reason": "blocked_term",
+            "automod": null,
+            "blocked_term": {
+                "terms_found": [
+                    {
+                        "term_id": "e4d4f1ba-99bf-4b19-9875-cd4eda98ead9",
+                        "owner_broadcaster_user_id": "129546453",
+                        "owner_broadcaster_user_login": "nerixyz",
+                        "owner_broadcaster_user_name": "nerixyz",
+                        "boundary": {
+                            "start_pos": 15,
+                            "end_pos": 17
+                        }
+                    },
+                    {
+                        "term_id": "e60a94ea-e5d9-444e-a114-4cfd2f86c6ad",
+                        "owner_broadcaster_user_id": "129546453",
+                        "owner_broadcaster_user_login": "nerixyz",
+                        "owner_broadcaster_user_name": "nerixyz",
+                        "boundary": {
+                            "start_pos": 19,
+                            "end_pos": 25
+                        }
+                    }
+                ]
+            },
+            "held_at": "2024-11-18T16:58:41.476117057Z"
+        }
+    }
+    "##;
+
+    let val = Event::parse(payload).unwrap();
+    crate::tests::roundtrip(&val);
+
+    let Event::AutomodMessageHoldBeta(val) = val else {
+        panic!("invalid event type");
+    };
+    let Message::Notification(notif) = val.message else {
+        panic!("invalid message type");
+    };
+
+    assert_eq!(notif.broadcaster_user_id.as_str(), "129546453");
+    assert_eq!(notif.message.fragments.len(), 7);
+
+    let AutomodHeldReason::BlockedTerm { blocked_term } = &notif.reason else {
+        panic!("invalid held reason");
+    };
+    assert_eq!(blocked_term.terms_found.len(), 2);
+    assert_eq!(
+        blocked_term.terms_found[0].term_id.as_str(),
+        "e4d4f1ba-99bf-4b19-9875-cd4eda98ead9"
+    );
+    assert_eq!(
+        blocked_term.terms_found[0].boundary,
+        AutomodMessageBoundary {
+            start_pos: 15,
+            end_pos: 17
+        }
+    );
 }

--- a/src/eventsub/automod/message/mod.rs
+++ b/src/eventsub/automod/message/mod.rs
@@ -13,6 +13,9 @@ pub use hold::{AutomodMessageHoldBeta, AutomodMessageHoldBetaPayload};
 #[doc(inline)]
 pub use hold::{AutomodMessageHoldV1, AutomodMessageHoldV1Payload};
 #[doc(inline)]
+#[cfg(feature = "beta")]
+pub use update::{AutomodMessageUpdateBeta, AutomodMessageUpdateBetaPayload};
+#[doc(inline)]
 pub use update::{AutomodMessageUpdateV1, AutomodMessageUpdateV1Payload};
 
 /// A message's Automod status

--- a/src/eventsub/automod/message/mod.rs
+++ b/src/eventsub/automod/message/mod.rs
@@ -23,6 +23,8 @@ pub enum AutomodMessageStatus {
     Denied,
     /// The message is too old, it can't be acted upon anymore.
     Expired,
+    /// The message was invalid
+    Invalid,
     /// An unknown Automod message status, contains the raw string provided by Twitch.
     #[serde(untagged)]
     Unknown(String),

--- a/src/eventsub/automod/message/mod.rs
+++ b/src/eventsub/automod/message/mod.rs
@@ -27,3 +27,69 @@ pub enum AutomodMessageStatus {
     #[serde(untagged)]
     Unknown(String),
 }
+
+/// A message sent in automod events
+///
+/// This message is different to the one from [channel.chat.message]
+/// in that it doesn't contain "mention" fragments and that the "emote" fragment
+/// doesn't contain the owner nor the format.
+// XXX: this struct can never be deny_unknown_fields
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct AutomodMessage {
+    /// The chat message in plain text.
+    pub text: String,
+    /// Ordered list of chat message fragments.
+    pub fragments: Vec<AutomodMessageFragment>,
+}
+
+/// A chat message fragment
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum AutomodMessageFragment {
+    /// A Cheermote.
+    Cheermote {
+        /// Message text in a fragment
+        text: String,
+        /// A Cheermote.
+        cheermote: AutomodMessageCheermote,
+    },
+    /// A Emote.
+    Emote {
+        /// Message text in a fragment
+        text: String,
+        /// A Emote.
+        emote: AutomodMessageEmote,
+    },
+    /// A text fragment, see [`AutomodMessageFragment::text`].
+    Text {
+        /// Message text in a fragment
+        text: String,
+    },
+}
+
+impl AutomodMessageFragment {
+    /// Get the text data
+    pub fn text(&self) -> &str {
+        match self {
+            Self::Cheermote { text, .. } => text,
+            Self::Emote { text, .. } => text,
+            Self::Text { text } => text,
+        }
+    }
+}
+
+/// A cheermote in a message filtered by automod
+pub type AutomodMessageCheermote = crate::eventsub::channel::chat::Cheermote;
+
+/// An emote in a message filtered by automod
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[non_exhaustive]
+pub struct AutomodMessageEmote {
+    /// An ID that uniquely identifies this emote.
+    pub id: types::EmoteId,
+    /// An ID that identifies the emote set that the emote belongs to.
+    pub emote_set_id: types::EmoteSetId,
+}

--- a/src/eventsub/automod/message/mod.rs
+++ b/src/eventsub/automod/message/mod.rs
@@ -8,6 +8,9 @@ pub mod hold;
 pub mod update;
 
 #[doc(inline)]
+#[cfg(feature = "beta")]
+pub use hold::{AutomodMessageHoldBeta, AutomodMessageHoldBetaPayload};
+#[doc(inline)]
 pub use hold::{AutomodMessageHoldV1, AutomodMessageHoldV1Payload};
 #[doc(inline)]
 pub use update::{AutomodMessageUpdateV1, AutomodMessageUpdateV1Payload};
@@ -94,4 +97,83 @@ pub struct AutomodMessageEmote {
     pub id: types::EmoteId,
     /// An ID that identifies the emote set that the emote belongs to.
     pub emote_set_id: types::EmoteSetId,
+}
+
+/// The reason why a message was held
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "reason", rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum AutomodHeldReason {
+    /// The message was caught by automod's rules
+    Automod {
+        /// Information on why a message was caught by automod
+        automod: AutomodMessageInfo,
+    },
+    /// The message was caught because of one or more blocked terms
+    BlockedTerm {
+        /// Information on which blocked terms were matched in a message
+        blocked_term: AutomodBlockedTermInfo,
+    },
+}
+
+/// Information on why a message was caught by automod
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[non_exhaustive]
+pub struct AutomodMessageInfo {
+    /// The category of the caught message.
+    pub category: AutomodCategory,
+    /// The level of severity (1-4).
+    pub level: u8,
+    /// The bounds of the text that caused the message to be caught.
+    pub boundaries: Vec<AutomodMessageBoundary>,
+}
+
+/// Information on which blocked terms were matched in a message
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[non_exhaustive]
+pub struct AutomodBlockedTermInfo {
+    /// The list of blocked terms found in the message.
+    pub terms_found: Vec<AutomodBlockedTerm>,
+}
+
+/// The bounds of the text that caused the message to be caught.
+///
+/// These bounds are given in Unicode code points not in bytes.
+/// See [char] and [str::chars].
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[non_exhaustive]
+pub struct AutomodMessageBoundary {
+    /// Index in the message for the start of the problem (0 indexed, inclusive).
+    pub start_pos: usize,
+    /// Index in the message for the end of the problem (0 indexed, inclusive).
+    pub end_pos: usize,
+}
+
+/// Information about the blocked terms that caused a message to be caught by automod.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[non_exhaustive]
+pub struct AutomodBlockedTermsInfo {
+    /// The list of blocked terms found in the message.
+    pub terms_found: Vec<AutomodBlockedTerm>,
+}
+
+/// A blocked term that was found in a message
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[non_exhaustive]
+pub struct AutomodBlockedTerm {
+    /// The id of the blocked term found.
+    pub term_id: types::BlockedTermId,
+    /// The bounds of the text that caused the message to be caught.
+    pub boundary: AutomodMessageBoundary,
+    /// The id of the broadcaster that owns the blocked term.
+    pub owner_broadcaster_user_id: types::UserId,
+    /// The login of the broadcaster that owns the blocked term.
+    pub owner_broadcaster_user_login: types::UserName,
+    /// The username of the broadcaster that owns the blocked term.
+    pub owner_broadcaster_user_name: types::DisplayName,
 }

--- a/src/eventsub/automod/message/update.rs
+++ b/src/eventsub/automod/message/update.rs
@@ -81,7 +81,7 @@ pub struct AutomodMessageUpdateV1Payload {
 
 #[cfg(test)]
 #[test]
-fn parse_payload() {
+fn parse_payload_v1() {
     use crate::eventsub::{Event, Message};
 
     let payload = r##"
@@ -147,4 +147,291 @@ fn parse_payload() {
     assert_eq!(notif.level, 4);
     assert_eq!(notif.status, AutomodMessageStatus::Approved);
     assert_eq!(notif.message.fragments.len(), 1);
+}
+
+/// [`automod.message.update`](dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#automodmessageupdate-v2): a message in the automod queue had its status changed.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[non_exhaustive]
+#[cfg(feature = "beta")]
+pub struct AutomodMessageUpdateBeta {
+    /// User ID of the broadcaster (channel).
+    #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
+    pub broadcaster_user_id: types::UserId,
+    /// User ID of the moderator.
+    #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
+    pub moderator_user_id: types::UserId,
+}
+
+#[cfg(feature = "beta")]
+impl AutomodMessageUpdateBeta {
+    /// Get automod update notifications for this channel as a moderator
+    pub fn new(
+        broadcaster_user_id: impl Into<types::UserId>,
+        moderator_user_id: impl Into<types::UserId>,
+    ) -> Self {
+        Self {
+            broadcaster_user_id: broadcaster_user_id.into(),
+            moderator_user_id: moderator_user_id.into(),
+        }
+    }
+}
+
+#[cfg(feature = "beta")]
+impl EventSubscription for AutomodMessageUpdateBeta {
+    type Payload = AutomodMessageUpdateBetaPayload;
+
+    const EVENT_TYPE: EventType = EventType::AutomodMessageUpdate;
+    #[cfg(feature = "twitch_oauth2")]
+    const SCOPE: twitch_oauth2::Validator =
+        twitch_oauth2::validator![twitch_oauth2::Scope::ModeratorManageAutoMod];
+    const VERSION: &'static str = "beta";
+}
+
+/// [`automod.message.hold`](AutomodMessageUpdateBeta) response payload.
+// XXX: this struct can't be deny-unknown-fields because of the flattened reason
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+#[cfg(feature = "beta")]
+pub struct AutomodMessageUpdateBetaPayload {
+    /// The ID of the broadcaster specified in the request.
+    pub broadcaster_user_id: types::UserId,
+    /// The login of the broadcaster specified in the request.
+    pub broadcaster_user_login: types::UserName,
+    /// The user name of the broadcaster specified in the request.
+    pub broadcaster_user_name: types::DisplayName,
+
+    /// The message sender’s user ID.
+    pub user_id: types::UserId,
+    /// The message sender’s login name.
+    pub user_login: types::UserName,
+    /// The message sender’s display name.
+    pub user_name: types::DisplayName,
+
+    /// The ID of the moderator.
+    pub moderator_user_id: types::UserId,
+    /// The login of the moderator.
+    pub moderator_user_login: types::UserName,
+    /// The moderator’s user name.
+    pub moderator_user_name: types::DisplayName,
+
+    /// The ID of the message that was flagged by automod.
+    pub message_id: types::MsgId,
+    /// The body of the message.
+    pub message: AutomodMessage,
+    /// The message’s status.
+    pub status: AutomodMessageStatus,
+    /// The timestamp of when automod saved the message.
+    pub held_at: types::Timestamp,
+    /// The reason why a message was held
+    #[serde(flatten)]
+    pub reason: AutomodHeldReason,
+}
+
+#[cfg(all(test, feature = "beta"))]
+#[test]
+fn parse_payload_v2_automod() {
+    use crate::eventsub::{Event, Message};
+
+    let payload = r##"
+    {
+        "subscription": {
+            "id": "5d64b907-001e-4cf1-9227-37871c7ce1b0",
+            "status": "enabled",
+            "type": "automod.message.update",
+            "version": "beta",
+            "condition": {
+                "broadcaster_user_id": "129546453",
+                "moderator_user_id": "129546453"
+            },
+            "transport": {
+                "method": "websocket",
+                "session_id": "AgoQSrkrRHHrQsS-i4xbndeC0hIGY2VsbC1j"
+            },
+            "created_at": "2024-11-18T19:25:05.666970955Z",
+            "cost": 0
+        },
+        "event": {
+            "broadcaster_user_id": "129546453",
+            "broadcaster_user_login": "nerixyz",
+            "broadcaster_user_name": "nerixyz",
+            "user_id": "489584266",
+            "user_login": "uint128",
+            "user_name": "uint128",
+            "moderator_user_id": "129546453",
+            "moderator_user_login": "nerixyz",
+            "moderator_user_name": "nerixyz",
+            "message_id": "2a867e45-a4d3-4e7e-a5cc-a9a00ee98bf7",
+            "message": {
+                "text": "Kappa ass",
+                "fragments": [
+                    {
+                        "type": "emote",
+                        "text": "Kappa",
+                        "cheermote": null,
+                        "emote": {
+                            "id": "25",
+                            "emote_set_id": "0"
+                        }
+                    },
+                    {
+                        "type": "text",
+                        "text": " ",
+                        "cheermote": null,
+                        "emote": null
+                    },
+                    {
+                        "type": "text",
+                        "text": "ass",
+                        "cheermote": null,
+                        "emote": null
+                    }
+                ]
+            },
+            "reason": "automod",
+            "automod": {
+                "category": "swearing",
+                "level": 4,
+                "boundaries": [
+                    {
+                        "start_pos": 6,
+                        "end_pos": 8
+                    }
+                ]
+            },
+            "blocked_term": null,
+            "status": "denied",
+            "held_at": "2024-11-18T19:26:37.707305502Z"
+        }
+    }
+    "##;
+
+    let val = Event::parse(payload).unwrap();
+    crate::tests::roundtrip(&val);
+
+    let Event::AutomodMessageUpdateBeta(val) = val else {
+        panic!("invalid event type");
+    };
+    let Message::Notification(notif) = val.message else {
+        panic!("invalid message type");
+    };
+
+    assert_eq!(notif.broadcaster_user_id.as_str(), "129546453");
+    assert_eq!(notif.message.fragments.len(), 3);
+    assert_eq!(notif.status, AutomodMessageStatus::Denied);
+
+    let AutomodHeldReason::Automod { automod } = &notif.reason else {
+        panic!("invalid held reason");
+    };
+    assert_eq!(
+        automod.category,
+        AutomodCategory::Unknown("swearing".to_string())
+    );
+    assert_eq!(automod.level, 4);
+    assert_eq!(
+        automod.boundaries,
+        &[AutomodMessageBoundary {
+            start_pos: 6,
+            end_pos: 8
+        }]
+    );
+}
+
+#[cfg(all(test, feature = "beta"))]
+#[test]
+fn parse_payload_v2_blocked_term() {
+    use crate::eventsub::{Event, Message};
+
+    let payload = r##"
+    {
+        "subscription": {
+            "id": "5d64b907-001e-4cf1-9227-37871c7ce1b0",
+            "status": "enabled",
+            "type": "automod.message.update",
+            "version": "beta",
+            "condition": {
+                "broadcaster_user_id": "129546453",
+                "moderator_user_id": "129546453"
+            },
+            "transport": {
+                "method": "websocket",
+                "session_id": "AgoQSrkrRHHrQsS-i4xbndeC0hIGY2VsbC1j"
+            },
+            "created_at": "2024-11-18T19:25:05.666970955Z",
+            "cost": 0
+        },
+        "event": {
+            "broadcaster_user_id": "129546453",
+            "broadcaster_user_login": "nerixyz",
+            "broadcaster_user_name": "nerixyz",
+            "user_id": "489584266",
+            "user_login": "uint128",
+            "user_name": "uint128",
+            "moderator_user_id": "129546453",
+            "moderator_user_login": "nerixyz",
+            "moderator_user_name": "nerixyz",
+            "message_id": "8c2b43ed-88a0-4b3e-8c02-266c323e1d95",
+            "message": {
+                "text": "foo",
+                "fragments": [
+                    {
+                        "type": "text",
+                        "text": "foo",
+                        "cheermote": null,
+                        "emote": null
+                    }
+                ]
+            },
+            "reason": "blocked_term",
+            "automod": null,
+            "blocked_term": {
+                "terms_found": [
+                    {
+                        "term_id": "e4d4f1ba-99bf-4b19-9875-cd4eda98ead9",
+                        "owner_broadcaster_user_id": "129546453",
+                        "owner_broadcaster_user_login": "nerixyz",
+                        "owner_broadcaster_user_name": "nerixyz",
+                        "boundary": {
+                            "start_pos": 0,
+                            "end_pos": 2
+                        }
+                    }
+                ]
+            },
+            "status": "approved",
+            "held_at": "2024-11-18T19:25:52.991756968Z"
+        }
+    }
+    "##;
+
+    let val = Event::parse(payload).unwrap();
+    crate::tests::roundtrip(&val);
+
+    let Event::AutomodMessageUpdateBeta(val) = val else {
+        panic!("invalid event type");
+    };
+    let Message::Notification(notif) = val.message else {
+        panic!("invalid message type");
+    };
+
+    assert_eq!(notif.broadcaster_user_id.as_str(), "129546453");
+    assert_eq!(notif.message.fragments.len(), 1);
+    assert_eq!(notif.status, AutomodMessageStatus::Approved);
+
+    let AutomodHeldReason::BlockedTerm { blocked_term } = &notif.reason else {
+        panic!("invalid held reason");
+    };
+    assert_eq!(blocked_term.terms_found.len(), 1);
+    assert_eq!(
+        blocked_term.terms_found[0].term_id.as_str(),
+        "e4d4f1ba-99bf-4b19-9875-cd4eda98ead9"
+    );
+    assert_eq!(
+        blocked_term.terms_found[0].boundary,
+        AutomodMessageBoundary {
+            start_pos: 0,
+            end_pos: 2
+        }
+    );
 }

--- a/src/eventsub/automod/message/update.rs
+++ b/src/eventsub/automod/message/update.rs
@@ -68,7 +68,7 @@ pub struct AutomodMessageUpdateV1Payload {
     /// The ID of the message that was flagged by automod.
     pub message_id: types::MsgId,
     /// The body of the message.
-    pub message: crate::eventsub::channel::chat::Message,
+    pub message: AutomodMessage,
     /// The category of the message.
     pub category: super::AutomodCategory,
     /// The level of severity. Measured between 1 to 4.

--- a/src/eventsub/automod/mod.rs
+++ b/src/eventsub/automod/mod.rs
@@ -13,6 +13,9 @@ pub use message::{AutomodMessageHoldBeta, AutomodMessageHoldBetaPayload};
 #[doc(inline)]
 pub use message::{AutomodMessageHoldV1, AutomodMessageHoldV1Payload};
 #[doc(inline)]
+#[cfg(feature = "beta")]
+pub use message::{AutomodMessageUpdateBeta, AutomodMessageUpdateBetaPayload};
+#[doc(inline)]
 pub use message::{AutomodMessageUpdateV1, AutomodMessageUpdateV1Payload};
 
 #[doc(inline)]

--- a/src/eventsub/automod/mod.rs
+++ b/src/eventsub/automod/mod.rs
@@ -8,6 +8,9 @@ pub mod settings;
 pub mod terms;
 
 #[doc(inline)]
+#[cfg(feature = "beta")]
+pub use message::{AutomodMessageHoldBeta, AutomodMessageHoldBetaPayload};
+#[doc(inline)]
 pub use message::{AutomodMessageHoldV1, AutomodMessageHoldV1Payload};
 #[doc(inline)]
 pub use message::{AutomodMessageUpdateV1, AutomodMessageUpdateV1Payload};

--- a/src/eventsub/channel/chat/mod.rs
+++ b/src/eventsub/channel/chat/mod.rs
@@ -9,6 +9,7 @@ pub mod clear_user_messages;
 pub mod message;
 pub mod message_delete;
 pub mod notification;
+pub mod user_message_hold;
 
 #[doc(inline)]
 pub use clear::{ChannelChatClearV1, ChannelChatClearV1Payload};
@@ -22,6 +23,8 @@ pub use message::{ChannelChatMessageV1, ChannelChatMessageV1Payload};
 pub use message_delete::{ChannelChatMessageDeleteV1, ChannelChatMessageDeleteV1Payload};
 #[doc(inline)]
 pub use notification::{ChannelChatNotificationV1, ChannelChatNotificationV1Payload};
+#[doc(inline)]
+pub use user_message_hold::{ChannelChatUserMessageHoldV1, ChannelChatUserMessageHoldV1Payload};
 
 /// A message
 // XXX: this struct can never be deny_unknown_fields

--- a/src/eventsub/channel/chat/mod.rs
+++ b/src/eventsub/channel/chat/mod.rs
@@ -10,6 +10,7 @@ pub mod message;
 pub mod message_delete;
 pub mod notification;
 pub mod user_message_hold;
+pub mod user_message_update;
 
 #[doc(inline)]
 pub use clear::{ChannelChatClearV1, ChannelChatClearV1Payload};
@@ -25,6 +26,10 @@ pub use message_delete::{ChannelChatMessageDeleteV1, ChannelChatMessageDeleteV1P
 pub use notification::{ChannelChatNotificationV1, ChannelChatNotificationV1Payload};
 #[doc(inline)]
 pub use user_message_hold::{ChannelChatUserMessageHoldV1, ChannelChatUserMessageHoldV1Payload};
+#[doc(inline)]
+pub use user_message_update::{
+    ChannelChatUserMessageUpdateV1, ChannelChatUserMessageUpdateV1Payload,
+};
 
 /// A message
 // XXX: this struct can never be deny_unknown_fields

--- a/src/eventsub/channel/chat/user_message_hold.rs
+++ b/src/eventsub/channel/chat/user_message_hold.rs
@@ -1,0 +1,144 @@
+#![doc(alias = "channel.chat.user_message_hold")]
+//! A user's message is caught by automod.
+
+use super::*;
+/// [`channel.chat.user_message_hold`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelchatuser_message_hold): a user's message is caught by automod.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[non_exhaustive]
+pub struct ChannelChatUserMessageHoldV1 {
+    /// User ID of the channel to receive chat message events for.
+    #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
+    pub broadcaster_user_id: types::UserId,
+    /// The user ID to read chat as.
+    #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
+    pub user_id: types::UserId,
+}
+
+impl ChannelChatUserMessageHoldV1 {
+    /// Get user message hold events on a broadcasters channel reading chat as a specific user.
+    pub fn new(
+        broadcaster_user_id: impl Into<types::UserId>,
+        user_id: impl Into<types::UserId>,
+    ) -> Self {
+        Self {
+            broadcaster_user_id: broadcaster_user_id.into(),
+            user_id: user_id.into(),
+        }
+    }
+}
+
+impl EventSubscription for ChannelChatUserMessageHoldV1 {
+    type Payload = ChannelChatUserMessageHoldV1Payload;
+
+    const EVENT_TYPE: EventType = EventType::ChannelChatUserMessageHold;
+    #[cfg(feature = "twitch_oauth2")]
+    const SCOPE: twitch_oauth2::Validator =
+        twitch_oauth2::validator![twitch_oauth2::Scope::UserReadChat];
+    const VERSION: &'static str = "1";
+}
+
+/// [`channel.chat.user_message_hold`](ChannelChatUserMessageHoldV1) response payload.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[non_exhaustive]
+pub struct ChannelChatUserMessageHoldV1Payload {
+    /// The ID of the broadcaster specified in the request.
+    pub broadcaster_user_id: types::UserId,
+    /// The login of the broadcaster specified in the request.
+    pub broadcaster_user_login: types::UserName,
+    /// The user name of the broadcaster specified in the request.
+    pub broadcaster_user_name: types::DisplayName,
+    /// The User ID of the message sender.
+    pub user_id: types::UserId,
+    /// The message sender’s login.
+    pub user_login: types::UserName,
+    /// The message sender’s display name.
+    pub user_name: types::DisplayName,
+    /// The ID of the message that was flagged by automod.
+    pub message_id: types::MsgId,
+    /// The body of the message.
+    pub message: crate::eventsub::automod::message::AutomodMessage,
+}
+
+#[cfg(test)]
+#[test]
+fn parse_payload() {
+    use crate::eventsub::{Event, Message};
+
+    let payload = r##"
+    {
+        "subscription": {
+            "id": "f1c2a387-161a-49f9-a165-0f21d7a4e1c4",
+            "type": "channel.chat.user_message_hold",
+            "version": "1",
+            "status": "enabled",
+            "cost": 0,
+            "condition": {
+                "broadcaster_user_id": "1337",
+                "user_id": "9001"
+            },
+            "transport": {
+                "method": "webhook",
+                "callback": "https://example.com/webhooks/callback"
+            },
+            "created_at": "2023-04-11T10:11:12.123Z"
+        },
+        "event": {
+            "broadcaster_user_id": "123",
+            "broadcaster_user_login": "bob",
+            "broadcaster_user_name": "Bob",
+            "user_id": "456",
+            "user_login": "tom",
+            "user_name": "Tommy",
+            "message_id": "789",
+            "message": {
+                "text": "hey world",
+                "fragments": [
+                    {
+                        "type": "emote",
+                        "text": "hey world",
+                        "cheermote": null,
+                        "emote": {
+                            "id": "foo",
+                            "emote_set_id": "7"
+                        }
+                    },
+                    {
+                        "type": "cheermote",
+                        "text": "bye world",
+                        "cheermote": {
+                            "prefix": "prefix",
+                            "bits": 100,
+                            "tier": 1
+                        },
+                        "emote": null
+                    },
+                    {
+                        "type": "text",
+                        "text": "surprise",
+                        "cheermote": null,
+                        "emote": null
+                    }
+                ]
+            }
+        }
+    }
+    "##;
+
+    let val = Event::parse(payload).unwrap();
+    crate::tests::roundtrip(&val);
+
+    let Event::ChannelChatUserMessageHoldV1(val) = val else {
+        panic!("invalid event type");
+    };
+    let Message::Notification(notif) = val.message else {
+        panic!("invalid message type");
+    };
+
+    assert_eq!(notif.broadcaster_user_id.as_str(), "123");
+    assert_eq!(notif.user_id.as_str(), "456");
+    assert_eq!(notif.message_id.as_str(), "789");
+    assert_eq!(notif.message.text, "hey world");
+}

--- a/src/eventsub/channel/chat/user_message_update.rs
+++ b/src/eventsub/channel/chat/user_message_update.rs
@@ -1,0 +1,151 @@
+#![doc(alias = "channel.chat.user_message_update")]
+//! A user's message's automod status is updated
+
+use super::*;
+/// [`channel.chat.user_message_update`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelchatuser_message_update): a user's message's automod status is updated.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[non_exhaustive]
+pub struct ChannelChatUserMessageUpdateV1 {
+    /// User ID of the channel to receive chat message events for.
+    #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
+    pub broadcaster_user_id: types::UserId,
+    /// The user ID to read chat as.
+    #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
+    pub user_id: types::UserId,
+}
+
+impl ChannelChatUserMessageUpdateV1 {
+    /// Get user message update events on a broadcasters channel reading chat as a specific user.
+    pub fn new(
+        broadcaster_user_id: impl Into<types::UserId>,
+        user_id: impl Into<types::UserId>,
+    ) -> Self {
+        Self {
+            broadcaster_user_id: broadcaster_user_id.into(),
+            user_id: user_id.into(),
+        }
+    }
+}
+
+impl EventSubscription for ChannelChatUserMessageUpdateV1 {
+    type Payload = ChannelChatUserMessageUpdateV1Payload;
+
+    const EVENT_TYPE: EventType = EventType::ChannelChatUserMessageUpdate;
+    #[cfg(feature = "twitch_oauth2")]
+    const SCOPE: twitch_oauth2::Validator =
+        twitch_oauth2::validator![twitch_oauth2::Scope::UserReadChat];
+    const VERSION: &'static str = "1";
+}
+
+/// [`channel.chat.user_message_update`](ChannelChatUserMessageUpdateV1) response payload.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[non_exhaustive]
+pub struct ChannelChatUserMessageUpdateV1Payload {
+    /// The ID of the broadcaster specified in the request.
+    pub broadcaster_user_id: types::UserId,
+    /// The login of the broadcaster specified in the request.
+    pub broadcaster_user_login: types::UserName,
+    /// The user name of the broadcaster specified in the request.
+    pub broadcaster_user_name: types::DisplayName,
+    /// The User ID of the message sender.
+    pub user_id: types::UserId,
+    /// The message sender’s login.
+    pub user_login: types::UserName,
+    /// The message sender’s display name.
+    pub user_name: types::DisplayName,
+    /// The message’s status
+    pub status: crate::eventsub::automod::message::AutomodMessageStatus,
+    /// The ID of the message that was flagged by automod.
+    pub message_id: types::MsgId,
+    /// The body of the message.
+    pub message: crate::eventsub::automod::message::AutomodMessage,
+}
+
+#[cfg(test)]
+#[test]
+fn parse_payload() {
+    use crate::eventsub::{Event, Message};
+
+    let payload = r##"
+    {
+        "subscription": {
+            "id": "f1c2a387-161a-49f9-a165-0f21d7a4e1c4",
+            "type": "channel.chat.user_message_update",
+            "version": "1",
+            "status": "enabled",
+            "cost": 0,
+            "condition": {
+                "broadcaster_user_id": "1337",
+                "user_id": "9001"
+            },
+            "transport": {
+                "method": "webhook",
+                "callback": "https://example.com/webhooks/callback"
+            },
+            "created_at": "2023-04-11T10:11:12.123Z"
+        },
+        "event": {
+            "broadcaster_user_id": "123",
+            "broadcaster_user_login": "bob",
+            "broadcaster_user_name": "Bob",
+            "user_id": "456",
+            "user_login": "tom",
+            "user_name": "Tommy",
+            "status": "approved",
+            "message_id": "789",
+            "message": {
+                "text": "hey world",
+                "fragments": [
+                    {
+                        "type": "emote",
+                        "text": "hey world",
+                        "cheermote": null,
+                        "emote": {
+                            "id": "foo",
+                            "emote_set_id": "7"
+                        }
+                    },
+                    {
+                        "type": "cheermote",
+                        "text": "bye world",
+                        "cheermote": {
+                            "prefix": "prefix",
+                            "bits": 100,
+                            "tier": 1
+                        },
+                        "emote": null
+                    },
+                    {
+                        "type": "text",
+                        "text": "surprise",
+                        "cheermote": null,
+                        "emote": null
+                    }
+                ]
+            }
+        }
+    }
+    "##;
+
+    let val = Event::parse(payload).unwrap();
+    crate::tests::roundtrip(&val);
+
+    let Event::ChannelChatUserMessageUpdateV1(val) = val else {
+        panic!("invalid event type");
+    };
+    let Message::Notification(notif) = val.message else {
+        panic!("invalid message type");
+    };
+
+    assert_eq!(notif.broadcaster_user_id.as_str(), "123");
+    assert_eq!(notif.user_id.as_str(), "456");
+    assert_eq!(
+        notif.status,
+        crate::eventsub::automod::message::AutomodMessageStatus::Approved
+    );
+    assert_eq!(notif.message_id.as_str(), "789");
+    assert_eq!(notif.message.text, "hey world");
+}

--- a/src/eventsub/channel/mod.rs
+++ b/src/eventsub/channel/mod.rs
@@ -71,6 +71,8 @@ pub use chat::{ChannelChatMessageV1, ChannelChatMessageV1Payload};
 #[doc(inline)]
 pub use chat::{ChannelChatNotificationV1, ChannelChatNotificationV1Payload};
 #[doc(inline)]
+pub use chat::{ChannelChatUserMessageHoldV1, ChannelChatUserMessageHoldV1Payload};
+#[doc(inline)]
 pub use cheer::{ChannelCheerV1, ChannelCheerV1Payload};
 #[doc(inline)]
 pub use follow::{ChannelFollowV1, ChannelFollowV1Payload};

--- a/src/eventsub/channel/mod.rs
+++ b/src/eventsub/channel/mod.rs
@@ -73,6 +73,8 @@ pub use chat::{ChannelChatNotificationV1, ChannelChatNotificationV1Payload};
 #[doc(inline)]
 pub use chat::{ChannelChatUserMessageHoldV1, ChannelChatUserMessageHoldV1Payload};
 #[doc(inline)]
+pub use chat::{ChannelChatUserMessageUpdateV1, ChannelChatUserMessageUpdateV1Payload};
+#[doc(inline)]
 pub use cheer::{ChannelCheerV1, ChannelCheerV1Payload};
 #[doc(inline)]
 pub use follow::{ChannelFollowV1, ChannelFollowV1Payload};

--- a/src/eventsub/event.rs
+++ b/src/eventsub/event.rs
@@ -12,6 +12,8 @@ macro_rules! fill_events {
     ($callback:ident( $($args:tt)* )) => {
         $callback!($($args)*
             automod::AutomodMessageHoldV1;
+            #[cfg(feature = "beta")]
+            automod::AutomodMessageHoldBeta;
             automod::AutomodMessageUpdateV1;
             automod::AutomodSettingsUpdateV1;
             automod::AutomodTermsUpdateV1;
@@ -279,6 +281,9 @@ fn main() {
 pub enum Event {
     /// Automod Message Hold V1 Event
     AutomodMessageHoldV1(Payload<automod::AutomodMessageHoldV1>),
+    /// Automod Message Hold Beta Event
+    #[cfg(feature = "beta")]
+    AutomodMessageHoldBeta(Payload<automod::AutomodMessageHoldBeta>),
     /// Automod Message Update V1 Event
     AutomodMessageUpdateV1(Payload<automod::AutomodMessageUpdateV1>),
     /// Automod Settings Update V1 Event

--- a/src/eventsub/event.rs
+++ b/src/eventsub/event.rs
@@ -27,6 +27,7 @@ macro_rules! fill_events {
             channel::ChannelChatMessageDeleteV1;
             channel::ChannelChatNotificationV1;
             channel::ChannelChatUserMessageHoldV1;
+            channel::ChannelChatUserMessageUpdateV1;
             channel::ChannelCheerV1;
             channel::ChannelFollowV1;
             channel::ChannelFollowV2;
@@ -165,6 +166,8 @@ make_event_type!("Event Types": pub enum EventType {
     ChannelChatNotification => "channel.chat.notification",
     "a user's message is caught by automod.":
     ChannelChatUserMessageHold => "channel.chat.user_message_hold",
+    "a user's message's automod status is updated.":
+    ChannelChatUserMessageUpdate => "channel.chat.user_message_update",
     "a user donates to the broadcaster’s charity campaign.":
     ChannelCharityCampaignDonate => "channel.charity_campaign.donate",
     "progress is made towards the campaign’s goal or when the broadcaster changes the fundraising goal.":
@@ -296,6 +299,8 @@ pub enum Event {
     ChannelChatNotificationV1(Payload<channel::ChannelChatNotificationV1>),
     /// Channel Chat UserMessageHold V1 Event
     ChannelChatUserMessageHoldV1(Payload<channel::ChannelChatUserMessageHoldV1>),
+    /// Channel Chat UserMessageUpdate V1 Event
+    ChannelChatUserMessageUpdateV1(Payload<channel::ChannelChatUserMessageUpdateV1>),
     /// Channel Charity Campaign Donate V1 Event
     ChannelCharityCampaignDonateV1(Payload<channel::ChannelCharityCampaignDonateV1>),
     /// Channel Charity Campaign Progress V1 Event

--- a/src/eventsub/event.rs
+++ b/src/eventsub/event.rs
@@ -15,6 +15,8 @@ macro_rules! fill_events {
             #[cfg(feature = "beta")]
             automod::AutomodMessageHoldBeta;
             automod::AutomodMessageUpdateV1;
+            #[cfg(feature = "beta")]
+            automod::AutomodMessageUpdateBeta;
             automod::AutomodSettingsUpdateV1;
             automod::AutomodTermsUpdateV1;
             channel::ChannelAdBreakBeginV1;
@@ -286,6 +288,9 @@ pub enum Event {
     AutomodMessageHoldBeta(Payload<automod::AutomodMessageHoldBeta>),
     /// Automod Message Update V1 Event
     AutomodMessageUpdateV1(Payload<automod::AutomodMessageUpdateV1>),
+    /// Automod Message Update Beta Event
+    #[cfg(feature = "beta")]
+    AutomodMessageUpdateBeta(Payload<automod::AutomodMessageUpdateBeta>),
     /// Automod Settings Update V1 Event
     AutomodSettingsUpdateV1(Payload<automod::AutomodSettingsUpdateV1>),
     /// Automod Terms Update V1 Event

--- a/src/eventsub/event.rs
+++ b/src/eventsub/event.rs
@@ -26,6 +26,7 @@ macro_rules! fill_events {
             channel::ChannelChatMessageV1;
             channel::ChannelChatMessageDeleteV1;
             channel::ChannelChatNotificationV1;
+            channel::ChannelChatUserMessageHoldV1;
             channel::ChannelCheerV1;
             channel::ChannelFollowV1;
             channel::ChannelFollowV2;
@@ -162,6 +163,8 @@ make_event_type!("Event Types": pub enum EventType {
     ChannelChatMessageDelete => "channel.chat.message_delete",
     "an event that appears in chat occurs, such as someone subscribing to the channel or a subscription is gifted.":
     ChannelChatNotification => "channel.chat.notification",
+    "a user's message is caught by automod.":
+    ChannelChatUserMessageHold => "channel.chat.user_message_hold",
     "a user donates to the broadcaster’s charity campaign.":
     ChannelCharityCampaignDonate => "channel.charity_campaign.donate",
     "progress is made towards the campaign’s goal or when the broadcaster changes the fundraising goal.":
@@ -291,6 +294,8 @@ pub enum Event {
     ChannelChatMessageDeleteV1(Payload<channel::ChannelChatMessageDeleteV1>),
     /// Channel Chat Notification V1 Event
     ChannelChatNotificationV1(Payload<channel::ChannelChatNotificationV1>),
+    /// Channel Chat UserMessageHold V1 Event
+    ChannelChatUserMessageHoldV1(Payload<channel::ChannelChatUserMessageHoldV1>),
     /// Channel Charity Campaign Donate V1 Event
     ChannelCharityCampaignDonateV1(Payload<channel::ChannelCharityCampaignDonateV1>),
     /// Channel Charity Campaign Progress V1 Event

--- a/src/eventsub/mod.rs
+++ b/src/eventsub/mod.rs
@@ -92,7 +92,7 @@
 //!
 //! </details>
 //!
-//! <details><summary style="cursor: pointer"><code style="color: var(--link-color)">channel.*</code> 🟡 45/65</summary>
+//! <details><summary style="cursor: pointer"><code style="color: var(--link-color)">channel.*</code> 🟡 46/65</summary>
 //!
 //! | Name | Subscription<br>Payload |
 //! |---|:---|
@@ -113,7 +113,7 @@
 //! | [`channel.chat.message`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelchatmessage) | [ChannelChatMessageV1](channel::ChannelChatMessageV1)<br>[ChannelChatMessageV1Payload](channel::ChannelChatMessageV1Payload) |
 //! | [`channel.chat.message_delete`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelchatmessage_delete) | [ChannelChatMessageDeleteV1](channel::ChannelChatMessageDeleteV1)<br>[ChannelChatMessageDeleteV1Payload](channel::ChannelChatMessageDeleteV1Payload) |
 //! | [`channel.chat.notification`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelchatnotification) | [ChannelChatNotificationV1](channel::ChannelChatNotificationV1)<br>[ChannelChatNotificationV1Payload](channel::ChannelChatNotificationV1Payload) |
-//! | [`channel.chat.user_message_hold`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelchatuser_message_hold) | -<br>- |
+//! | [`channel.chat.user_message_hold`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelchatuser_message_hold) | [ChannelChatUserMessageHoldV1](channel::ChannelChatUserMessageHoldV1)<br>[ChannelChatUserMessageHoldV1Payload](channel::ChannelChatUserMessageHoldV1Payload) |
 //! | [`channel.chat.user_message_update`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelchatuser_message_update) | -<br>- |
 //! | [`channel.chat_settings.update`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelchat_settingsupdate) | -<br>- |
 //! | [`channel.cheer`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelcheer) | [ChannelCheerV1](channel::ChannelCheerV1)<br>[ChannelCheerV1Payload](channel::ChannelCheerV1Payload) |

--- a/src/eventsub/mod.rs
+++ b/src/eventsub/mod.rs
@@ -79,14 +79,14 @@
 //!
 //! <!-- generate with "cargo xtask overview" (with a nightly toolchain) -->
 //! <!-- BEGIN-OVERVIEW -->
-//! <details><summary style="cursor: pointer"><code style="color: var(--link-color)">automod.*</code> 🟡 5/6</summary>
+//! <details><summary style="cursor: pointer"><code style="color: var(--link-color)">automod.*</code> 🟢 6/6</summary>
 //!
 //! | Name | Subscription<br>Payload |
 //! |---|:---|
 //! | [`automod.message.hold`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#automodmessagehold) | [AutomodMessageHoldV1](automod::AutomodMessageHoldV1)<br>[AutomodMessageHoldV1Payload](automod::AutomodMessageHoldV1Payload) |
 //! | [`automod.message.hold`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#automodmessagehold-v2) | [AutomodMessageHoldBeta](automod::AutomodMessageHoldBeta)<br>[AutomodMessageHoldBetaPayload](automod::AutomodMessageHoldBetaPayload) |
 //! | [`automod.message.update`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#automodmessageupdate) | [AutomodMessageUpdateV1](automod::AutomodMessageUpdateV1)<br>[AutomodMessageUpdateV1Payload](automod::AutomodMessageUpdateV1Payload) |
-//! | [`automod.message.update`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#automodmessageupdate-v2) | -<br>- |
+//! | [`automod.message.update`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#automodmessageupdate-v2) | [AutomodMessageUpdateBeta](automod::AutomodMessageUpdateBeta)<br>[AutomodMessageUpdateBetaPayload](automod::AutomodMessageUpdateBetaPayload) |
 //! | [`automod.settings.update`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#automodsettingsupdate) | [AutomodSettingsUpdateV1](automod::AutomodSettingsUpdateV1)<br>[AutomodSettingsUpdateV1Payload](automod::AutomodSettingsUpdateV1Payload) |
 //! | [`automod.terms.update`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#automodtermsupdate) | [AutomodTermsUpdateV1](automod::AutomodTermsUpdateV1)<br>[AutomodTermsUpdateV1Payload](automod::AutomodTermsUpdateV1Payload) |
 //!

--- a/src/eventsub/mod.rs
+++ b/src/eventsub/mod.rs
@@ -92,7 +92,7 @@
 //!
 //! </details>
 //!
-//! <details><summary style="cursor: pointer"><code style="color: var(--link-color)">channel.*</code> 🟡 46/65</summary>
+//! <details><summary style="cursor: pointer"><code style="color: var(--link-color)">channel.*</code> 🟡 47/65</summary>
 //!
 //! | Name | Subscription<br>Payload |
 //! |---|:---|
@@ -114,7 +114,7 @@
 //! | [`channel.chat.message_delete`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelchatmessage_delete) | [ChannelChatMessageDeleteV1](channel::ChannelChatMessageDeleteV1)<br>[ChannelChatMessageDeleteV1Payload](channel::ChannelChatMessageDeleteV1Payload) |
 //! | [`channel.chat.notification`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelchatnotification) | [ChannelChatNotificationV1](channel::ChannelChatNotificationV1)<br>[ChannelChatNotificationV1Payload](channel::ChannelChatNotificationV1Payload) |
 //! | [`channel.chat.user_message_hold`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelchatuser_message_hold) | [ChannelChatUserMessageHoldV1](channel::ChannelChatUserMessageHoldV1)<br>[ChannelChatUserMessageHoldV1Payload](channel::ChannelChatUserMessageHoldV1Payload) |
-//! | [`channel.chat.user_message_update`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelchatuser_message_update) | -<br>- |
+//! | [`channel.chat.user_message_update`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelchatuser_message_update) | [ChannelChatUserMessageUpdateV1](channel::ChannelChatUserMessageUpdateV1)<br>[ChannelChatUserMessageUpdateV1Payload](channel::ChannelChatUserMessageUpdateV1Payload) |
 //! | [`channel.chat_settings.update`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelchat_settingsupdate) | -<br>- |
 //! | [`channel.cheer`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelcheer) | [ChannelCheerV1](channel::ChannelCheerV1)<br>[ChannelCheerV1Payload](channel::ChannelCheerV1Payload) |
 //! | [`channel.follow`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelfollow) | [ChannelFollowV2](channel::ChannelFollowV2)<br>[ChannelFollowV2Payload](channel::ChannelFollowV2Payload) |

--- a/src/eventsub/mod.rs
+++ b/src/eventsub/mod.rs
@@ -79,12 +79,12 @@
 //!
 //! <!-- generate with "cargo xtask overview" (with a nightly toolchain) -->
 //! <!-- BEGIN-OVERVIEW -->
-//! <details><summary style="cursor: pointer"><code style="color: var(--link-color)">automod.*</code> 🟡 4/6</summary>
+//! <details><summary style="cursor: pointer"><code style="color: var(--link-color)">automod.*</code> 🟡 5/6</summary>
 //!
 //! | Name | Subscription<br>Payload |
 //! |---|:---|
 //! | [`automod.message.hold`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#automodmessagehold) | [AutomodMessageHoldV1](automod::AutomodMessageHoldV1)<br>[AutomodMessageHoldV1Payload](automod::AutomodMessageHoldV1Payload) |
-//! | [`automod.message.hold`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#automodmessagehold-v2) | -<br>- |
+//! | [`automod.message.hold`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#automodmessagehold-v2) | [AutomodMessageHoldBeta](automod::AutomodMessageHoldBeta)<br>[AutomodMessageHoldBetaPayload](automod::AutomodMessageHoldBetaPayload) |
 //! | [`automod.message.update`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#automodmessageupdate) | [AutomodMessageUpdateV1](automod::AutomodMessageUpdateV1)<br>[AutomodMessageUpdateV1Payload](automod::AutomodMessageUpdateV1Payload) |
 //! | [`automod.message.update`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#automodmessageupdate-v2) | -<br>- |
 //! | [`automod.settings.update`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#automodsettingsupdate) | [AutomodSettingsUpdateV1](automod::AutomodSettingsUpdateV1)<br>[AutomodSettingsUpdateV1Payload](automod::AutomodSettingsUpdateV1Payload) |

--- a/src/eventsub/mod.rs
+++ b/src/eventsub/mod.rs
@@ -79,12 +79,14 @@
 //!
 //! <!-- generate with "cargo xtask overview" (with a nightly toolchain) -->
 //! <!-- BEGIN-OVERVIEW -->
-//! <details><summary style="cursor: pointer"><code style="color: var(--link-color)">automod.*</code> 🟢 4/4</summary>
+//! <details><summary style="cursor: pointer"><code style="color: var(--link-color)">automod.*</code> 🟡 4/6</summary>
 //!
 //! | Name | Subscription<br>Payload |
 //! |---|:---|
 //! | [`automod.message.hold`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#automodmessagehold) | [AutomodMessageHoldV1](automod::AutomodMessageHoldV1)<br>[AutomodMessageHoldV1Payload](automod::AutomodMessageHoldV1Payload) |
+//! | [`automod.message.hold`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#automodmessagehold-v2) | -<br>- |
 //! | [`automod.message.update`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#automodmessageupdate) | [AutomodMessageUpdateV1](automod::AutomodMessageUpdateV1)<br>[AutomodMessageUpdateV1Payload](automod::AutomodMessageUpdateV1Payload) |
+//! | [`automod.message.update`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#automodmessageupdate-v2) | -<br>- |
 //! | [`automod.settings.update`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#automodsettingsupdate) | [AutomodSettingsUpdateV1](automod::AutomodSettingsUpdateV1)<br>[AutomodSettingsUpdateV1Payload](automod::AutomodSettingsUpdateV1Payload) |
 //! | [`automod.terms.update`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#automodtermsupdate) | [AutomodTermsUpdateV1](automod::AutomodTermsUpdateV1)<br>[AutomodTermsUpdateV1Payload](automod::AutomodTermsUpdateV1Payload) |
 //!


### PR DESCRIPTION
...and I noticed the message definitions between `automod.message` and `channel.chat.message` are different 🙃.

Adds

- `channel.chat.user_message_hold`
- `channel.chat.user_message_update`
- `automod.message.hold` (the new beta for v2)
- `automod.message.update` (the new beta for v2)