### PR TITLE
feat: add `user.whisper.message`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3331,7 +3331,7 @@ dependencies = [
 
 [[package]]
 name = "twitch_oauth2"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "aliri_braid",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ exclude = ["twitch_types", "twitch_oauth2"]
 
 [workspace.dependencies]
 twitch_api = { version = "0.7.0-rc.8", path = "." }
-twitch_oauth2 = { version = "0.15.0", path = "twitch_oauth2/" }
+twitch_oauth2 = { version = "0.15.1", path = "twitch_oauth2/" }
 twitch_types = { version = "0.4.8", features = [
     "serde",
 ], path = "./twitch_types" }

--- a/src/eventsub/event.rs
+++ b/src/eventsub/event.rs
@@ -94,6 +94,7 @@ macro_rules! fill_events {
             user::UserAuthorizationGrantV1;
             user::UserAuthorizationRevokeV1;
             user::UserUpdateV1;
+            user::UserWhisperMessageV1;
         )
     };
 }
@@ -316,6 +317,8 @@ make_event_type!("Event Types": pub enum EventType {
     UserAuthorizationRevoke => "user.authorization.revoke",
     "a user’s authorization has been granted to your client id.":
     UserAuthorizationGrant => "user.authorization.grant",
+    "a user receives a whisper.":
+    UserWhisperMessage => "user.whisper.message",
 },
     to_str: r#"Get the event string of this event.
 ```
@@ -499,6 +502,8 @@ pub enum Event {
     UserAuthorizationGrantV1(Payload<user::UserAuthorizationGrantV1>),
     /// User Authorization Revoke V1 Event
     UserAuthorizationRevokeV1(Payload<user::UserAuthorizationRevokeV1>),
+    /// User Whisper Message V1 Event
+    UserWhisperMessageV1(Payload<user::UserWhisperMessageV1>),
     /// Channel Subscription End V1 Event
     ChannelSubscriptionEndV1(Payload<channel::ChannelSubscriptionEndV1>),
     /// Channel Subscription Gift V1 Event

--- a/src/eventsub/mod.rs
+++ b/src/eventsub/mod.rs
@@ -197,14 +197,14 @@
 //!
 //! </details>
 //!
-//! <details><summary style="cursor: pointer"><code style="color: var(--link-color)">user.*</code> 🟡 3/4</summary>
+//! <details><summary style="cursor: pointer"><code style="color: var(--link-color)">user.*</code> 🟢 4/4</summary>
 //!
 //! | Name | Subscription<br>Payload |
 //! |---|:---|
 //! | [`user.authorization.grant`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#userauthorizationgrant) (v1) | [UserAuthorizationGrantV1](user::UserAuthorizationGrantV1)<br>[UserAuthorizationGrantV1Payload](user::UserAuthorizationGrantV1Payload) |
 //! | [`user.authorization.revoke`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#userauthorizationrevoke) (v1) | [UserAuthorizationRevokeV1](user::UserAuthorizationRevokeV1)<br>[UserAuthorizationRevokeV1Payload](user::UserAuthorizationRevokeV1Payload) |
 //! | [`user.update`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#userupdate) (v1) | [UserUpdateV1](user::UserUpdateV1)<br>[UserUpdateV1Payload](user::UserUpdateV1Payload) |
-//! | [`user.whisper.message`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#userwhispermessage) (v1) | -<br>- |
+//! | [`user.whisper.message`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#userwhispermessage) (v1) | [UserWhisperMessageV1](user::UserWhisperMessageV1)<br>[UserWhisperMessageV1Payload](user::UserWhisperMessageV1Payload) |
 //!
 //! </details>
 //!

--- a/src/eventsub/user/mod.rs
+++ b/src/eventsub/user/mod.rs
@@ -6,6 +6,7 @@ use serde_derive::{Deserialize, Serialize};
 
 pub mod authorization;
 pub mod update;
+pub mod whisper;
 
 #[doc(inline)]
 pub use authorization::{UserAuthorizationGrantV1, UserAuthorizationGrantV1Payload};
@@ -13,3 +14,5 @@ pub use authorization::{UserAuthorizationGrantV1, UserAuthorizationGrantV1Payloa
 pub use authorization::{UserAuthorizationRevokeV1, UserAuthorizationRevokeV1Payload};
 #[doc(inline)]
 pub use update::{UserUpdateV1, UserUpdateV1Payload};
+#[doc(inline)]
+pub use whisper::{UserWhisperMessageV1, UserWhisperMessageV1Payload};

--- a/src/eventsub/user/whisper/message.rs
+++ b/src/eventsub/user/whisper/message.rs
@@ -1,0 +1,106 @@
+#![doc(alias = "user.whisper.message")]
+//! A user receives a whisper
+use super::*;
+
+/// [`user.whisper.message`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#userwhispermessage): a user receives a whisper.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[non_exhaustive]
+pub struct UserWhisperMessageV1 {
+    /// The user ID of the person receiving whispers.
+    #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
+    pub user_id: types::UserId,
+}
+
+impl UserWhisperMessageV1 {
+    /// The user ID of the person receiving whispers.
+    pub fn new(user_id: impl Into<types::UserId>) -> Self {
+        Self {
+            user_id: user_id.into(),
+        }
+    }
+}
+
+impl EventSubscription for UserWhisperMessageV1 {
+    type Payload = UserWhisperMessageV1Payload;
+
+    const EVENT_TYPE: EventType = EventType::UserWhisperMessage;
+    #[cfg(feature = "twitch_oauth2")]
+    const SCOPE: twitch_oauth2::Validator = twitch_oauth2::validator![any(
+        twitch_oauth2::Scope::UserReadWhispers,
+        twitch_oauth2::Scope::UserManageWhispers
+    )];
+    const VERSION: &'static str = "1";
+}
+
+/// [`user.whisper.message`](UserWhisperMessageV1) response payload.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[non_exhaustive]
+pub struct UserWhisperMessageV1Payload {
+    /// The ID of the user sending the message.
+    pub from_user_id: types::UserId,
+    /// The name of the user sending the message.
+    pub from_user_name: types::DisplayName,
+    /// The login of the user sending the message.
+    pub from_user_login: types::UserName,
+    /// The ID of the user receiving the message.
+    pub to_user_id: types::UserId,
+    /// The name of the user receiving the message.
+    pub to_user_name: types::DisplayName,
+    /// The login of the user receiving the message.
+    pub to_user_login: types::UserName,
+    /// The whisper ID.
+    pub whisper_id: types::WhisperId,
+    /// Object containing whisper information.
+    pub whisper: Whisper,
+}
+
+/// Object containing whisper information.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[non_exhaustive]
+pub struct Whisper {
+    /// The body of the whisper message.
+    pub text: String,
+}
+
+#[cfg(test)]
+#[test]
+fn parse_payload() {
+    let payload = r#"
+    {
+        "subscription": {
+            "id": "7297f7eb-3bf5-461f-8ae6-7cd7781ebce3",
+            "status": "enabled",
+            "type": "user.whisper.message",
+            "version": "1",
+            "condition": {
+                "user_id": "423374343"
+            },
+            "transport": {
+                "method": "webhook",
+                "callback": "https://example.com/webhooks/callback"
+            },
+            "created_at": "2024-02-23T21:12:33.771005262Z",
+            "cost": 0
+        },
+        "event": {
+            "from_user_id": "423374343",
+            "from_user_login": "glowillig",
+            "from_user_name": "glowillig",
+            "to_user_id": "424596340",
+            "to_user_login": "quotrok",
+            "to_user_name": "quotrok",
+            "whisper_id": "some-whisper-id",
+            "whisper": {
+                "text": "a secret"
+            }
+        }
+    }
+    "#;
+
+    let val = dbg!(crate::eventsub::Event::parse(payload).unwrap());
+    crate::tests::roundtrip(&val)
+}

--- a/src/eventsub/user/whisper/mod.rs
+++ b/src/eventsub/user/whisper/mod.rs
@@ -1,0 +1,10 @@
+#![doc(alias = "user.whisper")]
+//! Notifications for whispers (private messages)
+use super::{EventSubscription, EventType};
+use crate::types;
+use serde_derive::{Deserialize, Serialize};
+
+pub mod message;
+
+#[doc(inline)]
+pub use message::{UserWhisperMessageV1, UserWhisperMessageV1Payload, Whisper};


### PR DESCRIPTION
[`user.whisper.message`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#userwhispermessage) - This is the last remaining event. The example for the payload in the docs is missing the `cost` in the subscription.