### PR TITLE
feat: add `channel.bits.use`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 [Commits](https://github.com/twitch-rs/twitch_api/compare/v0.7.0...Unreleased)
 
+### Added
+
+- Added the following eventsub topics:
+  `Channel Bits Use V1`
+
 ### Fixed
 
 - Eventsub `channel.moderate` action `Timeout` and `Ban` field `reason` is now `None` when the string is empty.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -578,11 +578,11 @@ checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 
 [[package]]
 name = "cc"
-version = "1.0.83"
+version = "1.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
+checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
 dependencies = [
- "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -2330,16 +2330,16 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.17.7"
+version = "0.17.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "688c63d65483050968b2a8937f7995f443e27041a0f7700aa59b0822aedebb74"
+checksum = "70ac5d832aa16abd7d1def883a8545280c20a60f523a370aa3a9617c2b8550ee"
 dependencies = [
  "cc",
+ "cfg-if",
  "getrandom 0.2.12",
  "libc",
- "spin",
  "untrusted",
- "windows-sys 0.48.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2652,6 +2652,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2696,12 +2702,6 @@ dependencies = [
  "libc",
  "windows-sys 0.48.0",
 ]
-
-[[package]]
-name = "spin"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
 
 [[package]]
 name = "spinning_top"

--- a/src/eventsub/channel/bits/mod.rs
+++ b/src/eventsub/channel/bits/mod.rs
@@ -24,13 +24,13 @@ pub enum BitsType {
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[non_exhaustive]
 pub struct BitsPowerUp {
-    /// Possible values: message_effect | celebration | gigantify_an_emote
+    /// The type of Power Up used
     #[serde(rename = "type")]
-    pub _type: BitsPowerUpType,
-    /// Optional. Emote associated with the reward.
+    pub type_: BitsPowerUpType,
+    /// Emote associated with the reward.
     pub emote: Option<crate::eventsub::channel::chat::Emote>,
-    /// Optional. The ID of the message effect.
-    pub message_effect_id: Option<String>,
+    /// The ID of the message effect.
+    pub message_effect_id: String,
 }
 
 /// The type of Power Up used.
@@ -38,10 +38,13 @@ pub struct BitsPowerUp {
 #[non_exhaustive]
 #[serde(rename_all = "snake_case")]
 pub enum BitsPowerUpType {
-    /// Message Effect Power-Up used
+    /// Message Effect Power-Up
     MessageEffect,
-    /// Celebration Effect Power-Up used
+    /// Celebration Effect Power-Up
     Celebration,
-    /// Gigantify an Emote Effect Power-Up used
+    /// Gigantify an Emote Effect Power-Up
     GigantifyAnEmote,
+    /// An unknown Power-Up, contains the raw string provided by Twitch.
+    #[serde(untagged)]
+    Unknown(String),
 }

--- a/src/eventsub/channel/bits/mod.rs
+++ b/src/eventsub/channel/bits/mod.rs
@@ -1,0 +1,47 @@
+#![doc(alias = "channel.bits")]
+//! Bits are used in a channel
+use super::{EventSubscription, EventType};
+use crate::types;
+use serde_derive::{Deserialize, Serialize};
+
+pub mod r#use;
+
+#[doc(inline)]
+pub use r#use::{ChannelBitsUseV1, ChannelBitsUseV1Payload};
+
+/// The type of Bits used.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+#[serde(rename_all = "snake_case")]
+pub enum BitsType {
+    /// Bits send via Cheer
+    Cheer,
+    /// Bits send via Power-Up
+    PowerUp,
+}
+
+/// Data about Power-up
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+pub struct BitsPowerUp {
+    /// Possible values: message_effect | celebration | gigantify_an_emote
+    #[serde(rename = "type")]
+    pub _type: BitsPowerUpType,
+    /// Optional. Emote associated with the reward.
+    pub emote: Option<crate::eventsub::channel::chat::Emote>,
+    /// Optional. The ID of the message effect.
+    pub message_effect_id: Option<String>,
+}
+
+/// The type of Power Up used.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[non_exhaustive]
+#[serde(rename_all = "snake_case")]
+pub enum BitsPowerUpType {
+    /// Message Effect Power-Up used
+    MessageEffect,
+    /// Celebration Effect Power-Up used
+    Celebration,
+    /// Gigantify an Emote Effect Power-Up used
+    GigantifyAnEmote,
+}

--- a/src/eventsub/channel/bits/mod.rs
+++ b/src/eventsub/channel/bits/mod.rs
@@ -30,7 +30,7 @@ pub struct BitsPowerUp {
     /// Emote associated with the reward.
     pub emote: Option<crate::eventsub::channel::chat::Emote>,
     /// The ID of the message effect.
-    pub message_effect_id: String,
+    pub message_effect_id: Option<String>,
 }
 
 /// The type of Power Up used.

--- a/src/eventsub/channel/bits/use.rs
+++ b/src/eventsub/channel/bits/use.rs
@@ -1,0 +1,130 @@
+#![doc(alias = "channel.bits.use")]
+//! sends a notification whenever Bits are used on a channel
+
+use super::*;
+
+/// [`channel.bits.use`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#channelbitsuse): sends a notification whenever Bits are used on a channel
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "typed-builder", derive(typed_builder::TypedBuilder))]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[non_exhaustive]
+pub struct ChannelBitsUseV1 {
+    /// The ID of the broadcaster that you want to get Channel Bits notifications for.
+    #[cfg_attr(feature = "typed-builder", builder(setter(into)))]
+    pub broadcaster_user_id: types::UserId,
+}
+
+impl ChannelBitsUseV1 {
+    /// The ID of the broadcaster that you want to get Channel Bits notifications for.
+    pub fn broadcaster_user_id(broadcaster_user_id: impl Into<types::UserId>) -> Self {
+        Self {
+            broadcaster_user_id: broadcaster_user_id.into(),
+        }
+    }
+}
+
+impl EventSubscription for ChannelBitsUseV1 {
+    type Payload = ChannelBitsUseV1Payload;
+
+    const EVENT_TYPE: EventType = EventType::ChannelBitsUse;
+    #[cfg(feature = "twitch_oauth2")]
+    const SCOPE: twitch_oauth2::Validator =
+        twitch_oauth2::validator![any(twitch_oauth2::Scope::BitsRead)];
+    const VERSION: &'static str = "1";
+}
+
+/// [`channel.bits.use`](ChannelBitsUseV1) response payload.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[cfg_attr(feature = "deny_unknown_fields", serde(deny_unknown_fields))]
+#[non_exhaustive]
+pub struct ChannelBitsUseV1Payload {
+    /// The User ID of the redeeming user.
+    pub user_id: types::UserId,
+    /// The login name of the redeeming user.
+    pub user_login: types::UserName,
+    /// The display name of the redeeming user.
+    pub user_name: types::UserName,
+    /// The User ID of the channel where the Bits were redeemed.
+    pub broadcaster_user_id: types::UserId,
+    /// The login of the channel where the Bits were used.
+    pub broadcaster_user_login: types::UserName,
+    /// The display name of the channel where the Bits were used.
+    pub broadcaster_user_name: types::UserName,
+    /// The number of Bits used.
+    pub bits: usize,
+    /// Possible values are: cheer | power_up
+    #[serde(rename = "type")]
+    pub _type: BitsType,
+    /// Optional. Data about Power-up.
+    pub power_up: Option<BitsPowerUp>,
+    /// Optional. An object that contains the user message and emote information needed to recreate the message.
+    pub message: crate::eventsub::automod::message::AutomodMessage,
+}
+
+#[cfg(test)]
+#[test]
+fn parse_payload() {
+    // FIXME: twitch docs has trailing commas
+    // FIXME: it uses string for the integer and bool, https://github.com/twitchdev/issues/issues/857#issuecomment-1793796590
+    let payload = r##"
+    {
+        "subscription": {
+            "id": "f1c2a387-161a-49f9-a165-0f21d7a4e1c4",
+            "type": "channel.bits.use",
+            "version": "1",
+            "status": "enabled",
+            "cost": 0,
+            "condition": {
+                "broadcaster_user_id": "1337"
+            },
+             "transport": {
+                "method": "webhook",
+                "callback": "https://example.com/webhooks/callback"
+            },
+            "created_at": "2019-11-16T10:11:12.634234626Z"
+        },
+        "event": {
+            "user_id": "1234",
+            "user_login": "cool_user",
+            "user_name": "Cool_User",
+            "broadcaster_user_id": "1337",
+            "broadcaster_user_login": "cooler_user",
+            "broadcaster_user_name": "Cooler_User",
+            "bits": 2,
+            "type": "cheer",
+            "power_up": null,
+            "message": {
+               "text": "cheer1 hi cheer1",
+               "fragments": [{
+                  "type": "cheermote",
+                  "text": "cheer1",
+                  "cheermote": {
+                     "prefix": "cheer",
+                     "bits": 1,
+                     "tier": 1
+                  },
+                  "emote": null
+               }, {
+                  "type": "text",
+                  "text": " hi ",
+                  "cheermote": null,
+                  "emote": null
+
+               }, {
+                  "type": "cheermote",
+                  "text": "cheer1",
+                  "cheermote": {
+                     "prefix": "cheer",
+                     "bits": 1,
+                     "tier": 1
+                  },
+                  "emote": null
+                }]
+    	   }
+        }
+    }
+    "##;
+
+    let val = dbg!(crate::eventsub::Event::parse(payload).unwrap());
+    crate::tests::roundtrip(&val)
+}

--- a/src/eventsub/channel/bits/use.rs
+++ b/src/eventsub/channel/bits/use.rs
@@ -43,29 +43,27 @@ pub struct ChannelBitsUseV1Payload {
     /// The login name of the redeeming user.
     pub user_login: types::UserName,
     /// The display name of the redeeming user.
-    pub user_name: types::UserName,
+    pub user_name: types::DisplayName,
     /// The User ID of the channel where the Bits were redeemed.
     pub broadcaster_user_id: types::UserId,
     /// The login of the channel where the Bits were used.
     pub broadcaster_user_login: types::UserName,
     /// The display name of the channel where the Bits were used.
-    pub broadcaster_user_name: types::UserName,
+    pub broadcaster_user_name: types::DisplayName,
     /// The number of Bits used.
     pub bits: usize,
-    /// Possible values are: cheer | power_up
+    /// The type of Bits used.
     #[serde(rename = "type")]
-    pub _type: BitsType,
-    /// Optional. Data about Power-up.
+    pub type_: BitsType,
+    /// Data about Power-up.
     pub power_up: Option<BitsPowerUp>,
-    /// Optional. An object that contains the user message and emote information needed to recreate the message.
-    pub message: crate::eventsub::automod::message::AutomodMessage,
+    /// An object that contains the user message and emote information needed to recreate the message.
+    pub message: crate::eventsub::channel::chat::Message,
 }
 
 #[cfg(test)]
 #[test]
 fn parse_payload() {
-    // FIXME: twitch docs has trailing commas
-    // FIXME: it uses string for the integer and bool, https://github.com/twitchdev/issues/issues/857#issuecomment-1793796590
     let payload = r##"
     {
         "subscription": {

--- a/src/eventsub/channel/bits/use.rs
+++ b/src/eventsub/channel/bits/use.rs
@@ -58,7 +58,7 @@ pub struct ChannelBitsUseV1Payload {
     /// Data about Power-up.
     pub power_up: Option<BitsPowerUp>,
     /// An object that contains the user message and emote information needed to recreate the message.
-    pub message: crate::eventsub::channel::chat::Message,
+    pub message: Option<crate::eventsub::channel::chat::Message>,
 }
 
 #[cfg(test)]

--- a/src/eventsub/channel/mod.rs
+++ b/src/eventsub/channel/mod.rs
@@ -7,6 +7,7 @@ use serde_derive::{Deserialize, Serialize};
 
 pub mod ad_break;
 pub mod ban;
+pub mod bits;
 pub mod channel_points_automatic_reward_redemption;
 pub mod channel_points_custom_reward;
 pub mod channel_points_custom_reward_redemption;
@@ -44,6 +45,8 @@ pub mod warning;
 pub use ad_break::{ChannelAdBreakBeginV1, ChannelAdBreakBeginV1Payload};
 #[doc(inline)]
 pub use ban::{ChannelBanV1, ChannelBanV1Payload};
+#[doc(inline)]
+pub use bits::{ChannelBitsUseV1, ChannelBitsUseV1Payload};
 #[doc(inline)]
 pub use channel_points_automatic_reward_redemption::{
     ChannelPointsAutomaticRewardRedemptionAddV1, ChannelPointsAutomaticRewardRedemptionAddV1Payload,

--- a/src/eventsub/event.rs
+++ b/src/eventsub/event.rs
@@ -19,6 +19,7 @@ macro_rules! fill_events {
             automod::AutomodTermsUpdateV1;
             channel::ChannelAdBreakBeginV1;
             channel::ChannelBanV1;
+            channel::ChannelBitsUseV1;
             channel::ChannelCharityCampaignDonateV1;
             channel::ChannelCharityCampaignProgressV1;
             channel::ChannelCharityCampaignStartV1;
@@ -179,6 +180,8 @@ make_event_type!("Event Types": pub enum EventType {
     AutomodTermsUpdate => "automod.terms.update",
     "a user runs a midroll commercial break, either manually or automatically via ads manager.":
     ChannelAdBreakBegin => "channel.ad_break.begin",
+    "sends a notification whenever Bits are used on a channel.":
+    ChannelBitsUse => "channel.bits.use",
     "a moderator or bot clears all messages from the chat room.":
     ChannelChatClear => "channel.chat.clear",
     "a moderator or bot clears all messages for a specific user.":
@@ -352,6 +355,8 @@ pub enum Event {
     AutomodTermsUpdateV1(Payload<automod::AutomodTermsUpdateV1>),
     /// Channel Ad Break Begin V1 Event
     ChannelAdBreakBeginV1(Payload<channel::ChannelAdBreakBeginV1>),
+    /// Channel Bit Use V1 Event
+    ChannelBitsUseV1(Payload<channel::ChannelBitsUseV1>),
     /// Channel Chat Clear V1 Event
     ChannelChatClearV1(Payload<channel::ChannelChatClearV1>),
     /// Channel Chat ClearUserMessages V1 Event

--- a/src/eventsub/mod.rs
+++ b/src/eventsub/mod.rs
@@ -92,13 +92,13 @@
 //!
 //! </details>
 //!
-//! <details><summary style="cursor: pointer"><code style="color: var(--link-color)">channel.*</code> 🟡 65/67</summary>
+//! <details><summary style="cursor: pointer"><code style="color: var(--link-color)">channel.*</code> 🟡 66/67</summary>
 //!
 //! | Name | Subscription<br>Payload |
 //! |---|:---|
 //! | [`channel.ad_break.begin`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelad_breakbegin) (v1) | [ChannelAdBreakBeginV1](channel::ChannelAdBreakBeginV1)<br>[ChannelAdBreakBeginV1Payload](channel::ChannelAdBreakBeginV1Payload) |
 //! | [`channel.ban`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelban) (v1) | [ChannelBanV1](channel::ChannelBanV1)<br>[ChannelBanV1Payload](channel::ChannelBanV1Payload) |
-//! | [`channel.bits.use`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelbitsuse) (v1) | -<br>- |
+//! | [`channel.bits.use`](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelbitsuse) (v1) | [ChannelBitsUseV1](channel::ChannelBitsUseV1)<br>[ChannelBitsUseV1Payload](channel::ChannelBitsUseV1Payload) |
 //! | [<span style="font-size: 0.9em">`channel.channel_points_automatic_reward_redemption.add`</span>](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelchannel_points_automatic_reward_redemptionadd) (v1) | [ChannelPointsAutomaticRewardRedemptionAddV1](channel::ChannelPointsAutomaticRewardRedemptionAddV1)<br>[ChannelPointsAutomaticRewardRedemptionAddV1Payload](channel::ChannelPointsAutomaticRewardRedemptionAddV1Payload) |
 //! | [<span style="font-size: 0.9em">`channel.channel_points_automatic_reward_redemption.add`</span>](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelchannel_points_automatic_reward_redemptionadd-v2) (v2) | -<br>- |
 //! | [<span style="font-size: 0.9em">`channel.channel_points_custom_reward.add`</span>](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types#channelchannel_points_custom_rewardadd) (v1) | [ChannelPointsCustomRewardAddV1](channel::ChannelPointsCustomRewardAddV1)<br>[ChannelPointsCustomRewardAddV1Payload](channel::ChannelPointsCustomRewardAddV1Payload) |


### PR DESCRIPTION
Implementation of [channel.bits.use](https://dev.twitch.tv/docs/eventsub/eventsub-subscription-types/#channelbitsuse).
The example for the payload in the docs is missing the `power_up` in the event.