### PR TITLE
feat: add channel.channel_points_automatic_reward_redemption.add

### DIFF
--- a/src/eventsub/channel/channel_points_automatic_reward_redemption/add.rs
+++ b/src/eventsub/channel/channel_points_automatic_reward_redemption/add.rs
@@ -1,0 +1,137 @@
+#![doc(alias = "channel.channel_points_automatic_reward_redemption.add")]
+//! A viewer has redeemed an automatic channel points reward on the specified channel.
+
+use super::*;
+/// [`channel.channel_points_automatic_reward_redemption.add`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelchannel_points_automatic_reward_redemptionadd):a viewer has redeemed an automatic channel points reward on the specified channel.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[non_exhaustive]
+pub struct ChannelPointsAutomaticRewardRedemptionAddV1 {
+    /// The broadcaster user ID for the channel you want to receive channel points reward add notifications for.
+    #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
+    pub broadcaster_user_id: types::UserId,
+}
+
+impl ChannelPointsAutomaticRewardRedemptionAddV1 {
+    /// The broadcaster user ID for the channel you want to receive channel points reward add notifications for.
+    pub fn broadcaster_user_id(broadcaster_user_id: impl Into<types::UserId>) -> Self {
+        Self {
+            broadcaster_user_id: broadcaster_user_id.into(),
+        }
+    }
+}
+
+impl EventSubscription for ChannelPointsAutomaticRewardRedemptionAddV1 {
+    type Payload = ChannelPointsAutomaticRewardRedemptionAddV1Payload;
+
+    const EVENT_TYPE: EventType = EventType::ChannelPointsAutomaticRewardRedemptionAdd;
+    #[cfg(feature = "twitch_oauth2")]
+    const SCOPE: twitch_oauth2::Validator = twitch_oauth2::validator![any(
+        twitch_oauth2::Scope::ChannelReadRedemptions,
+        twitch_oauth2::Scope::ChannelManageRedemptions
+    )];
+    const VERSION: &'static str = "1";
+}
+
+/// [`channel.channel_points_automatic_reward_redemption.add`](ChannelPointsAutomaticRewardRedemptionAddV1) response payload.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[non_exhaustive]
+pub struct ChannelPointsAutomaticRewardRedemptionAddV1Payload {
+    /// The ID of the channel where the reward was redeemed.
+    pub broadcaster_user_id: types::UserId,
+    /// The login of the channel where the reward was redeemed.
+    pub broadcaster_user_login: types::UserName,
+    /// The display name of the channel where the reward was redeemed.
+    pub broadcaster_user_name: types::DisplayName,
+    /// The ID of the redeeming user.
+    pub user_id: types::UserId,
+    /// The login of the redeeming user.
+    pub user_login: types::UserName,
+    /// The display name of the redeeming user.
+    pub user_name: types::DisplayName,
+    /// The ID of the Redemption.
+    pub id: types::RedemptionId,
+    /// An object that contains the reward information.
+    pub reward: AutomaticReward,
+    /// An object that contains the user message and emote information needed to recreate the message.
+    pub message: RedemptionMessage,
+    /// A string that the user entered if the reward requires input.
+    pub user_input: String,
+    /// The UTC date and time (in RFC3339 format) of when the reward was redeemed.
+    pub redeemed_at: types::Timestamp,
+}
+
+#[cfg(test)]
+#[test]
+fn parse_payload() {
+    use crate::eventsub::{Event, Message};
+
+    let payload = r##"
+    {
+        "subscription": {
+            "id": "7297f7eb-3bf5-461f-8ae6-7cd7781ebce3",
+            "status": "enabled",
+            "type": "channel.channel_points_automatic_reward_redemption.add",
+            "version": "1",
+            "condition": {
+                "broadcaster_user_id": "12826"
+            },
+            "transport": {
+                "method": "webhook",
+                "callback": "https://example.com/webhooks/callback"
+            },
+            "created_at": "2024-02-23T21:12:33.771005262Z",
+            "cost": 0
+        },
+        "event": {
+            "broadcaster_user_id": "12826",
+            "broadcaster_user_name": "Twitch",
+            "broadcaster_user_login": "twitch",
+            "user_id": "141981764",
+            "user_name": "TwitchDev",
+            "user_login": "twitchdev",
+            "id": "f024099a-e0fe-4339-9a0a-a706fb59f353",
+            "reward": {
+                "type": "send_highlighted_message",
+                "cost": 100,
+                "unlocked_emote": null
+            },
+            "message": {
+                "text": "Hello world! VoHiYo",
+                "emotes": [
+                    {
+                        "id": "81274",
+                        "begin": 13,
+                        "end": 18
+                    }
+                ]
+            },
+            "user_input": "Hello world! VoHiYo ",
+            "redeemed_at": "2024-02-23T21:14:34.260398045Z"
+        }
+    }
+    "##;
+
+    let val = Event::parse(payload).unwrap();
+    crate::tests::roundtrip(&val);
+
+    let Event::ChannelPointsAutomaticRewardRedemptionAddV1(val) = val else {
+        panic!("invalid event type");
+    };
+    let Message::Notification(notif) = val.message else {
+        panic!("invalid message type");
+    };
+
+    assert_eq!(notif.broadcaster_user_id.as_str(), "12826");
+    assert_eq!(notif.user_id.as_str(), "141981764");
+    assert_eq!(notif.id.as_str(), "f024099a-e0fe-4339-9a0a-a706fb59f353");
+    assert_eq!(notif.reward.cost, 100);
+    assert!(notif.reward.unlocked_emote.is_none());
+    assert_eq!(
+        notif.reward.type_,
+        AutomaticRewardType::SendHighlightedMessage
+    );
+    assert_eq!(notif.message.emotes.len(), 1);
+}

