### PR TITLE
fix(client): transition to `Cont` when receiving single cunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Fixed
 
 - Eventsub `channel.moderate` action `Timeout` and `Ban` field `reason` is now `None` when the string is empty.
+- `ClientExt::get_eventsub_subscriptions` now returns all pages (previously, only the first page was returned).
 
 ## [v0.7.0] - 2025-01-22
 

--- a/src/helix/client/client_ext.rs
+++ b/src/helix/client/client_ext.rs
@@ -2189,7 +2189,11 @@ where
             r: super::Response<Req, <Req as super::Request>::Response>,
             d: std::collections::VecDeque<Item>,
         ) -> Self {
-            self.mode = StateMode::Cont(r, d);
+            self.mode = if d.is_empty() {
+                StateMode::Next(Some(r))
+            } else {
+                StateMode::Cont(r, d)
+            };
             self
         }
 


### PR DESCRIPTION
I was wondering why `get_eventsub_subscriptions` only returned 100 items. Turns out, `make_stream` was only requesting the first chunk.

After requesting, a deque is created from the items and the first item is returned:
```rust
let mut deq = fun(resp.data.clone());
deq.pop_front().map(|d| (Ok(d), state.process(resp, deq)))
```
`state.process` transitions into `State::Cont` which yields all the remaining values. For `get_eventsub_subscriptions` however, there's only one value in the deque, which was removed by `pop_front`. If the deque is empty when subsequently handling `Cont`, the stream stops (`None` is returned).

I changed `State::process` to immediately transition to `Next` if the queue was empty. This adds the invariant that `State::Cont` will always hold a non-empty deque.

---

Having a few tests for `make_stream` might be nice. I guess that would require something like a `TestClient` that can be fed with predefined responses.