### PR TITLE
fix(eventsub): flatten automod v2 held reason

### DIFF
--- a/src/eventsub/automod/message/hold.rs
+++ b/src/eventsub/automod/message/hold.rs
@@ -138,8 +138,7 @@ fn parse_payload_v1() {
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
 #[non_exhaustive]
-#[cfg(feature = "beta")]
-pub struct AutomodMessageHoldBeta {
+pub struct AutomodMessageHoldV2 {
     /// User ID of the broadcaster (channel).
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     pub broadcaster_user_id: types::UserId,
@@ -148,8 +147,7 @@ pub struct AutomodMessageHoldBeta {
     pub moderator_user_id: types::UserId,
 }
 
-#[cfg(feature = "beta")]
-impl AutomodMessageHoldBeta {
+impl AutomodMessageHoldV2 {
     /// Get automod hold notifications for this channel as a moderator
     pub fn new(
         broadcaster_user_id: impl Into<types::UserId>,
@@ -162,23 +160,21 @@ impl AutomodMessageHoldBeta {
     }
 }
 
-#[cfg(feature = "beta")]
-impl EventSubscription for AutomodMessageHoldBeta {
-    type Payload = AutomodMessageHoldBetaPayload;
+impl EventSubscription for AutomodMessageHoldV2 {
+    type Payload = AutomodMessageHoldV2Payload;
 
     const EVENT_TYPE: EventType = EventType::AutomodMessageHold;
     #[cfg(feature = "twitch_oauth2")]
     const SCOPE: twitch_oauth2::Validator =
         twitch_oauth2::validator![twitch_oauth2::Scope::ModeratorManageAutoMod];
-    const VERSION: &'static str = "beta";
+    const VERSION: &'static str = "2";
 }
 
-/// [`automod.message.hold`](AutomodMessageHoldBeta) response payload.
+/// [`automod.message.hold`](AutomodMessageHoldV2) response payload.
 // XXX: this struct can't be deny-unknown-fields because of the flattened reason
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
-#[cfg(feature = "beta")]
-pub struct AutomodMessageHoldBetaPayload {
+pub struct AutomodMessageHoldV2Payload {
     /// The ID of the broadcaster specified in the request.
     pub broadcaster_user_id: types::UserId,
     /// The login of the broadcaster specified in the request.
@@ -202,7 +198,6 @@ pub struct AutomodMessageHoldBetaPayload {
     pub held_at: types::Timestamp,
 }
 
-#[cfg(all(test, feature = "beta"))]
 #[test]
 fn parse_payload_v2_automod() {
     use crate::eventsub::{Event, Message};
@@ -213,7 +208,7 @@ fn parse_payload_v2_automod() {
             "id": "85c8dcb0-7af4-4581-b684-32087d386384",
             "status": "enabled",
             "type": "automod.message.hold",
-            "version": "beta",
+            "version": "2",
             "condition": {
                 "broadcaster_user_id": "129546453",
                 "moderator_user_id": "129546453"
@@ -270,7 +265,7 @@ fn parse_payload_v2_automod() {
     let val = Event::parse(payload).unwrap();
     crate::tests::roundtrip(&val);
 
-    let Event::AutomodMessageHoldBeta(val) = val else {
+    let Event::AutomodMessageHoldV2(val) = val else {
         panic!("invalid event type");
     };
     let Message::Notification(notif) = val.message else {
@@ -294,7 +289,6 @@ fn parse_payload_v2_automod() {
     );
 }
 
-#[cfg(all(test, feature = "beta"))]
 #[test]
 fn parse_payload_v2_blocked_term() {
     use crate::eventsub::{Event, Message};
@@ -305,7 +299,7 @@ fn parse_payload_v2_blocked_term() {
             "id": "85c8dcb0-7af4-4581-b684-32087d386384",
             "status": "enabled",
             "type": "automod.message.hold",
-            "version": "beta",
+            "version": "2",
             "condition": {
                 "broadcaster_user_id": "129546453",
                 "moderator_user_id": "129546453"
@@ -409,7 +403,7 @@ fn parse_payload_v2_blocked_term() {
     let val = Event::parse(payload).unwrap();
     crate::tests::roundtrip(&val);
 
-    let Event::AutomodMessageHoldBeta(val) = val else {
+    let Event::AutomodMessageHoldV2(val) = val else {
         panic!("invalid event type");
     };
     let Message::Notification(notif) = val.message else {

--- a/src/eventsub/automod/message/hold.rs
+++ b/src/eventsub/automod/message/hold.rs
@@ -275,7 +275,7 @@ fn parse_payload_v2_automod() {
     assert_eq!(notif.broadcaster_user_id.as_str(), "129546453");
     assert_eq!(notif.message.fragments.len(), 2);
 
-    let AutomodHeldReason::Automod { automod } = &notif.reason else {
+    let AutomodHeldReason::Automod(automod) = &notif.reason else {
         panic!("invalid held reason");
     };
     assert_eq!(automod.category, AutomodCategory::Swearing);
@@ -413,7 +413,7 @@ fn parse_payload_v2_blocked_term() {
     assert_eq!(notif.broadcaster_user_id.as_str(), "129546453");
     assert_eq!(notif.message.fragments.len(), 7);
 
-    let AutomodHeldReason::BlockedTerm { blocked_term } = &notif.reason else {
+    let AutomodHeldReason::BlockedTerm(blocked_term) = &notif.reason else {
         panic!("invalid held reason");
     };
     assert_eq!(blocked_term.terms_found.len(), 2);

--- a/src/eventsub/automod/message/mod.rs
+++ b/src/eventsub/automod/message/mod.rs
@@ -8,15 +8,13 @@ pub mod hold;
 pub mod update;
 
 #[doc(inline)]
-#[cfg(feature = "beta")]
-pub use hold::{AutomodMessageHoldBeta, AutomodMessageHoldBetaPayload};
-#[doc(inline)]
 pub use hold::{AutomodMessageHoldV1, AutomodMessageHoldV1Payload};
 #[doc(inline)]
-#[cfg(feature = "beta")]
-pub use update::{AutomodMessageUpdateBeta, AutomodMessageUpdateBetaPayload};
+pub use hold::{AutomodMessageHoldV2, AutomodMessageHoldV2Payload};
 #[doc(inline)]
 pub use update::{AutomodMessageUpdateV1, AutomodMessageUpdateV1Payload};
+#[doc(inline)]
+pub use update::{AutomodMessageUpdateV2, AutomodMessageUpdateV2Payload};
 
 /// A message's Automod status
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]

--- a/src/eventsub/automod/message/mod.rs
+++ b/src/eventsub/automod/message/mod.rs
@@ -106,15 +106,11 @@ pub struct AutomodMessageEmote {
 #[non_exhaustive]
 pub enum AutomodHeldReason {
     /// The message was caught by automod's rules
-    Automod {
-        /// Information on why a message was caught by automod
-        automod: AutomodMessageInfo,
-    },
+    #[serde(with = "crate::eventsub::enum_field_as_inner")]
+    Automod(AutomodMessageInfo),
     /// The message was caught because of one or more blocked terms
-    BlockedTerm {
-        /// Information on which blocked terms were matched in a message
-        blocked_term: AutomodBlockedTermInfo,
-    },
+    #[serde(with = "crate::eventsub::enum_field_as_inner")]
+    BlockedTerm(AutomodBlockedTermInfo),
 }
 
 /// Information on why a message was caught by automod
@@ -130,6 +126,10 @@ pub struct AutomodMessageInfo {
     pub boundaries: Vec<AutomodMessageBoundary>,
 }
 
+impl crate::eventsub::NamedField for AutomodMessageInfo {
+    const NAME: &'static str = "automod";
+}
+
 /// Information on which blocked terms were matched in a message
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
@@ -137,6 +137,10 @@ pub struct AutomodMessageInfo {
 pub struct AutomodBlockedTermInfo {
     /// The list of blocked terms found in the message.
     pub terms_found: Vec<AutomodBlockedTerm>,
+}
+
+impl crate::eventsub::NamedField for AutomodBlockedTermInfo {
+    const NAME: &'static str = "blocked_term";
 }
 
 /// The bounds of the text that caused the message to be caught.

--- a/src/eventsub/automod/message/update.rs
+++ b/src/eventsub/automod/message/update.rs
@@ -316,7 +316,7 @@ fn parse_payload_v2_automod() {
     assert_eq!(notif.message.fragments.len(), 3);
     assert_eq!(notif.status, AutomodMessageStatus::Denied);
 
-    let AutomodHeldReason::Automod { automod } = &notif.reason else {
+    let AutomodHeldReason::Automod(automod) = &notif.reason else {
         panic!("invalid held reason");
     };
     assert_eq!(automod.category, AutomodCategory::Swearing);
@@ -410,7 +410,7 @@ fn parse_payload_v2_blocked_term() {
     assert_eq!(notif.message.fragments.len(), 1);
     assert_eq!(notif.status, AutomodMessageStatus::Approved);
 
-    let AutomodHeldReason::BlockedTerm { blocked_term } = &notif.reason else {
+    let AutomodHeldReason::BlockedTerm(blocked_term) = &notif.reason else {
         panic!("invalid held reason");
     };
     assert_eq!(blocked_term.terms_found.len(), 1);

--- a/src/eventsub/automod/message/update.rs
+++ b/src/eventsub/automod/message/update.rs
@@ -154,8 +154,7 @@ fn parse_payload_v1() {
 #[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
 #[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
 #[non_exhaustive]
-#[cfg(feature = "beta")]
-pub struct AutomodMessageUpdateBeta {
+pub struct AutomodMessageUpdateV2 {
     /// User ID of the broadcaster (channel).
     #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
     pub broadcaster_user_id: types::UserId,
@@ -164,8 +163,7 @@ pub struct AutomodMessageUpdateBeta {
     pub moderator_user_id: types::UserId,
 }
 
-#[cfg(feature = "beta")]
-impl AutomodMessageUpdateBeta {
+impl AutomodMessageUpdateV2 {
     /// Get automod update notifications for this channel as a moderator
     pub fn new(
         broadcaster_user_id: impl Into<types::UserId>,
@@ -178,23 +176,21 @@ impl AutomodMessageUpdateBeta {
     }
 }
 
-#[cfg(feature = "beta")]
-impl EventSubscription for AutomodMessageUpdateBeta {
-    type Payload = AutomodMessageUpdateBetaPayload;
+impl EventSubscription for AutomodMessageUpdateV2 {
+    type Payload = AutomodMessageUpdateV2Payload;
 
     const EVENT_TYPE: EventType = EventType::AutomodMessageUpdate;
     #[cfg(feature = "twitch_oauth2")]
     const SCOPE: twitch_oauth2::Validator =
         twitch_oauth2::validator![twitch_oauth2::Scope::ModeratorManageAutoMod];
-    const VERSION: &'static str = "beta";
+    const VERSION: &'static str = "2";
 }
 
-/// [`automod.message.hold`](AutomodMessageUpdateBeta) response payload.
+/// [`automod.message.hold`](AutomodMessageUpdateV2) response payload.
 // XXX: this struct can't be deny-unknown-fields because of the flattened reason
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
-#[cfg(feature = "beta")]
-pub struct AutomodMessageUpdateBetaPayload {
+pub struct AutomodMessageUpdateV2Payload {
     /// The ID of the broadcaster specified in the request.
     pub broadcaster_user_id: types::UserId,
     /// The login of the broadcaster specified in the request.
@@ -229,7 +225,6 @@ pub struct AutomodMessageUpdateBetaPayload {
     pub reason: AutomodHeldReason,
 }
 
-#[cfg(all(test, feature = "beta"))]
 #[test]
 fn parse_payload_v2_automod() {
     use crate::eventsub::{Event, Message};
@@ -240,7 +235,7 @@ fn parse_payload_v2_automod() {
             "id": "5d64b907-001e-4cf1-9227-37871c7ce1b0",
             "status": "enabled",
             "type": "automod.message.update",
-            "version": "beta",
+            "version": "2",
             "condition": {
                 "broadcaster_user_id": "129546453",
                 "moderator_user_id": "129546453"
@@ -310,7 +305,7 @@ fn parse_payload_v2_automod() {
     let val = Event::parse(payload).unwrap();
     crate::tests::roundtrip(&val);
 
-    let Event::AutomodMessageUpdateBeta(val) = val else {
+    let Event::AutomodMessageUpdateV2(val) = val else {
         panic!("invalid event type");
     };
     let Message::Notification(notif) = val.message else {
@@ -335,7 +330,6 @@ fn parse_payload_v2_automod() {
     );
 }
 
-#[cfg(all(test, feature = "beta"))]
 #[test]
 fn parse_payload_v2_blocked_term() {
     use crate::eventsub::{Event, Message};
@@ -346,7 +340,7 @@ fn parse_payload_v2_blocked_term() {
             "id": "5d64b907-001e-4cf1-9227-37871c7ce1b0",
             "status": "enabled",
             "type": "automod.message.update",
-            "version": "beta",
+            "version": "2",
             "condition": {
                 "broadcaster_user_id": "129546453",
                 "moderator_user_id": "129546453"
@@ -405,7 +399,7 @@ fn parse_payload_v2_blocked_term() {
     let val = Event::parse(payload).unwrap();
     crate::tests::roundtrip(&val);
 
-    let Event::AutomodMessageUpdateBeta(val) = val else {
+    let Event::AutomodMessageUpdateV2(val) = val else {
         panic!("invalid event type");
     };
     let Message::Notification(notif) = val.message else {

--- a/src/eventsub/automod/mod.rs
+++ b/src/eventsub/automod/mod.rs
@@ -8,15 +8,13 @@ pub mod settings;
 pub mod terms;
 
 #[doc(inline)]
-#[cfg(feature = "beta")]
-pub use message::{AutomodMessageHoldBeta, AutomodMessageHoldBetaPayload};
-#[doc(inline)]
 pub use message::{AutomodMessageHoldV1, AutomodMessageHoldV1Payload};
 #[doc(inline)]
-#[cfg(feature = "beta")]
-pub use message::{AutomodMessageUpdateBeta, AutomodMessageUpdateBetaPayload};
+pub use message::{AutomodMessageHoldV2, AutomodMessageHoldV2Payload};
 #[doc(inline)]
 pub use message::{AutomodMessageUpdateV1, AutomodMessageUpdateV1Payload};
+#[doc(inline)]
+pub use message::{AutomodMessageUpdateV2, AutomodMessageUpdateV2Payload};
 
 #[doc(inline)]
 pub use terms::{AutomodTermsUpdateV1, AutomodTermsUpdateV1Payload};

--- a/src/eventsub/event.rs
+++ b/src/eventsub/event.rs
@@ -12,11 +12,9 @@ macro_rules! fill_events {
     ($callback:ident( $($args:tt)* )) => {
         $callback!($($args)*
             automod::AutomodMessageHoldV1;
-            #[cfg(feature = "beta")]
-            automod::AutomodMessageHoldBeta;
+            automod::AutomodMessageHoldV2;
             automod::AutomodMessageUpdateV1;
-            #[cfg(feature = "beta")]
-            automod::AutomodMessageUpdateBeta;
+            automod::AutomodMessageUpdateV2;
             automod::AutomodSettingsUpdateV1;
             automod::AutomodTermsUpdateV1;
             channel::ChannelAdBreakBeginV1;
@@ -286,14 +284,12 @@ fn main() {
 pub enum Event {
     /// Automod Message Hold V1 Event
     AutomodMessageHoldV1(Payload<automod::AutomodMessageHoldV1>),
-    /// Automod Message Hold Beta Event
-    #[cfg(feature = "beta")]
-    AutomodMessageHoldBeta(Payload<automod::AutomodMessageHoldBeta>),
+    /// Automod Message Hold V2 Event
+    AutomodMessageHoldV2(Payload<automod::AutomodMessageHoldV2>),
     /// Automod Message Update V1 Event
     AutomodMessageUpdateV1(Payload<automod::AutomodMessageUpdateV1>),
-    /// Automod Message Update Beta Event
-    #[cfg(feature = "beta")]
-    AutomodMessageUpdateBeta(Payload<automod::AutomodMessageUpdateBeta>),
+    /// Automod Message Update V2 Event
+    AutomodMessageUpdateV2(Payload<automod::AutomodMessageUpdateV2>),
     /// Automod Settings Update V1 Event
     AutomodSettingsUpdateV1(Payload<automod::AutomodSettingsUpdateV1>),
     /// Automod Terms Update V1 Event

--- a/src/eventsub/mod.rs
+++ b/src/eventsub/mod.rs
@@ -84,9 +84,9 @@
 //! | Name | Subscription<br>Payload |
 //! |---|:---|
 //! | [`automod.message.hold`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#automodmessagehold) (v1) | [AutomodMessageHoldV1](automod::AutomodMessageHoldV1)<br>[AutomodMessageHoldV1Payload](automod::AutomodMessageHoldV1Payload) |
-//! | [`automod.message.hold`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#automodmessagehold-v2) (beta) | [AutomodMessageHoldBeta](automod::AutomodMessageHoldBeta)<br>[AutomodMessageHoldBetaPayload](automod::AutomodMessageHoldBetaPayload) |
+//! | [`automod.message.hold`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#automodmessagehold-v2) (v2) | [AutomodMessageHoldV2](automod::AutomodMessageHoldV2)<br>[AutomodMessageHoldV2Payload](automod::AutomodMessageHoldV2Payload) |
 //! | [`automod.message.update`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#automodmessageupdate) (v1) | [AutomodMessageUpdateV1](automod::AutomodMessageUpdateV1)<br>[AutomodMessageUpdateV1Payload](automod::AutomodMessageUpdateV1Payload) |
-//! | [`automod.message.update`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#automodmessageupdate-v2) (beta) | [AutomodMessageUpdateBeta](automod::AutomodMessageUpdateBeta)<br>[AutomodMessageUpdateBetaPayload](automod::AutomodMessageUpdateBetaPayload) |
+//! | [`automod.message.update`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#automodmessageupdate-v2) (v2) | [AutomodMessageUpdateV2](automod::AutomodMessageUpdateV2)<br>[AutomodMessageUpdateV2Payload](automod::AutomodMessageUpdateV2Payload) |
 //! | [`automod.settings.update`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#automodsettingsupdate) (v1) | [AutomodSettingsUpdateV1](automod::AutomodSettingsUpdateV1)<br>[AutomodSettingsUpdateV1Payload](automod::AutomodSettingsUpdateV1Payload) |
 //! | [`automod.terms.update`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#automodtermsupdate) (v1) | [AutomodTermsUpdateV1](automod::AutomodTermsUpdateV1)<br>[AutomodTermsUpdateV1Payload](automod::AutomodTermsUpdateV1Payload) |
 //!


### PR DESCRIPTION
In https://github.com/twitch-rs/twitch_api/commit/83208f0df7dc729636c8411968f11b74feba15ee I missed `eventsub::enum_field_as_inner` - this makes the `AutomodHeldReason` a bit nicer to use.