--- a/src/eventsub/channel/channel_points_automatic_reward_redemption/mod.rs
+++ b/src/eventsub/channel/channel_points_automatic_reward_redemption/mod.rs
@@ -1,0 +1,74 @@
+#![doc(alias = "channel.channel_points_automatic_reward_redemption")]
+//! A viewer has redeemed an automatic channel points reward in a specified channel.
+use super::{EventSubscription, EventType};
+use crate::types;
+use serde_derive::{Deserialize, Serialize};
+
+pub mod add;
+
+#[doc(inline)]
+pub use add::{
+    ChannelPointsAutomaticRewardRedemptionAddV1, ChannelPointsAutomaticRewardRedemptionAddV1Payload,
+};
+
+/// Basic information about the automatic reward that was redeemed, at the time it was redeemed.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[non_exhaustive]
+pub struct AutomaticReward {
+    /// The type of reward.
+    #[serde(rename = "type")]
+    pub type_: AutomaticRewardType,
+    /// The reward cost.
+    pub cost: i64,
+    /// Emote that was unlocked.
+    pub unlocked_emote: Option<UnlockedEmote>,
+}
+
+/// The type of reward
+#[derive(PartialEq, Eq, Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "snake_case")]
+#[non_exhaustive]
+pub enum AutomaticRewardType {
+    /// Send a message in sub mode as a non-sub
+    SingleMessageBypassSubMode,
+    /// Send a message with a highlight
+    SendHighlightedMessage,
+    /// Unlock a random sub emote
+    RandomSubEmoteUnlock,
+    /// Unlock a specific sub emote
+    ChosenSubEmoteUnlock,
+    /// Unlock a specific sub emote with a modifier
+    ChosenModifiedSubEmoteUnlock,
+    /// Add a special effect to the message
+    MessageEffect,
+    /// Send a giant emote in chat
+    GigantifyAnEmote,
+    /// On-screen celebration
+    Celebration,
+    /// An unknown type was redeemed
+    #[serde(untagged)]
+    Unknown(String),
+}
+
+/// An emote that was unlocked as part of a reward
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[non_exhaustive]
+pub struct UnlockedEmote {
+    /// The emote ID.
+    pub id: types::EmoteId,
+    /// The human readable emote token.
+    pub name: String,
+}
+
+/// The user message and emote information from a reward redemption
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[non_exhaustive]
+pub struct RedemptionMessage {
+    /// The text of the chat message.
+    pub text: String,
+    /// An array that includes the emote ID and start and end positions for where the emote appears in the text.
+    pub emotes: Vec<types::EmoteOccurrence>,
+}

--- a/src/eventsub/channel/mod.rs
+++ b/src/eventsub/channel/mod.rs
@@ -7,6 +7,7 @@ use serde_derive::{Deserialize, Serialize};
 
 pub mod ad_break;
 pub mod ban;
+pub mod channel_points_automatic_reward_redemption;
 pub mod channel_points_custom_reward;
 pub mod channel_points_custom_reward_redemption;
 pub mod charity_campaign;
@@ -30,6 +31,10 @@ pub mod update;
 pub use ad_break::{ChannelAdBreakBeginV1, ChannelAdBreakBeginV1Payload};
 #[doc(inline)]
 pub use ban::{ChannelBanV1, ChannelBanV1Payload};
