### PR TITLE
Fix warnings when generating documentation

### DIFF
--- a/src/helix/client/client_ext.rs
+++ b/src/helix/client/client_ext.rs
@@ -1269,7 +1269,7 @@ impl<'client, C: crate::HttpClient + Sync + 'client> HelixClient<'client, C> {
 
     /// Get a user's chat color
     ///
-    /// [`None`](Option::None) is returned if the user never set their color in the settings.
+    /// [`None`] is returned if the user never set their color in the settings.
     pub async fn get_user_chat_color<T>(
         &'client self,
         user_id: impl Into<&types::UserIdRef> + Send,

--- a/src/helix/endpoints/games/get_games.rs
+++ b/src/helix/endpoints/games/get_games.rs
@@ -80,7 +80,7 @@ impl<'a> GetGamesRequest<'a> {
     }
 
     /// Returns an empty [`GetGamesRequest`]
-    fn empty() -> Self {
+    pub fn empty() -> Self {
         Self {
             id: types::Collection::default(),
             name: types::Collection::default(),


### PR DESCRIPTION
Two warnings that pop up when generating the docs.