+#[doc(inline)]
+pub use channel_points_automatic_reward_redemption::{
+    ChannelPointsAutomaticRewardRedemptionAddV1, ChannelPointsAutomaticRewardRedemptionAddV1Payload,
+};
 #[doc(inline)]
 pub use channel_points_custom_reward::{
     ChannelPointsCustomRewardAddV1, ChannelPointsCustomRewardAddV1Payload,

--- a/src/eventsub/event.rs
+++ b/src/eventsub/event.rs
@@ -41,6 +41,7 @@ macro_rules! fill_events {
             channel::ChannelHypeTrainBeginV1;
             channel::ChannelHypeTrainEndV1;
             channel::ChannelHypeTrainProgressV1;
+            channel::ChannelPointsAutomaticRewardRedemptionAddV1;
             channel::ChannelPointsCustomRewardAddV1;
             channel::ChannelPointsCustomRewardRedemptionAddV1;
             channel::ChannelPointsCustomRewardRedemptionUpdateV1;
@@ -192,6 +193,8 @@ make_event_type!("Event Types": pub enum EventType {
     ChannelBan => "channel.ban",
     "a viewer is unbanned from the specified channel.":
     ChannelUnban => "channel.unban",
+    "a viewer has redeemed an automatic channel points reward on the specified channel.":
+    ChannelPointsAutomaticRewardRedemptionAdd => "channel.channel_points_automatic_reward_redemption.add",
     "a custom channel points reward has been created for the specified channel.":
     ChannelPointsCustomRewardAdd => "channel.channel_points_custom_reward.add",
     "a custom channel points reward has been updated for the specified channel.":
@@ -337,6 +340,10 @@ pub enum Event {
     ChannelBanV1(Payload<channel::ChannelBanV1>),
     /// Channel Unban V1 Event
     ChannelUnbanV1(Payload<channel::ChannelUnbanV1>),
+    /// Channel Points Automatic Reward Redemption Add V1 Event
+    ChannelPointsAutomaticRewardRedemptionAddV1(
+        Payload<channel::ChannelPointsAutomaticRewardRedemptionAddV1>,
+    ),
     /// Channel Points Custom Reward Add V1 Event
     ChannelPointsCustomRewardAddV1(Payload<channel::ChannelPointsCustomRewardAddV1>),
     /// Channel Points Custom Reward Update V1 Event

--- a/src/eventsub/mod.rs
+++ b/src/eventsub/mod.rs
@@ -92,13 +92,13 @@
 //!
 //! </details>
 //!
-//! <details><summary style="cursor: pointer"><code style="color: var(--link-color)">channel.*</code> 🟡 47/65</summary>
+//! <details><summary style="cursor: pointer"><code style="color: var(--link-color)">channel.*</code> 🟡 48/65</summary>
 //!
 //! | Name | Subscription<br>Payload |
 //! |---|:---|
 //! | [`channel.ad_break.begin`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelad_breakbegin) (v1) | [ChannelAdBreakBeginV1](channel::ChannelAdBreakBeginV1)<br>[ChannelAdBreakBeginV1Payload](channel::ChannelAdBreakBeginV1Payload) |
 //! | [`channel.ban`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelban) (v1) | [ChannelBanV1](channel::ChannelBanV1)<br>[ChannelBanV1Payload](channel::ChannelBanV1Payload) |
-//! | [<span style="font-size: 0.9em">`channel.channel_points_automatic_reward_redemption.add`</span>](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelchannel_points_automatic_reward_redemptionadd) (v1) | -<br>- |
+//! | [<span style="font-size: 0.9em">`channel.channel_points_automatic_reward_redemption.add`</span>](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelchannel_points_automatic_reward_redemptionadd) (v1) | [ChannelPointsAutomaticRewardRedemptionAddV1](channel::ChannelPointsAutomaticRewardRedemptionAddV1)<br>[ChannelPointsAutomaticRewardRedemptionAddV1Payload](channel::ChannelPointsAutomaticRewardRedemptionAddV1Payload) |
 //! | [<span style="font-size: 0.9em">`channel.channel_points_custom_reward.add`</span>](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelchannel_points_custom_rewardadd) (v1) | [ChannelPointsCustomRewardAddV1](channel::ChannelPointsCustomRewardAddV1)<br>[ChannelPointsCustomRewardAddV1Payload](channel::ChannelPointsCustomRewardAddV1Payload) |
 //! | [<span style="font-size: 0.9em">`channel.channel_points_custom_reward.remove`</span>](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelchannel_points_custom_rewardremove) (v1) | [ChannelPointsCustomRewardRemoveV1](channel::ChannelPointsCustomRewardRemoveV1)<br>[ChannelPointsCustomRewardRemoveV1Payload](channel::ChannelPointsCustomRewardRemoveV1Payload) |
 //! | [<span style="font-size: 0.9em">`channel.channel_points_custom_reward.update`</span>](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelchannel_points_custom_rewardupdate) (v1) | [ChannelPointsCustomRewardUpdateV1](channel::ChannelPointsCustomRewardUpdateV1)<br>[ChannelPointsCustomRewardUpdateV1Payload](channel::ChannelPointsCustomRewardUpdateV1Payload) |


### PR DESCRIPTION
Adds [`channel.channel_points_automatic_reward_redemption.add`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#channelchannel_points_automatic_reward_redemptionadd).